### PR TITLE
feat: detect manual X replies via Activity post.create

### DIFF
--- a/convex/lib/outreachCore.ts
+++ b/convex/lib/outreachCore.ts
@@ -755,6 +755,7 @@ export async function refinePlan(
         supersededAt: now,
         supersededByVersion: nextVersion,
       });
+      await stopActiveOutreachRecoveryMonitorsForTask(ctx, task._id);
       await dismissNotificationsForTask(ctx, task._id);
     }
 
@@ -882,6 +883,70 @@ export async function getProspectActivePlan(
 }
 
 /**
+ * Stops recovery monitors when a plan is abandoned without deleting the plan
+ * history. This is especially important for event-driven X/Twitter monitors,
+ * which intentionally have no expiry deadline while a task is waiting_manual.
+ */
+export async function stopActiveOutreachRecoveryMonitorsForPlan(
+  ctx: MutationCtx,
+  planId: Id<"outreachPlans">
+): Promise<number> {
+  const monitors = await ctx.db
+    .query("outreachRecoveryMonitors")
+    .withIndex("by_plan", (q) => q.eq("planId", planId))
+    .collect();
+  const activeMonitors = monitors.filter(
+    (monitor) => monitor.status === "active"
+  );
+  if (activeMonitors.length === 0) return 0;
+
+  const now = getCurrentUTCTimestamp();
+  for (const monitor of activeMonitors) {
+    await ctx.db.patch("outreachRecoveryMonitors", monitor._id, {
+      status: "expired",
+      nextCheckAt: undefined,
+      completedAt: now,
+      lastErrorMessage: "The outreach plan was abandoned.",
+    });
+    if (monitor.taskId) {
+      await dismissNotificationsForTask(ctx, monitor.taskId);
+    }
+  }
+
+  return activeMonitors.length;
+}
+
+/**
+ * Stops recovery monitors when their task is superseded or otherwise resolved.
+ */
+export async function stopActiveOutreachRecoveryMonitorsForTask(
+  ctx: MutationCtx,
+  taskId: Id<"outreachTasks">
+): Promise<number> {
+  const monitors = await ctx.db
+    .query("outreachRecoveryMonitors")
+    .withIndex("by_task_and_kind", (q) => q.eq("taskId", taskId))
+    .collect();
+  const activeMonitors = monitors.filter(
+    (monitor) => monitor.status === "active"
+  );
+  if (activeMonitors.length === 0) return 0;
+
+  const now = getCurrentUTCTimestamp();
+  for (const monitor of activeMonitors) {
+    await ctx.db.patch("outreachRecoveryMonitors", monitor._id, {
+      status: "expired",
+      nextCheckAt: undefined,
+      completedAt: now,
+      lastErrorMessage: "The outreach task is no longer active.",
+    });
+  }
+  await dismissNotificationsForTask(ctx, taskId);
+
+  return activeMonitors.length;
+}
+
+/**
  * Permanently deletes an outreach plan and cleanup rows that would otherwise
  * leave stale UI state behind.
  */
@@ -918,10 +983,8 @@ export async function deleteOutreachPlanCascade(
 
   const recoveryMonitors = await ctx.db
     .query("outreachRecoveryMonitors")
-    .withIndex("by_prospect_and_status", (q) =>
-      q.eq("prospectId", plan.prospectId)
-    )
-    .take(100);
+    .withIndex("by_plan", (q) => q.eq("planId", plan._id))
+    .collect();
 
   for (const monitor of planMonitors) {
     if (monitor.status !== "deleted") {

--- a/convex/lib/outreachRecoveryCore.ts
+++ b/convex/lib/outreachRecoveryCore.ts
@@ -8,12 +8,6 @@ export type OutreachRecoveryKind =
   | "linkedin_comment_reply"
   | "linkedin_connection_then_dm";
 
-/**
- * Temporary SocialAPI cost brake for twitter_manual_reply detecting_outbound.
- * Remove once X Activity post.create recovery ships.
- */
-export const TWITTER_MANUAL_REPLY_POLL_INTERVAL_MS = 24 * 60 * 60 * 1000;
-
 const MAX_BASELINE_IDS = 100;
 
 export function parseRecoveryArtifactIds(value?: string): Set<string> {
@@ -63,16 +57,121 @@ export function getRecoveryNextCheckDelayMs(
     return 30 * 60 * 1000;
   }
 
-  // Temporary: SocialAPI verifyUserCommented was burning credits at high
-  // frequency. Keep Twitter manual-reply detection at most once per day until
-  // the X Activity rewrite lands.
-  if (kind === "twitter_manual_reply") {
-    return TWITTER_MANUAL_REPLY_POLL_INTERVAL_MS;
-  }
-
+  // LinkedIn comment outbound detection still uses sparse polling.
+  // Twitter manual-reply detecting_outbound is event-driven via X Activity
+  // (`post.create`); do not add SocialAPI poll intervals for that kind here.
+  void kind;
   if (attemptCount < 2) return 15 * 1000;
   if (attemptCount < 5) return 30 * 1000;
   if (attemptCount < 10) return 60 * 1000;
   if (attemptCount < 20) return 5 * 60 * 1000;
   return 15 * 60 * 1000;
+}
+
+export type ActivityCreatedPost = {
+  postId: string;
+  authorId?: string;
+  text?: string;
+  createdAtMs?: number;
+  repliedToPostId?: string;
+  conversationId?: string;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function asString(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return undefined;
+}
+
+function parseCreatedAtMs(value: unknown): number | undefined {
+  const raw = asString(value);
+  if (!raw) return undefined;
+  const ms = Date.parse(raw);
+  return Number.isFinite(ms) ? ms : undefined;
+}
+
+function extractRepliedToPostId(
+  payload: Record<string, unknown>
+): string | undefined {
+  const referenced = payload.referenced_tweets;
+  if (Array.isArray(referenced)) {
+    for (const entry of referenced) {
+      const record = asRecord(entry);
+      if (!record) continue;
+      const type = asString(record.type);
+      if (type !== "replied_to") continue;
+      const id = asString(record.id);
+      if (id) return id;
+    }
+  }
+
+  return (
+    asString(payload.in_reply_to_status_id_str) ??
+    asString(payload.in_reply_to_status_id) ??
+    asString(payload.inReplyToTweetId)
+  );
+}
+
+/**
+ * Normalize an X Activity `post.create` envelope/payload into the fields we
+ * need to match a pending manual-reply recovery monitor.
+ */
+export function extractActivityCreatedPost(
+  event: unknown
+): ActivityCreatedPost | null {
+  const envelope = asRecord(event);
+  if (!envelope) return null;
+
+  const payload = asRecord(envelope.payload) ?? envelope;
+  const postId = asString(payload.id) ?? asString(payload.id_str);
+  if (!postId) return null;
+
+  return {
+    postId,
+    authorId:
+      asString(payload.author_id) ??
+      asString(payload.authorId) ??
+      asString(asRecord(payload.user)?.id_str) ??
+      asString(asRecord(payload.user)?.id),
+    text: asString(payload.text) ?? asString(payload.full_text),
+    createdAtMs: parseCreatedAtMs(payload.created_at ?? payload.createdAt),
+    repliedToPostId: extractRepliedToPostId(payload),
+    conversationId:
+      asString(payload.conversation_id) ?? asString(payload.conversationId),
+  };
+}
+
+/**
+ * Returns true when an Activity post is a direct reply that can satisfy a
+ * twitter_manual_reply monitor in detecting_outbound.
+ */
+export function matchesTwitterManualReplyRecovery(args: {
+  post: ActivityCreatedPost;
+  sourcePostId: string;
+  connectedXUserId: string;
+  startedAt: number;
+}): boolean {
+  if (!args.post.repliedToPostId) return false;
+  if (args.post.repliedToPostId !== args.sourcePostId) return false;
+  if (args.post.authorId && args.post.authorId !== args.connectedXUserId) {
+    return false;
+  }
+  if (
+    typeof args.post.createdAtMs === "number" &&
+    args.post.createdAtMs + 60_000 < args.startedAt
+  ) {
+    return false;
+  }
+  return true;
 }

--- a/convex/lib/outreachRecoveryCore.ts
+++ b/convex/lib/outreachRecoveryCore.ts
@@ -8,34 +8,6 @@ export type OutreachRecoveryKind =
   | "linkedin_comment_reply"
   | "linkedin_connection_then_dm";
 
-const MAX_BASELINE_IDS = 100;
-
-export function parseRecoveryArtifactIds(value?: string): Set<string> {
-  if (!value) return new Set();
-  try {
-    const parsed = JSON.parse(value) as unknown;
-    return new Set(
-      Array.isArray(parsed)
-        ? parsed.filter((item): item is string => typeof item === "string")
-        : []
-    );
-  } catch {
-    return new Set();
-  }
-}
-
-export function serializeRecoveryArtifactIds(ids: readonly string[]): string {
-  return JSON.stringify(Array.from(new Set(ids)).slice(0, MAX_BASELINE_IDS));
-}
-
-export function getNewRecoveryArtifactIds(
-  currentIds: readonly string[],
-  baselineIdsJson?: string
-): string[] {
-  const baseline = parseRecoveryArtifactIds(baselineIdsJson);
-  return Array.from(new Set(currentIds)).filter((id) => !baseline.has(id));
-}
-
 export function getRecoveryNextCheckDelayMs(
   stage: OutreachRecoveryStage,
   attemptCount: number,
@@ -58,8 +30,9 @@ export function getRecoveryNextCheckDelayMs(
   }
 
   // LinkedIn comment outbound detection still uses sparse polling.
-  // Twitter manual-reply detecting_outbound is event-driven via X Activity
-  // (`post.create`); do not add SocialAPI poll intervals for that kind here.
+  // X/Twitter manual-reply detecting_outbound is event-driven via X/Twitter
+  // Activity (`post.create`); do not add SocialAPI poll intervals for that kind
+  // here.
   void kind;
   if (attemptCount < 2) return 15 * 1000;
   if (attemptCount < 5) return 30 * 1000;
@@ -124,8 +97,8 @@ function extractRepliedToPostId(
 }
 
 /**
- * Normalize an X Activity `post.create` envelope/payload into the fields we
- * need to match a pending manual-reply recovery monitor.
+ * Normalize an X/Twitter Activity `post.create` envelope/payload into the
+ * fields we need to match a pending manual-reply recovery monitor.
  */
 export function extractActivityCreatedPost(
   event: unknown
@@ -164,7 +137,7 @@ export function matchesTwitterManualReplyRecovery(args: {
 }): boolean {
   if (!args.post.repliedToPostId) return false;
   if (args.post.repliedToPostId !== args.sourcePostId) return false;
-  if (args.post.authorId && args.post.authorId !== args.connectedXUserId) {
+  if (args.post.authorId !== args.connectedXUserId) {
     return false;
   }
   if (

--- a/convex/lib/xActivity.ts
+++ b/convex/lib/xActivity.ts
@@ -7,7 +7,17 @@ export const X_DM_ACTIVITY_EVENT_TYPES = [
   "chat.conversation_join",
 ] as const;
 
+export const X_POST_ACTIVITY_EVENT_TYPES = ["post.create"] as const;
+
+export const X_ACTIVITY_EVENT_TYPES = [
+  ...X_DM_ACTIVITY_EVENT_TYPES,
+  ...X_POST_ACTIVITY_EVENT_TYPES,
+] as const;
+
 export type XDmActivityEventType = (typeof X_DM_ACTIVITY_EVENT_TYPES)[number];
+export type XPostActivityEventType =
+  (typeof X_POST_ACTIVITY_EVENT_TYPES)[number];
+export type XActivityEventType = (typeof X_ACTIVITY_EVENT_TYPES)[number];
 export type XActivityAuthMode = "app" | "user";
 
 const textEncoder = new TextEncoder();
@@ -67,7 +77,7 @@ type XWebhookRecord = {
 
 type XActivitySubscriptionRecord = {
   subscriptionId: string;
-  eventType: XDmActivityEventType;
+  eventType: XActivityEventType;
   filterUserId?: string;
   webhookId?: string;
   tag?: string;
@@ -135,7 +145,7 @@ function normalizeSubscription(
   if (
     !subscriptionId ||
     !eventType ||
-    !X_DM_ACTIVITY_EVENT_TYPES.includes(eventType as XDmActivityEventType)
+    !X_ACTIVITY_EVENT_TYPES.includes(eventType as XActivityEventType)
   ) {
     return null;
   }
@@ -143,7 +153,7 @@ function normalizeSubscription(
   const filter = input.filter as Record<string, unknown> | undefined;
   return {
     subscriptionId,
-    eventType: eventType as XDmActivityEventType,
+    eventType: eventType as XActivityEventType,
     filterUserId:
       typeof filter?.user_id === "string"
         ? filter.user_id
@@ -301,11 +311,11 @@ export async function listXActivitySubscriptions(): Promise<
 }
 
 export async function createXActivitySubscription(args: {
-  eventType: XDmActivityEventType;
+  eventType: XActivityEventType;
   xUserId: string;
   webhookId: string;
   tag: string;
-  userOAuthAccessToken: string;
+  userOAuthAccessToken?: string;
 }): Promise<{
   subscription: XActivitySubscriptionRecord;
   authMode: XActivityAuthMode;
@@ -332,7 +342,10 @@ export async function createXActivitySubscription(args: {
       requestInit
     );
   } catch (error) {
-    if (!shouldRetryCreateWithUserAuth(error)) {
+    if (
+      !shouldRetryCreateWithUserAuth(error) ||
+      !args.userOAuthAccessToken?.trim()
+    ) {
       throw error;
     }
     response = await xActivityUserRequest(

--- a/convex/lib/xActivity.ts
+++ b/convex/lib/xActivity.ts
@@ -35,7 +35,7 @@ function getRequiredConsumerSecret(): string {
   const value = process.env.X_CONSUMER_SECRET?.trim();
   if (!value) {
     throw new Error(
-      "X_CONSUMER_SECRET is not set in the Convex environment (OAuth 1.0 API Key Secret from X Developer Portal)."
+      "X_CONSUMER_SECRET is not set in the Convex environment (OAuth 1.0 API Key Secret from X/Twitter Developer Portal)."
     );
   }
   return value;
@@ -93,7 +93,7 @@ class XActivityRequestError extends Error {
     body: string;
     authMode: XActivityAuthMode;
   }) {
-    super(`X Activity request failed (${args.status}): ${args.body}`);
+    super(`X/Twitter Activity request failed (${args.status}): ${args.body}`);
     this.name = "XActivityRequestError";
     this.status = args.status;
     this.body = args.body;
@@ -278,7 +278,7 @@ export async function createXWebhook(url: string): Promise<XWebhookRecord> {
   );
   const webhook = normalizeWebhook(response);
   if (!webhook) {
-    throw new Error("X returned an invalid webhook response.");
+    throw new Error("X/Twitter returned an invalid webhook response.");
   }
   return webhook;
 }
@@ -294,7 +294,9 @@ export async function validateXWebhook(
   );
   const webhook = normalizeWebhook(response);
   if (!webhook) {
-    throw new Error("X returned an invalid webhook validation response.");
+    throw new Error(
+      "X/Twitter returned an invalid webhook validation response."
+    );
   }
   return webhook;
 }
@@ -361,7 +363,9 @@ export async function createXActivitySubscription(args: {
       {}
   );
   if (!subscription) {
-    throw new Error("X returned an invalid activity subscription response.");
+    throw new Error(
+      "X/Twitter returned an invalid activity subscription response."
+    );
   }
   return { subscription, authMode };
 }

--- a/convex/outreach.ts
+++ b/convex/outreach.ts
@@ -19,10 +19,12 @@ import {
   getProspectActivePlan,
   createOutreachPlan,
   deleteOutreachPlanCascade,
+  stopActiveOutreachRecoveryMonitorsForPlan,
   refinePlan as refinePlanCore,
   getProspectActivityLog,
   logProspectActivity,
   createNotification,
+  stopActiveOutreachRecoveryMonitorsForTask,
   type OutreachPlanInput,
   type OutreachPlanSnapshot,
   type OutreachTaskInput,
@@ -1860,6 +1862,7 @@ async function cancelOwnedPlan(
     status: "abandoned",
     updatedAt: getCurrentUTCTimestamp(),
   });
+  await stopActiveOutreachRecoveryMonitorsForPlan(ctx, planId);
   await recordMemoryWorkflowEvent(ctx, {
     workspaceId: plan.workspaceId,
     eventType: "outreach_plan_abandoned",
@@ -2000,6 +2003,7 @@ export const setPlanLifecycleInternal = internalMutation({
       status: "abandoned",
       updatedAt: getCurrentUTCTimestamp(),
     });
+    await stopActiveOutreachRecoveryMonitorsForPlan(ctx, planId);
     await recordMemoryWorkflowEvent(ctx, {
       workspaceId: plan.workspaceId,
       eventType: "outreach_plan_abandoned",
@@ -2925,6 +2929,14 @@ export const updateTaskResult = internalMutation({
           ? getCurrentUTCTimestamp()
           : undefined,
     });
+
+    if (
+      args.status === "completed" ||
+      args.status === "failed" ||
+      args.status === "skipped"
+    ) {
+      await stopActiveOutreachRecoveryMonitorsForTask(ctx, args.taskId);
+    }
 
     if (
       args.status === "waiting_response" ||

--- a/convex/outreachRecovery.ts
+++ b/convex/outreachRecovery.ts
@@ -21,12 +21,7 @@ import {
   getProspectDisplayFields,
   upsertNotificationByKey,
 } from "./lib/notificationHelpers";
-import {
-  getNewRecoveryArtifactIds,
-  getRecoveryNextCheckDelayMs,
-  serializeRecoveryArtifactIds,
-  TWITTER_MANUAL_REPLY_POLL_INTERVAL_MS,
-} from "./lib/outreachRecoveryCore";
+import { getRecoveryNextCheckDelayMs } from "./lib/outreachRecoveryCore";
 
 const SOCIALAPI_BASE_URL = "https://api.socialapi.me";
 const TWITTER_MANUAL_DETECTION_WINDOW_MS = 48 * 60 * 60 * 1000;
@@ -35,12 +30,6 @@ const LINKEDIN_CONNECTION_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
 const internalRecovery = (internal as any).outreachRecovery;
 
 type RecoveryMonitor = Doc<"outreachRecoveryMonitors">;
-
-type SocialApiCommentedResponse = {
-  comment_ids?: string[];
-  is_commented?: boolean;
-  status?: string;
-};
 
 type SocialApiSearchResponse = {
   tweets?: unknown[];
@@ -129,56 +118,12 @@ async function fetchSocialApiJson<T>(
   return JSON.parse(body) as T;
 }
 
-async function fetchTwitterCommentIds(
-  ctx: ActionCtx,
-  tweetId: string,
-  xUserId: string
-): Promise<string[]> {
-  const payload = await fetchSocialApiJson<SocialApiCommentedResponse>(
-    ctx,
-    "outreachRecovery.verifyUserCommented",
-    `/twitter/tweets/${encodeURIComponent(tweetId)}/commented_by/${encodeURIComponent(xUserId)}`
-  );
-  return Array.isArray(payload.comment_ids)
-    ? payload.comment_ids.filter(
-        (commentId): commentId is string => typeof commentId === "string"
-      )
-    : [];
-}
-
 function getTweetReplyTargetId(tweet: unknown): string | undefined {
   const record = getNestedRecord({ tweet }, "tweet");
   return (
     getStringProperty(record, "in_reply_to_status_id_str") ??
     getStringProperty(record, "inReplyToTweetId")
   );
-}
-
-function getTweetAuthorId(tweet: unknown): string | undefined {
-  const record = getNestedRecord({ tweet }, "tweet");
-  const user = getNestedRecord(record, "user");
-  const author = getNestedRecord(record, "author");
-  return (
-    getStringProperty(user, "id_str") ??
-    getStringProperty(user, "id") ??
-    getStringProperty(author, "id") ??
-    getStringProperty(record, "author_id")
-  );
-}
-
-async function hydrateTwitterPost(
-  ctx: ActionCtx,
-  userId: Id<"users">,
-  tweetId: string
-): Promise<unknown | null> {
-  const result = await ctx.runAction(
-    internal.x.getHydratedTwitterPostInternal,
-    {
-      userId,
-      tweetId,
-    }
-  );
-  return result?.tweet ?? null;
 }
 
 export const beginTwitterManualReplyRecovery = internalAction({
@@ -216,20 +161,17 @@ export const beginTwitterManualReplyRecovery = internalAction({
       return { started: false };
     }
 
-    let baselineIds: string[] = [];
-    try {
-      baselineIds = await fetchTwitterCommentIds(
-        ctx,
-        task.targetTweetId,
-        connection.xUserId
-      );
-    } catch (error) {
+    const ensured = await ctx.runAction(
+      internal.xActivity.ensurePostCreateActivitySubscriptionForUserInternal,
+      { userId: planData.plan.userId }
+    );
+    if (!ensured.ensured) {
       console.warn(
-        "[OutreachRecovery] Could not snapshot existing X replies before manual handoff",
+        "[OutreachRecovery] post.create Activity subscription not ready; manual reply detection may expire without detection",
         {
           taskId: String(args.taskId),
-          targetTweetId: task.targetTweetId,
-          error: error instanceof Error ? error.message : String(error),
+          userId: String(planData.plan.userId),
+          reason: ensured.reason,
         }
       );
     }
@@ -239,7 +181,6 @@ export const beginTwitterManualReplyRecovery = internalAction({
       {
         taskId: args.taskId,
         planId: args.planId,
-        baselineArtifactIdsJson: serializeRecoveryArtifactIds(baselineIds),
         errorMessage: args.errorMessage,
       }
     );
@@ -411,7 +352,6 @@ export const startTwitterManualReplyRecovery = internalMutation({
   args: {
     taskId: v.id("outreachTasks"),
     planId: v.id("outreachPlans"),
-    baselineArtifactIdsJson: v.string(),
     errorMessage: v.string(),
   },
   returns: v.id("outreachRecoveryMonitors"),
@@ -434,6 +374,7 @@ export const startTwitterManualReplyRecovery = internalMutation({
     if (existing) return existing._id;
 
     const now = getCurrentUTCTimestamp();
+    const expiresAt = now + TWITTER_MANUAL_DETECTION_WINDOW_MS;
     const monitorId = await ctx.db.insert("outreachRecoveryMonitors", {
       userId: plan.userId,
       workspaceId: plan.workspaceId,
@@ -444,11 +385,9 @@ export const startTwitterManualReplyRecovery = internalMutation({
       stage: "detecting_outbound",
       status: "active",
       sourcePostId: task.targetTweetId,
-      baselineArtifactIdsJson: args.baselineArtifactIdsJson,
       startedAt: now,
-      expiresAt: now + TWITTER_MANUAL_DETECTION_WINDOW_MS,
+      expiresAt,
       attemptCount: 0,
-      nextCheckAt: now + TWITTER_MANUAL_REPLY_POLL_INTERVAL_MS,
     });
 
     await ctx.db.patch("outreachTasks", task._id, {
@@ -472,7 +411,7 @@ export const startTwitterManualReplyRecovery = internalMutation({
       type: "ask_human",
       notificationKey: `manual-x-reply:${task._id}`,
       title: "Post this reply manually on X",
-      message: `X blocked automatic posting. Open the post and publish the prepared reply: ${postUrl}\n\nReacherX is watching automatically and will continue the plan when your reply appears.`,
+      message: `X blocked automatic posting. Open the post and publish the prepared reply: ${postUrl}\n\nReacherX will continue the plan automatically when your reply appears on X.`,
       prospectId: plan.prospectId,
       planId: plan._id,
       taskId: task._id,
@@ -481,9 +420,11 @@ export const startTwitterManualReplyRecovery = internalMutation({
       ...display,
     });
 
+    // No SocialAPI polling — detection is via X Activity `post.create`.
+    // Only schedule expiry so silent failures don't linger forever.
     await ctx.scheduler.runAfter(
-      TWITTER_MANUAL_REPLY_POLL_INTERVAL_MS,
-      internalRecovery.checkRecoveryMonitor,
+      Math.max(0, expiresAt - now),
+      internalRecovery.expireTwitterManualReplyDetection,
       { monitorId }
     );
     return monitorId;
@@ -574,6 +515,136 @@ export const getRecoveryMonitorInternal = internalQuery({
   returns: v.union(v.null(), v.any()),
   handler: async (ctx, args) =>
     await ctx.db.get("outreachRecoveryMonitors", args.monitorId),
+});
+
+export const listActiveTwitterManualReplyMonitorsForUserInternal =
+  internalQuery({
+    args: { userId: v.id("users") },
+    returns: v.array(v.any()),
+    handler: async (ctx, args) => {
+      const active = await ctx.db
+        .query("outreachRecoveryMonitors")
+        .withIndex("by_user_and_status", (q) =>
+          q.eq("userId", args.userId).eq("status", "active")
+        )
+        .collect();
+      return active.filter(
+        (monitor) => monitor.kind === "twitter_manual_reply"
+      );
+    },
+  });
+
+async function expireTwitterManualReplyMonitor(
+  ctx: MutationCtx,
+  monitor: RecoveryMonitor
+) {
+  if (monitor.status !== "active" || monitor.stage !== "detecting_outbound") {
+    return;
+  }
+
+  const now = getCurrentUTCTimestamp();
+  await ctx.db.patch("outreachRecoveryMonitors", monitor._id, {
+    status: "expired",
+    lastCheckedAt: now,
+    nextCheckAt: undefined,
+    completedAt: now,
+  });
+
+  if (!monitor.taskId) return;
+
+  const prospect = await ctx.db.get("prospects", monitor.prospectId);
+  const display = getProspectDisplayFields(prospect);
+  await upsertNotificationByKey(ctx, {
+    userId: monitor.userId,
+    workspaceId: monitor.workspaceId,
+    type: "error",
+    notificationKey: `manual-x-reply-expired:${monitor.taskId}`,
+    title: "Manual X reply was not detected",
+    message:
+      "ReacherX could not verify a new direct reply on the selected X post. The outreach plan remains paused so it will not send a duplicate.",
+    prospectId: monitor.prospectId,
+    planId: monitor.planId,
+    taskId: monitor.taskId,
+    contextPlatform: "twitter",
+    ...display,
+  });
+}
+
+export const expireTwitterManualReplyDetection = internalMutation({
+  args: { monitorId: v.id("outreachRecoveryMonitors") },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const monitor = await ctx.db.get(
+      "outreachRecoveryMonitors",
+      args.monitorId
+    );
+    if (!monitor) return null;
+    if (
+      monitor.kind !== "twitter_manual_reply" ||
+      monitor.stage !== "detecting_outbound" ||
+      monitor.status !== "active"
+    ) {
+      return null;
+    }
+    if (getCurrentUTCTimestamp() < monitor.expiresAt) {
+      return null;
+    }
+    await expireTwitterManualReplyMonitor(ctx, monitor);
+    return null;
+  },
+});
+
+/**
+ * Stops SocialAPI-polling-era Twitter manual reply recoveries and any still
+ * waiting for Activity detection. Used when pausing a workspace and as a
+ * one-shot prod cleanup after deploy.
+ */
+export const cancelTwitterManualReplyRecoveriesInternal = internalMutation({
+  args: {
+    workspaceId: v.optional(v.id("workspaces")),
+    userId: v.optional(v.id("users")),
+  },
+  returns: v.object({ cancelledCount: v.number() }),
+  handler: async (ctx, args) => {
+    let monitors: Doc<"outreachRecoveryMonitors">[] = [];
+    if (args.workspaceId) {
+      monitors = await ctx.db
+        .query("outreachRecoveryMonitors")
+        .withIndex("by_workspace", (q) =>
+          q.eq("workspaceId", args.workspaceId!)
+        )
+        .collect();
+    } else if (args.userId) {
+      monitors = await ctx.db
+        .query("outreachRecoveryMonitors")
+        .withIndex("by_user_and_status", (q) =>
+          q.eq("userId", args.userId!).eq("status", "active")
+        )
+        .collect();
+    } else {
+      throw new Error("workspaceId or userId is required");
+    }
+
+    const now = getCurrentUTCTimestamp();
+    let cancelledCount = 0;
+    for (const monitor of monitors) {
+      if (
+        monitor.status !== "active" ||
+        monitor.kind !== "twitter_manual_reply"
+      ) {
+        continue;
+      }
+      await ctx.db.patch(monitor._id, {
+        status: "expired",
+        lastCheckedAt: now,
+        nextCheckAt: undefined,
+        completedAt: now,
+        lastErrorMessage: "Cancelled — switched to X Activity detection",
+      });
+      cancelledCount += 1;
+    }
+    return { cancelledCount };
+  },
 });
 
 export const recordRecoveryCheck = internalMutation({
@@ -850,82 +921,6 @@ export const confirmLinkedInOutboundComment = internalMutation({
   },
 });
 
-async function checkTwitterManualOutbound(
-  ctx: ActionCtx,
-  monitor: RecoveryMonitor
-): Promise<boolean> {
-  const connection = await ctx.runAction(
-    internal.x.getTwitterConnectionIdentityInternal,
-    { userId: monitor.userId }
-  );
-  if (!connection.isConnected || !connection.xUserId) {
-    throw new Error("Connected X identity is unavailable");
-  }
-
-  const commentIds = await fetchTwitterCommentIds(
-    ctx,
-    monitor.sourcePostId,
-    connection.xUserId
-  );
-  const candidates = getNewRecoveryArtifactIds(
-    commentIds,
-    monitor.baselineArtifactIdsJson
-  );
-
-  for (const commentId of candidates) {
-    const tweet = await hydrateTwitterPost(ctx, monitor.userId, commentId);
-    if (!tweet) continue;
-    const replyTargetId = getTweetReplyTargetId(tweet);
-    if (replyTargetId && replyTargetId !== monitor.sourcePostId) continue;
-    const authorId = getTweetAuthorId(tweet);
-    if (authorId && authorId !== connection.xUserId) continue;
-
-    const summary = summarizeTwitterPost(tweet);
-    if (summary?.createdAt && summary.createdAt < monitor.startedAt) continue;
-    const confirmedTaskId = await ctx.runMutation(
-      internalRecovery.confirmTwitterManualReply,
-      {
-        monitorId: monitor._id,
-        replyPostId: commentId,
-        replyText: summary?.textPreview,
-        repliedAt: summary?.createdAt ?? getCurrentUTCTimestamp(),
-      }
-    );
-    if (!confirmedTaskId) return false;
-
-    await ctx.runMutation(internal.outreach.upsertTwitterInteraction, {
-      userId: monitor.userId,
-      prospectId: monitor.prospectId,
-      sourcePostRef: {
-        platform: "twitter",
-        postId: monitor.sourcePostId,
-        conversationId: monitor.sourcePostId,
-      },
-      replyPostRef: {
-        platform: "twitter",
-        postId: commentId,
-        conversationId: monitor.sourcePostId,
-        authorHandle: connection.screenName,
-        url: buildTwitterPostUrl({
-          postId: commentId,
-          authorHandle: connection.screenName,
-        }),
-      },
-      replyPostSummary: summary ?? undefined,
-      threadId: monitor.sourcePostId,
-      repliedAt: summary?.createdAt ?? getCurrentUTCTimestamp(),
-      origin: "external_x",
-      discoveredVia: "socialapi_incremental",
-      status: "active",
-      direction: "outgoing",
-      discoveredAt: summary?.createdAt ?? getCurrentUTCTimestamp(),
-      lastSeenAt: getCurrentUTCTimestamp(),
-    });
-    return true;
-  }
-  return false;
-}
-
 async function checkTwitterProspectResponse(
   ctx: ActionCtx,
   monitor: RecoveryMonitor
@@ -1078,12 +1073,19 @@ export const checkRecoveryMonitor = internalAction({
     )) as RecoveryMonitor | null;
     if (!monitor || monitor.status !== "active") return null;
 
+    // Twitter manual outbound detection is event-driven via X Activity
+    // `post.create`. Expiry is handled by expireTwitterManualReplyDetection.
+    if (
+      monitor.kind === "twitter_manual_reply" &&
+      monitor.stage === "detecting_outbound"
+    ) {
+      return null;
+    }
+
     try {
       const detected =
         monitor.kind === "twitter_manual_reply"
-          ? monitor.stage === "detecting_outbound"
-            ? await checkTwitterManualOutbound(ctx, monitor)
-            : await checkTwitterProspectResponse(ctx, monitor)
+          ? await checkTwitterProspectResponse(ctx, monitor)
           : monitor.kind === "linkedin_connection_then_dm"
             ? await checkLinkedInConnection(ctx, monitor)
             : await checkLinkedInCommentResponse(ctx, monitor);

--- a/convex/outreachRecovery.ts
+++ b/convex/outreachRecovery.ts
@@ -1,4 +1,5 @@
 import { v } from "convex/values";
+import { paginationOptsValidator } from "convex/server";
 import type { ActionCtx, MutationCtx } from "./_generated/server";
 import type { Doc, Id } from "./_generated/dataModel";
 import { internal } from "./_generated/api";
@@ -18,23 +19,155 @@ import { resolveProspectTwitterIdentity } from "../shared/lib/twitter/prospectTw
 import { normalizeLinkedInReadUrn } from "../shared/lib/linkedin/comments";
 import { getNestedRecord, getStringProperty } from "./lib/typeGuards";
 import {
+  dismissNotificationsByKey,
   getProspectDisplayFields,
   upsertNotificationByKey,
 } from "./lib/notificationHelpers";
 import { getRecoveryNextCheckDelayMs } from "./lib/outreachRecoveryCore";
 
 const SOCIALAPI_BASE_URL = "https://api.socialapi.me";
-const TWITTER_MANUAL_DETECTION_WINDOW_MS = 48 * 60 * 60 * 1000;
 const RESPONSE_MONITOR_WINDOW_MS = 14 * 24 * 60 * 60 * 1000;
 const LINKEDIN_CONNECTION_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
 const internalRecovery = (internal as any).outreachRecovery;
 
 type RecoveryMonitor = Doc<"outreachRecoveryMonitors">;
 
+type RecoveryMonitorPage = {
+  page: RecoveryMonitor[];
+  isDone: boolean;
+  continueCursor: string;
+};
+
+type TwitterManualReplyMonitoringStatus =
+  | "ready"
+  | "reconnect_required"
+  | "configuring";
+
 type SocialApiSearchResponse = {
   tweets?: unknown[];
   message?: string;
 };
+
+const MANUAL_OUTBOUND_DETECTION_WINDOW_MS = 48 * 60 * 60 * 1000;
+const TWITTER_ACTIVITY_RETRY_DELAY_MS = 15 * 60 * 1000;
+
+async function expireInactiveTwitterManualReplyMonitor(
+  ctx: MutationCtx,
+  monitor: RecoveryMonitor
+) {
+  if (monitor.status !== "active") return;
+
+  const now = getCurrentUTCTimestamp();
+  await ctx.db.patch("outreachRecoveryMonitors", monitor._id, {
+    status: "expired",
+    lastCheckedAt: now,
+    nextCheckAt: undefined,
+    completedAt: now,
+    lastErrorMessage: "The outreach plan or task is no longer active.",
+  });
+  if (monitor.taskId) {
+    await dismissNotificationsByKey(ctx, {
+      userId: monitor.userId,
+      workspaceId: monitor.workspaceId,
+      notificationKey: `manual-x-reply:${monitor.taskId}`,
+    });
+  }
+}
+
+async function syncTwitterManualReplyNotification(
+  ctx: MutationCtx,
+  monitor: RecoveryMonitor,
+  status: TwitterManualReplyMonitoringStatus
+) {
+  if (!monitor.taskId || !monitor.planId) {
+    await expireInactiveTwitterManualReplyMonitor(ctx, monitor);
+    return;
+  }
+
+  const [task, plan, prospect] = await Promise.all([
+    ctx.db.get("outreachTasks", monitor.taskId),
+    ctx.db.get("outreachPlans", monitor.planId),
+    ctx.db.get("prospects", monitor.prospectId),
+  ]);
+  if (
+    !task ||
+    !plan ||
+    task.status !== "waiting_manual" ||
+    plan.status === "completed" ||
+    plan.status === "abandoned"
+  ) {
+    await expireInactiveTwitterManualReplyMonitor(ctx, monitor);
+    return;
+  }
+
+  if (plan.status !== "paused") {
+    await ctx.db.patch("outreachPlans", plan._id, {
+      status: "paused",
+      updatedAt: getCurrentUTCTimestamp(),
+    });
+  }
+
+  const postUrl = buildTwitterPostUrl({ postId: monitor.sourcePostId });
+  const notificationKey = `manual-x-reply:${task._id}`;
+  const copy =
+    status === "ready"
+      ? {
+          type: "ask_human" as const,
+          title: "Post this reply manually on X/Twitter",
+          message: `X/Twitter blocked automatic posting. Open the post and publish the prepared reply: ${postUrl}\n\nReacherX will continue the plan automatically when your reply appears on X/Twitter.`,
+          targetHref: undefined,
+          actionLabel: undefined,
+        }
+      : status === "reconnect_required"
+        ? {
+            type: "error" as const,
+            title: "Reconnect X/Twitter to continue",
+            message: `Your plan is paused because ReacherX cannot watch for your manual reply until X/Twitter is connected. Reconnect X/Twitter, then publish the prepared reply: ${postUrl}`,
+            targetHref: "/settings/connected-accounts",
+            actionLabel: "Reconnect",
+          }
+        : {
+            type: "error" as const,
+            title: "X/Twitter monitoring is being set up",
+            message: `Your plan is paused while ReacherX finishes setting up X/Twitter monitoring. We’ll try again automatically. You can publish the prepared reply here when ready: ${postUrl}`,
+            targetHref: undefined,
+            actionLabel: undefined,
+          };
+  const display = getProspectDisplayFields(prospect);
+  const existing = await ctx.db
+    .query("outreachNotifications")
+    .withIndex("by_user_workspace_key", (q) =>
+      q
+        .eq("userId", monitor.userId)
+        .eq("workspaceId", monitor.workspaceId)
+        .eq("notificationKey", notificationKey)
+    )
+    .first();
+  const isUnchanged =
+    existing?.type === copy.type &&
+    existing.title === copy.title &&
+    existing.message === copy.message &&
+    existing.targetHref === copy.targetHref &&
+    existing.actionLabel === copy.actionLabel;
+  if (isUnchanged) return;
+
+  await upsertNotificationByKey(ctx, {
+    userId: monitor.userId,
+    workspaceId: monitor.workspaceId,
+    type: copy.type,
+    notificationKey,
+    title: copy.title,
+    message: copy.message,
+    targetHref: copy.targetHref,
+    actionLabel: copy.actionLabel,
+    prospectId: monitor.prospectId,
+    planId: monitor.planId,
+    taskId: monitor.taskId,
+    threadId: plan.threadId,
+    contextPlatform: "twitter",
+    ...display,
+  });
+}
 
 async function resumeDmAfterLinkedInConnection(
   ctx: MutationCtx,
@@ -153,25 +286,34 @@ export const beginTwitterManualReplyRecovery = internalAction({
       return { started: false };
     }
 
-    const connection = await ctx.runAction(
-      internal.x.getTwitterConnectionIdentityInternal,
-      { userId: planData.plan.userId }
-    );
-    if (!connection.isConnected || !connection.xUserId) {
-      return { started: false };
-    }
-
-    const ensured = await ctx.runAction(
-      internal.xActivity.ensurePostCreateActivitySubscriptionForUserInternal,
-      { userId: planData.plan.userId }
-    );
-    if (!ensured.ensured) {
+    let monitoringStatus: TwitterManualReplyMonitoringStatus = "configuring";
+    try {
+      const connection = await ctx.runAction(
+        internal.x.getTwitterConnectionIdentityInternal,
+        { userId: planData.plan.userId }
+      );
+      if (!connection.isConnected || !connection.xUserId) {
+        monitoringStatus = "reconnect_required";
+      } else {
+        const ensured = await ctx.runAction(
+          internal.xActivity
+            .ensurePostCreateActivitySubscriptionForUserInternal,
+          { userId: planData.plan.userId }
+        );
+        monitoringStatus = ensured.ensured
+          ? "ready"
+          : ensured.reason === "missing_connection" ||
+              ensured.reason === "missing_scopes"
+            ? "reconnect_required"
+            : "configuring";
+      }
+    } catch (error) {
       console.warn(
-        "[OutreachRecovery] post.create Activity subscription not ready; manual reply detection may expire without detection",
+        "[OutreachRecovery] Unable to prepare X/Twitter monitoring",
         {
           taskId: String(args.taskId),
           userId: String(planData.plan.userId),
-          reason: ensured.reason,
+          error: error instanceof Error ? error.message : String(error),
         }
       );
     }
@@ -182,8 +324,16 @@ export const beginTwitterManualReplyRecovery = internalAction({
         taskId: args.taskId,
         planId: args.planId,
         errorMessage: args.errorMessage,
+        monitoringStatus,
       }
     );
+    if (monitoringStatus !== "ready") {
+      await ctx.scheduler.runAfter(
+        0,
+        internalRecovery.ensureTwitterManualReplyRecoveryForUserInternal,
+        { userId: planData.plan.userId }
+      );
+    }
     return { started: true, monitorId };
   },
 });
@@ -353,6 +503,13 @@ export const startTwitterManualReplyRecovery = internalMutation({
     taskId: v.id("outreachTasks"),
     planId: v.id("outreachPlans"),
     errorMessage: v.string(),
+    monitoringStatus: v.optional(
+      v.union(
+        v.literal("ready"),
+        v.literal("reconnect_required"),
+        v.literal("configuring")
+      )
+    ),
   },
   returns: v.id("outreachRecoveryMonitors"),
   handler: async (ctx, args) => {
@@ -371,10 +528,13 @@ export const startTwitterManualReplyRecovery = internalMutation({
         .order("desc")
         .take(5)
     ).find((monitor) => monitor.status === "active");
-    if (existing) return existing._id;
+    const monitoringStatus = args.monitoringStatus ?? "ready";
+    if (existing) {
+      await syncTwitterManualReplyNotification(ctx, existing, monitoringStatus);
+      return existing._id;
+    }
 
     const now = getCurrentUTCTimestamp();
-    const expiresAt = now + TWITTER_MANUAL_DETECTION_WINDOW_MS;
     const monitorId = await ctx.db.insert("outreachRecoveryMonitors", {
       userId: plan.userId,
       workspaceId: plan.workspaceId,
@@ -386,7 +546,6 @@ export const startTwitterManualReplyRecovery = internalMutation({
       status: "active",
       sourcePostId: task.targetTweetId,
       startedAt: now,
-      expiresAt,
       attemptCount: 0,
     });
 
@@ -402,31 +561,13 @@ export const startTwitterManualReplyRecovery = internalMutation({
       updatedAt: now,
     });
 
-    const prospect = await ctx.db.get("prospects", plan.prospectId);
-    const display = getProspectDisplayFields(prospect);
-    const postUrl = buildTwitterPostUrl({ postId: task.targetTweetId });
-    await upsertNotificationByKey(ctx, {
-      userId: plan.userId,
-      workspaceId: plan.workspaceId,
-      type: "ask_human",
-      notificationKey: `manual-x-reply:${task._id}`,
-      title: "Post this reply manually on X",
-      message: `X blocked automatic posting. Open the post and publish the prepared reply: ${postUrl}\n\nReacherX will continue the plan automatically when your reply appears on X.`,
-      prospectId: plan.prospectId,
-      planId: plan._id,
-      taskId: task._id,
-      threadId: plan.threadId,
-      contextPlatform: "twitter",
-      ...display,
-    });
+    const monitor = await ctx.db.get("outreachRecoveryMonitors", monitorId);
+    if (monitor) {
+      await syncTwitterManualReplyNotification(ctx, monitor, monitoringStatus);
+    }
 
-    // No SocialAPI polling — detection is via X Activity `post.create`.
-    // Only schedule expiry so silent failures don't linger forever.
-    await ctx.scheduler.runAfter(
-      Math.max(0, expiresAt - now),
-      internalRecovery.expireTwitterManualReplyDetection,
-      { monitorId }
-    );
+    // Detection is event-driven via X/Twitter Activity `post.create`. There is no
+    // polling deadline while the task remains waiting_manual.
     return monitorId;
   },
 });
@@ -497,7 +638,7 @@ export const startLinkedInCommentReplyMonitor = internalMutation({
         now +
         (args.commentId
           ? RESPONSE_MONITOR_WINDOW_MS
-          : TWITTER_MANUAL_DETECTION_WINDOW_MS),
+          : MANUAL_OUTBOUND_DETECTION_WINDOW_MS),
       attemptCount: 0,
       nextCheckAt: now + (args.commentId ? 5 * 60 * 1000 : 30_000),
     });
@@ -517,56 +658,447 @@ export const getRecoveryMonitorInternal = internalQuery({
     await ctx.db.get("outreachRecoveryMonitors", args.monitorId),
 });
 
-export const listActiveTwitterManualReplyMonitorsForUserInternal =
+export const listActiveTwitterManualReplyMonitorsPageForUserInternal =
   internalQuery({
-    args: { userId: v.id("users") },
-    returns: v.array(v.any()),
-    handler: async (ctx, args) => {
-      const active = await ctx.db
+    args: {
+      userId: v.id("users"),
+      paginationOpts: paginationOptsValidator,
+    },
+    returns: v.any(),
+    handler: async (ctx, args) =>
+      await ctx.db
         .query("outreachRecoveryMonitors")
-        .withIndex("by_user_and_status", (q) =>
-          q.eq("userId", args.userId).eq("status", "active")
+        .withIndex("by_user_kind_status_source_post", (q) =>
+          q
+            .eq("userId", args.userId)
+            .eq("kind", "twitter_manual_reply")
+            .eq("status", "active")
         )
-        .collect();
-      return active.filter(
-        (monitor) => monitor.kind === "twitter_manual_reply"
+        .filter((q) => q.eq(q.field("stage"), "detecting_outbound"))
+        .paginate(args.paginationOpts),
+  });
+
+export const getActiveTwitterManualReplyMonitorForSourcePostInternal =
+  internalQuery({
+    args: {
+      userId: v.id("users"),
+      sourcePostId: v.string(),
+    },
+    returns: v.union(v.null(), v.any()),
+    handler: async (ctx, args) =>
+      await ctx.db
+        .query("outreachRecoveryMonitors")
+        .withIndex("by_user_kind_status_source_post", (q) =>
+          q
+            .eq("userId", args.userId)
+            .eq("kind", "twitter_manual_reply")
+            .eq("status", "active")
+            .eq("sourcePostId", args.sourcePostId)
+        )
+        .filter((q) => q.eq(q.field("stage"), "detecting_outbound"))
+        .order("desc")
+        .first(),
+  });
+
+export const listTwitterManualReplyRecoveryMigrationPageInternal =
+  internalQuery({
+    args: {
+      paginationOpts: paginationOptsValidator,
+    },
+    returns: v.any(),
+    handler: async (ctx, args) =>
+      await ctx.db
+        .query("outreachRecoveryMonitors")
+        .withIndex("by_kind_and_status", (q) =>
+          q.eq("kind", "twitter_manual_reply").eq("status", "active")
+        )
+        .filter((q) => q.eq(q.field("stage"), "detecting_outbound"))
+        .paginate(args.paginationOpts),
+  });
+
+export const migrateTwitterManualReplyMonitorsBatchInternal = internalMutation({
+  args: {
+    monitorIds: v.array(v.id("outreachRecoveryMonitors")),
+    monitoringStatus: v.union(
+      v.literal("ready"),
+      v.literal("reconnect_required"),
+      v.literal("configuring")
+    ),
+  },
+  returns: v.object({ migratedCount: v.number() }),
+  handler: async (ctx, args) => {
+    let migratedCount = 0;
+    for (const monitorId of args.monitorIds) {
+      const monitor = await ctx.db.get("outreachRecoveryMonitors", monitorId);
+      if (
+        !monitor ||
+        monitor.status !== "active" ||
+        monitor.kind !== "twitter_manual_reply" ||
+        monitor.stage !== "detecting_outbound"
+      ) {
+        continue;
+      }
+      if (!monitor.taskId || !monitor.planId) {
+        await expireInactiveTwitterManualReplyMonitor(ctx, monitor);
+        continue;
+      }
+
+      const [task, plan] = await Promise.all([
+        ctx.db.get("outreachTasks", monitor.taskId),
+        ctx.db.get("outreachPlans", monitor.planId),
+      ]);
+      if (
+        !task ||
+        !plan ||
+        task.status !== "waiting_manual" ||
+        plan.status === "completed" ||
+        plan.status === "abandoned"
+      ) {
+        await expireInactiveTwitterManualReplyMonitor(ctx, monitor);
+        continue;
+      }
+
+      await syncTwitterManualReplyNotification(
+        ctx,
+        monitor,
+        args.monitoringStatus
       );
+      migratedCount += 1;
+    }
+    return { migratedCount };
+  },
+});
+
+/**
+ * One-shot, rerunnable migration for active Twitter manual-reply recoveries.
+ * It moves each recovery to indefinite X/Twitter Activity monitoring without
+ * performing any SocialAPI lookup.
+ */
+export const migrateTwitterManualReplyRecoveriesInternal = internalAction({
+  args: {
+    cursor: v.optional(v.union(v.string(), v.null())),
+    batchSize: v.optional(v.number()),
+  },
+  returns: v.object({
+    processedCount: v.number(),
+    migratedCount: v.number(),
+    continuationScheduled: v.boolean(),
+  }),
+  handler: async (ctx, args) => {
+    const batchSize = Math.max(
+      1,
+      Math.min(Math.floor(args.batchSize ?? 25), 50)
+    );
+    const page = (await ctx.runQuery(
+      internalRecovery.listTwitterManualReplyRecoveryMigrationPageInternal,
+      {
+        paginationOpts: {
+          cursor: args.cursor ?? null,
+          numItems: batchSize,
+        },
+      }
+    )) as {
+      page: RecoveryMonitor[];
+      isDone: boolean;
+      continueCursor: string;
+    };
+
+    const monitorIdsByUser = new Map<
+      Id<"users">,
+      Id<"outreachRecoveryMonitors">[]
+    >();
+    for (const monitor of page.page) {
+      const monitorIds = monitorIdsByUser.get(monitor.userId) ?? [];
+      monitorIds.push(monitor._id);
+      monitorIdsByUser.set(monitor.userId, monitorIds);
+    }
+
+    let migratedCount = 0;
+    for (const [userId, monitorIds] of monitorIdsByUser) {
+      let monitoringStatus: TwitterManualReplyMonitoringStatus = "configuring";
+      try {
+        const ensured = await ctx.runAction(
+          internalRecovery.ensureTwitterManualReplyRecoveryForUserInternal,
+          { userId }
+        );
+        monitoringStatus = ensured.monitoringStatus;
+      } catch (error) {
+        console.warn("[OutreachRecovery] Recovery migration setup failed", {
+          userId: String(userId),
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+
+      const result = await ctx.runMutation(
+        internalRecovery.migrateTwitterManualReplyMonitorsBatchInternal,
+        {
+          monitorIds,
+          monitoringStatus,
+        }
+      );
+      migratedCount += result.migratedCount;
+    }
+
+    const continuationScheduled = !page.isDone;
+    if (continuationScheduled) {
+      await ctx.scheduler.runAfter(
+        0,
+        internalRecovery.migrateTwitterManualReplyRecoveriesInternal,
+        {
+          cursor: page.continueCursor,
+          batchSize,
+        }
+      );
+    }
+
+    return {
+      processedCount: page.page.length,
+      migratedCount,
+      continuationScheduled,
+    };
+  },
+});
+
+export const syncTwitterManualReplyRecoveryStatusForUserInternal =
+  internalMutation({
+    args: {
+      userId: v.id("users"),
+      monitorIds: v.array(v.id("outreachRecoveryMonitors")),
+      monitoringStatus: v.union(
+        v.literal("ready"),
+        v.literal("reconnect_required"),
+        v.literal("configuring")
+      ),
+    },
+    returns: v.object({ updatedCount: v.number() }),
+    handler: async (ctx, args) => {
+      const monitors = (
+        await Promise.all(
+          args.monitorIds.map((monitorId) =>
+            ctx.db.get("outreachRecoveryMonitors", monitorId)
+          )
+        )
+      ).filter(
+        (monitor): monitor is RecoveryMonitor =>
+          monitor !== null &&
+          monitor.userId === args.userId &&
+          monitor.status === "active"
+      );
+      let updatedCount = 0;
+      for (const monitor of monitors) {
+        if (
+          monitor.kind !== "twitter_manual_reply" ||
+          monitor.stage !== "detecting_outbound"
+        ) {
+          continue;
+        }
+        const [task, plan] = await Promise.all([
+          monitor.taskId
+            ? ctx.db.get("outreachTasks", monitor.taskId)
+            : Promise.resolve(null),
+          monitor.planId
+            ? ctx.db.get("outreachPlans", monitor.planId)
+            : Promise.resolve(null),
+        ]);
+        if (
+          !task ||
+          !plan ||
+          task.status !== "waiting_manual" ||
+          plan.status === "completed" ||
+          plan.status === "abandoned"
+        ) {
+          await expireInactiveTwitterManualReplyMonitor(ctx, monitor);
+          continue;
+        }
+        await syncTwitterManualReplyNotification(
+          ctx,
+          monitor,
+          args.monitoringStatus
+        );
+        updatedCount += 1;
+      }
+      return { updatedCount };
     },
   });
 
-async function expireTwitterManualReplyMonitor(
+export const ensureTwitterManualReplyRecoveryForUserInternal = internalAction({
+  args: {
+    userId: v.id("users"),
+  },
+  returns: v.object({
+    monitoredCount: v.number(),
+    monitoringStatus: v.union(
+      v.literal("ready"),
+      v.literal("reconnect_required"),
+      v.literal("configuring")
+    ),
+  }),
+  handler: async (
+    ctx,
+    args
+  ): Promise<{
+    monitoredCount: number;
+    monitoringStatus: TwitterManualReplyMonitoringStatus;
+  }> => {
+    const monitors: RecoveryMonitor[] = [];
+    let cursor: string | null = null;
+    while (true) {
+      const page: RecoveryMonitorPage = await ctx.runQuery(
+        internalRecovery.listActiveTwitterManualReplyMonitorsPageForUserInternal,
+        {
+          userId: args.userId,
+          paginationOpts: {
+            cursor,
+            numItems: 100,
+          },
+        }
+      );
+      monitors.push(...page.page);
+      if (page.isDone) break;
+      cursor = page.continueCursor;
+    }
+    if (monitors.length === 0) {
+      return { monitoredCount: 0, monitoringStatus: "ready" as const };
+    }
+
+    const account = await ctx.runQuery(
+      internal.xStore.getXAccountForUserInternal,
+      { userId: args.userId }
+    );
+    if (!account || account.status !== "connected") {
+      await ctx.runMutation(
+        internalRecovery.syncTwitterManualReplyRecoveryStatusForUserInternal,
+        {
+          userId: args.userId,
+          monitorIds: monitors.map((monitor) => monitor._id),
+          monitoringStatus: "reconnect_required",
+        }
+      );
+      return {
+        monitoredCount: monitors.length,
+        monitoringStatus: "reconnect_required" as const,
+      };
+    }
+
+    const now = getCurrentUTCTimestamp();
+    const isPendingRetryWindow =
+      account.activitySubscriptionStatus === "pending_retry" &&
+      typeof account.activitySubscriptionsNextRetryAt === "number" &&
+      account.activitySubscriptionsNextRetryAt > now;
+    if (isPendingRetryWindow) {
+      await ctx.runMutation(
+        internalRecovery.syncTwitterManualReplyRecoveryStatusForUserInternal,
+        {
+          userId: args.userId,
+          monitorIds: monitors.map((monitor) => monitor._id),
+          monitoringStatus: "configuring",
+        }
+      );
+      await ctx.scheduler.runAfter(
+        Math.max(
+          0,
+          account.activitySubscriptionsNextRetryAt! - getCurrentUTCTimestamp()
+        ),
+        internalRecovery.ensureTwitterManualReplyRecoveryForUserInternal,
+        { userId: args.userId }
+      );
+      return {
+        monitoredCount: monitors.length,
+        monitoringStatus: "configuring" as const,
+      };
+    }
+
+    let monitoringStatus: TwitterManualReplyMonitoringStatus = "configuring";
+    try {
+      const ensured: {
+        ensured: boolean;
+        reason?: "missing_connection" | "missing_scopes";
+      } = await ctx.runAction(
+        internal.xActivity.ensurePostCreateActivitySubscriptionForUserInternal,
+        { userId: args.userId }
+      );
+      monitoringStatus = ensured.ensured
+        ? "ready"
+        : ensured.reason === "missing_connection" ||
+            ensured.reason === "missing_scopes"
+          ? "reconnect_required"
+          : "configuring";
+    } catch (error) {
+      console.warn("[OutreachRecovery] X/Twitter monitoring retry failed", {
+        userId: String(args.userId),
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
+    await ctx.runMutation(
+      internalRecovery.syncTwitterManualReplyRecoveryStatusForUserInternal,
+      {
+        userId: args.userId,
+        monitorIds: monitors.map((monitor) => monitor._id),
+        monitoringStatus,
+      }
+    );
+
+    if (monitoringStatus === "configuring") {
+      const latestAccount = await ctx.runQuery(
+        internal.xStore.getXAccountForUserInternal,
+        { userId: args.userId }
+      );
+      const retryAt =
+        typeof latestAccount?.activitySubscriptionsNextRetryAt === "number"
+          ? latestAccount.activitySubscriptionsNextRetryAt
+          : now + TWITTER_ACTIVITY_RETRY_DELAY_MS;
+      await ctx.scheduler.runAfter(
+        Math.max(0, retryAt - getCurrentUTCTimestamp()),
+        internalRecovery.ensureTwitterManualReplyRecoveryForUserInternal,
+        { userId: args.userId }
+      );
+    }
+
+    return {
+      monitoredCount: monitors.length,
+      monitoringStatus,
+    };
+  },
+});
+
+async function clearTwitterManualReplyMonitorDeadline(
   ctx: MutationCtx,
   monitor: RecoveryMonitor
 ) {
-  if (monitor.status !== "active" || monitor.stage !== "detecting_outbound") {
+  if (
+    monitor.status !== "active" ||
+    monitor.kind !== "twitter_manual_reply" ||
+    monitor.stage !== "detecting_outbound"
+  ) {
     return;
   }
 
+  const [task, plan] = await Promise.all([
+    monitor.taskId
+      ? ctx.db.get("outreachTasks", monitor.taskId)
+      : Promise.resolve(null),
+    monitor.planId
+      ? ctx.db.get("outreachPlans", monitor.planId)
+      : Promise.resolve(null),
+  ]);
   const now = getCurrentUTCTimestamp();
+  if (
+    !task ||
+    !plan ||
+    task.status !== "waiting_manual" ||
+    plan.status === "completed" ||
+    plan.status === "abandoned"
+  ) {
+    await expireInactiveTwitterManualReplyMonitor(ctx, monitor);
+    return;
+  }
+
   await ctx.db.patch("outreachRecoveryMonitors", monitor._id, {
-    status: "expired",
+    expiresAt: undefined,
     lastCheckedAt: now,
     nextCheckAt: undefined,
-    completedAt: now,
-  });
-
-  if (!monitor.taskId) return;
-
-  const prospect = await ctx.db.get("prospects", monitor.prospectId);
-  const display = getProspectDisplayFields(prospect);
-  await upsertNotificationByKey(ctx, {
-    userId: monitor.userId,
-    workspaceId: monitor.workspaceId,
-    type: "error",
-    notificationKey: `manual-x-reply-expired:${monitor.taskId}`,
-    title: "Manual X reply was not detected",
-    message:
-      "ReacherX could not verify a new direct reply on the selected X post. The outreach plan remains paused so it will not send a duplicate.",
-    prospectId: monitor.prospectId,
-    planId: monitor.planId,
-    taskId: monitor.taskId,
-    contextPlatform: "twitter",
-    ...display,
+    lastErrorMessage: undefined,
   });
 }
 
@@ -586,64 +1118,8 @@ export const expireTwitterManualReplyDetection = internalMutation({
     ) {
       return null;
     }
-    if (getCurrentUTCTimestamp() < monitor.expiresAt) {
-      return null;
-    }
-    await expireTwitterManualReplyMonitor(ctx, monitor);
+    await clearTwitterManualReplyMonitorDeadline(ctx, monitor);
     return null;
-  },
-});
-
-/**
- * Stops SocialAPI-polling-era Twitter manual reply recoveries and any still
- * waiting for Activity detection. Used when pausing a workspace and as a
- * one-shot prod cleanup after deploy.
- */
-export const cancelTwitterManualReplyRecoveriesInternal = internalMutation({
-  args: {
-    workspaceId: v.optional(v.id("workspaces")),
-    userId: v.optional(v.id("users")),
-  },
-  returns: v.object({ cancelledCount: v.number() }),
-  handler: async (ctx, args) => {
-    let monitors: Doc<"outreachRecoveryMonitors">[] = [];
-    if (args.workspaceId) {
-      monitors = await ctx.db
-        .query("outreachRecoveryMonitors")
-        .withIndex("by_workspace", (q) =>
-          q.eq("workspaceId", args.workspaceId!)
-        )
-        .collect();
-    } else if (args.userId) {
-      monitors = await ctx.db
-        .query("outreachRecoveryMonitors")
-        .withIndex("by_user_and_status", (q) =>
-          q.eq("userId", args.userId!).eq("status", "active")
-        )
-        .collect();
-    } else {
-      throw new Error("workspaceId or userId is required");
-    }
-
-    const now = getCurrentUTCTimestamp();
-    let cancelledCount = 0;
-    for (const monitor of monitors) {
-      if (
-        monitor.status !== "active" ||
-        monitor.kind !== "twitter_manual_reply"
-      ) {
-        continue;
-      }
-      await ctx.db.patch(monitor._id, {
-        status: "expired",
-        lastCheckedAt: now,
-        nextCheckAt: undefined,
-        completedAt: now,
-        lastErrorMessage: "Cancelled — switched to X Activity detection",
-      });
-      cancelledCount += 1;
-    }
-    return { cancelledCount };
   },
 });
 
@@ -661,7 +1137,14 @@ export const recordRecoveryCheck = internalMutation({
     if (!monitor || monitor.status !== "active") return null;
 
     const now = getCurrentUTCTimestamp();
-    if (now >= monitor.expiresAt) {
+    if (
+      monitor.kind === "twitter_manual_reply" &&
+      monitor.stage === "detecting_outbound"
+    ) {
+      await clearTwitterManualReplyMonitorDeadline(ctx, monitor);
+      return null;
+    }
+    if (monitor.expiresAt !== undefined && now >= monitor.expiresAt) {
       await ctx.db.patch("outreachRecoveryMonitors", monitor._id, {
         status: "expired",
         lastCheckedAt: now,
@@ -678,9 +1161,9 @@ export const recordRecoveryCheck = internalMutation({
           workspaceId: monitor.workspaceId,
           type: "error",
           notificationKey: `manual-x-reply-expired:${monitor.taskId}`,
-          title: "Manual X reply was not detected",
+          title: "Manual X/Twitter reply was not detected",
           message:
-            "ReacherX could not verify a new direct reply on the selected X post. The outreach plan remains paused so it will not send a duplicate.",
+            "ReacherX could not verify a new direct reply on the selected X/Twitter post. The outreach plan remains paused so it will not send a duplicate.",
           prospectId: monitor.prospectId,
           planId: monitor.planId,
           taskId: monitor.taskId,
@@ -786,7 +1269,18 @@ export const confirmTwitterManualReply = internalMutation({
     }
     const task = await ctx.db.get("outreachTasks", monitor.taskId);
     const plan = await ctx.db.get("outreachPlans", monitor.planId);
-    if (!task || !plan) return null;
+    if (!task || !plan) {
+      await expireInactiveTwitterManualReplyMonitor(ctx, monitor);
+      return null;
+    }
+    if (
+      task.status !== "waiting_manual" ||
+      plan.status === "completed" ||
+      plan.status === "abandoned"
+    ) {
+      await expireInactiveTwitterManualReplyMonitor(ctx, monitor);
+      return null;
+    }
 
     const now = getCurrentUTCTimestamp();
     await ctx.db.patch("outreachTasks", task._id, {
@@ -822,14 +1316,19 @@ export const confirmTwitterManualReply = internalMutation({
 
     const prospect = await ctx.db.get("prospects", monitor.prospectId);
     const display = getProspectDisplayFields(prospect);
+    await dismissNotificationsByKey(ctx, {
+      userId: monitor.userId,
+      workspaceId: monitor.workspaceId,
+      notificationKey: `manual-x-reply:${task._id}`,
+    });
     await upsertNotificationByKey(ctx, {
       userId: monitor.userId,
       workspaceId: monitor.workspaceId,
       type: "outreach_sent",
       notificationKey: `manual-x-reply-detected:${task._id}`,
-      title: "Manual X reply detected",
+      title: "Manual X/Twitter reply detected",
       message:
-        "Your reply was linked to this outreach plan. ReacherX is now monitoring the conversation for a response.",
+        "Your reply was linked to this outreach plan. ReacherX is now monitoring the conversation for a response on X/Twitter.",
       prospectId: monitor.prospectId,
       planId: plan._id,
       taskId: task._id,
@@ -844,7 +1343,8 @@ export const confirmTwitterManualReply = internalMutation({
       {
         prospectId: monitor.prospectId,
         workspaceId: monitor.workspaceId,
-        description: "Posted a reply manually on X after an API policy block.",
+        description:
+          "Posted a reply manually on X/Twitter after an API policy block.",
       }
     );
     await ctx.scheduler.runAfter(
@@ -931,7 +1431,7 @@ async function checkTwitterProspectResponse(
   if (!prospect) throw new Error("Prospect not found");
   const prospectIdentity = resolveProspectTwitterIdentity(prospect);
   if (!prospectIdentity.username) {
-    throw new Error("Prospect X handle is unavailable");
+    throw new Error("Prospect X/Twitter handle is unavailable");
   }
 
   const params = new URLSearchParams({
@@ -1073,8 +1573,8 @@ export const checkRecoveryMonitor = internalAction({
     )) as RecoveryMonitor | null;
     if (!monitor || monitor.status !== "active") return null;
 
-    // Twitter manual outbound detection is event-driven via X Activity
-    // `post.create`. Expiry is handled by expireTwitterManualReplyDetection.
+    // X/Twitter manual outbound detection is event-driven via X/Twitter Activity
+    // `post.create` and remains active while the task is waiting_manual.
     if (
       monitor.kind === "twitter_manual_reply" &&
       monitor.stage === "detecting_outbound"

--- a/convex/platformConversations.ts
+++ b/convex/platformConversations.ts
@@ -12,6 +12,7 @@ import {
   xDmEligibilityReasonCodeValidator,
   xDmPanelWarningCodeValidator,
 } from "./validators";
+import { getCurrentUTCTimestamp } from "../shared/lib/utils/time/timeUtils";
 
 function sortMessagesByTime<T extends { createdAtMs: number }>(
   messages: T[]
@@ -162,7 +163,7 @@ export const upsertConversationSnapshotInternal = internalMutation({
     ),
   },
   handler: async (ctx, args) => {
-    const now = Date.now();
+    const now = getCurrentUTCTimestamp();
     const existingConversation = await ctx.db
       .query("platformConversations")
       .withIndex("by_user_conversation", (q) =>
@@ -336,7 +337,7 @@ export const markConversationMessagesReadInternal = internalMutation({
       }
       await ctx.db.patch(message._id, {
         readAt: args.readAt,
-        updatedAt: Date.now(),
+        updatedAt: getCurrentUTCTimestamp(),
       });
     }
 
@@ -350,7 +351,7 @@ export const markConversationMessagesReadInternal = internalMutation({
     if (conversation) {
       await ctx.db.patch(conversation._id, {
         lastReadAt: args.readAt,
-        updatedAt: Date.now(),
+        updatedAt: getCurrentUTCTimestamp(),
       });
     }
 
@@ -368,7 +369,7 @@ export const upsertXActivitySubscriptionInternal = internalMutation({
     tag: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const now = Date.now();
+    const now = getCurrentUTCTimestamp();
     const existing = await ctx.db
       .query("xActivitySubscriptions")
       .withIndex("by_user_event", (q) =>
@@ -439,7 +440,7 @@ export const upsertXWebhookInternal = internalMutation({
     lastError: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const now = Date.now();
+    const now = getCurrentUTCTimestamp();
     const existing = await ctx.db
       .query("xWebhooks")
       .withIndex("by_webhook_id", (q) => q.eq("webhookId", args.webhookId))
@@ -481,5 +482,12 @@ export const getXWebhookByUrlInternal = internalQuery({
       .query("xWebhooks")
       .withIndex("by_url", (q) => q.eq("url", args.url))
       .first();
+  },
+});
+
+export const listXWebhooksInternal = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    return await ctx.db.query("xWebhooks").take(25);
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2561,6 +2561,7 @@ export default defineSchema({
     .index("by_task_and_kind", ["taskId", "kind"])
     .index("by_plan", ["planId"])
     .index("by_prospect_and_status", ["prospectId", "status"])
+    .index("by_user_and_status", ["userId", "status"])
     .index("by_status_and_next_check", ["status", "nextCheckAt"]),
 
   /**

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2549,7 +2549,9 @@ export default defineSchema({
     expectedText: v.optional(v.string()),
     baselineArtifactIdsJson: v.optional(v.string()),
     startedAt: v.number(),
-    expiresAt: v.number(),
+    // Twitter manual-reply monitors stay active while their task is waiting
+    // for the user's reply. Other recovery kinds still use this as a deadline.
+    expiresAt: v.optional(v.number()),
     attemptCount: v.number(),
     lastCheckedAt: v.optional(v.number()),
     nextCheckAt: v.optional(v.number()),
@@ -2562,6 +2564,13 @@ export default defineSchema({
     .index("by_plan", ["planId"])
     .index("by_prospect_and_status", ["prospectId", "status"])
     .index("by_user_and_status", ["userId", "status"])
+    .index("by_kind_and_status", ["kind", "status"])
+    .index("by_user_kind_status_source_post", [
+      "userId",
+      "kind",
+      "status",
+      "sourcePostId",
+    ])
     .index("by_status_and_next_check", ["status", "nextCheckAt"]),
 
   /**

--- a/convex/validators.ts
+++ b/convex/validators.ts
@@ -428,7 +428,8 @@ export const twitterInteractionDiscoverySourceValidator = v.union(
   v.literal("socialapi_incremental"),
   v.literal("socialapi_webhook"),
   v.literal("outreach_task"),
-  v.literal("action_request")
+  v.literal("action_request"),
+  v.literal("x_activity")
 );
 
 export const twitterInteractionStatusValidator = v.union(
@@ -580,7 +581,8 @@ export const xActivityEventTypeValidator = v.union(
   v.literal("dm.read"),
   v.literal("chat.sent"),
   v.literal("chat.received"),
-  v.literal("chat.conversation_join")
+  v.literal("chat.conversation_join"),
+  v.literal("post.create")
 );
 
 export const platformConversationEventTypeValidator = v.union(

--- a/convex/x.ts
+++ b/convex/x.ts
@@ -57,7 +57,7 @@ import {
 } from "../shared/lib/twitter/xPostTextLimit";
 import { resolveProspectTwitterIdentity } from "../shared/lib/twitter/prospectTwitterIdentity";
 
-const xLogger = logger.withScope("X");
+const xLogger = logger.withScope("X/Twitter");
 
 async function getAccessibleDefaultWorkspaceForUserAction(
   ctx: any,
@@ -136,13 +136,13 @@ async function syncXAccountHealthNotification(
     workspaceId: defaultWorkspace?._id,
     platform: "twitter",
     shouldNotify,
-    title: "Reconnect X account",
+    title: "Reconnect X/Twitter account",
     message:
       missingScopes.length > 0
-        ? "Reconnect X and approve the required permissions, including DM or write scopes."
+        ? "Reconnect X/Twitter and approve the required permissions so messaging can continue."
         : args.status.status === "expired"
-          ? "Your X session expired. Reconnect to continue sending outreach."
-          : "Reconnect your X account to restore full access.",
+          ? "Your X/Twitter session expired. Reconnect to continue sending outreach."
+          : "Reconnect your X/Twitter account to restore full access.",
   });
 }
 
@@ -263,7 +263,7 @@ function buildDmEligibility(args: {
     return {
       enabled: true,
       reasonCode: "eligible",
-      reasonLabel: "DM available on X.",
+      reasonLabel: "DM available on X/Twitter.",
       receivesYourDm: true,
       conversationId: args.conversationId,
     };
@@ -273,7 +273,7 @@ function buildDmEligibility(args: {
     return {
       enabled: false,
       reasonCode: "not_allowed",
-      reasonLabel: "This user doesn’t currently accept your DMs on X.",
+      reasonLabel: "This user doesn’t currently accept your DMs on X/Twitter.",
       receivesYourDm: false,
       conversationId: args.conversationId,
     };
@@ -393,10 +393,13 @@ function buildCachedDmWarning(args: {
     return {
       code: "rate_limited",
       message:
-        "Live refresh is temporarily limited on X. Showing last synced messages.",
+        "Live refresh is temporarily limited on X/Twitter. Showing last synced messages.",
       retryAfterMs:
         typeof conversation.nextSyncAllowedAt === "number"
-          ? Math.max(0, conversation.nextSyncAllowedAt - Date.now())
+          ? Math.max(
+              0,
+              conversation.nextSyncAllowedAt - getCurrentUTCTimestamp()
+            )
           : undefined,
     };
   }
@@ -408,7 +411,8 @@ function buildCachedDmWarning(args: {
     account?.activitySubscriptionStatus &&
     account.activitySubscriptionStatus !== "healthy" &&
     (typeof conversation?.lastSyncSuccessAt !== "number" ||
-      Date.now() - conversation.lastSyncSuccessAt > DM_PANEL_FRESH_MS)
+      getCurrentUTCTimestamp() - conversation.lastSyncSuccessAt >
+        DM_PANEL_FRESH_MS)
   ) {
     return {
       code: "activity_degraded",
@@ -416,7 +420,11 @@ function buildCachedDmWarning(args: {
         "Realtime DM activity is temporarily degraded. Messaging still works, but live updates may lag.",
       retryAfterMs:
         typeof account.activitySubscriptionsNextRetryAt === "number"
-          ? Math.max(0, account.activitySubscriptionsNextRetryAt - Date.now())
+          ? Math.max(
+              0,
+              account.activitySubscriptionsNextRetryAt -
+                getCurrentUTCTimestamp()
+            )
           : undefined,
     };
   }
@@ -499,14 +507,17 @@ function shouldPerformLiveDmSync(snapshot: any): boolean {
   }
   if (
     typeof conversation.nextSyncAllowedAt === "number" &&
-    conversation.nextSyncAllowedAt > Date.now()
+    conversation.nextSyncAllowedAt > getCurrentUTCTimestamp()
   ) {
     return false;
   }
   if (typeof conversation.lastSyncSuccessAt !== "number") {
     return true;
   }
-  return Date.now() - conversation.lastSyncSuccessAt > DM_PANEL_FRESH_MS;
+  return (
+    getCurrentUTCTimestamp() - conversation.lastSyncSuccessAt >
+    DM_PANEL_FRESH_MS
+  );
 }
 
 async function resolveLiveProspectDmEligibility(args: {
@@ -595,7 +606,7 @@ async function resolveLiveProspectDmEligibility(args: {
       participantVerified: profile.verified,
     };
   } catch (error) {
-    logger.warn("Unable to resolve live X DM eligibility", {
+    logger.warn("Unable to resolve live X/Twitter DM eligibility", {
       error: error instanceof Error ? error.message : String(error),
       userId: args.userId,
       prospectId: args.prospect._id,
@@ -627,7 +638,7 @@ async function syncProspectDmConversationForUser(
     baseContext: XDmPanelContext;
   }
 ): Promise<XDmPanelContext> {
-  const syncAttemptAt = Date.now();
+  const syncAttemptAt = getCurrentUTCTimestamp();
   const provider = await getXProviderContextForUser(ctx, getXStoreRefs(), {
     userId: args.userId,
     requiredScopes: ["tweet.read", "users.read", "dm.read"],
@@ -672,7 +683,7 @@ async function syncProspectDmConversationForUser(
       eligibility,
       messages,
       lastSyncAttemptAt: syncAttemptAt,
-      lastSyncSuccessAt: Date.now(),
+      lastSyncSuccessAt: getCurrentUTCTimestamp(),
       nextSyncAllowedAt: undefined,
       lastSyncErrorCode: undefined,
       lastSyncErrorMessage: undefined,
@@ -691,7 +702,7 @@ async function syncProspectDmConversationForUser(
         eligibility,
         messages,
         lastSyncAttemptAt: syncAttemptAt,
-        lastSyncSuccessAt: Date.now(),
+        lastSyncSuccessAt: getCurrentUTCTimestamp(),
         nextSyncAllowedAt: undefined,
         lastSyncErrorCode: undefined,
         lastSyncErrorMessage: undefined,
@@ -699,7 +710,8 @@ async function syncProspectDmConversationForUser(
     } else {
       const failure = getXExecutionFailure(error);
       if (failure.classification === "rate_limited") {
-        const nextSyncAllowedAt = Date.now() + DM_PANEL_RATE_LIMIT_RETRY_MS;
+        const nextSyncAllowedAt =
+          getCurrentUTCTimestamp() + DM_PANEL_RATE_LIMIT_RETRY_MS;
         await persistDmConversationSnapshot(ctx, {
           userId: args.userId,
           prospect: args.prospect,
@@ -728,7 +740,7 @@ async function syncProspectDmConversationForUser(
           warning: {
             code: "rate_limited",
             message:
-              "Live refresh is temporarily limited on X. Showing last synced messages.",
+              "Live refresh is temporarily limited on X/Twitter. Showing last synced messages.",
             retryAfterMs: DM_PANEL_RATE_LIMIT_RETRY_MS,
           },
         };
@@ -835,7 +847,7 @@ async function resolveProspectDmPanelContext(
       baseContext,
     });
   } catch (error) {
-    logger.warn("Unable to refresh X DM panel context", {
+    logger.warn("Unable to refresh X/Twitter DM panel context", {
       error: error instanceof Error ? error.message : String(error),
       userId,
       prospectId,
@@ -954,7 +966,10 @@ async function hydrateViewerStatesForPosts(
   } catch (error) {
     const failure = getXExecutionFailure(error);
     if (failure.classification !== "rate_limited") {
-      logger.warn("[X] Failed to hydrate commented viewer state.", error);
+      logger.warn(
+        "[X/Twitter] Failed to hydrate commented viewer state.",
+        error
+      );
     }
     return states;
   }
@@ -1058,6 +1073,11 @@ export const getTwitterConnectionStatus = action({
       userId,
       status: statusWithIssue,
     });
+    await ctx.scheduler.runAfter(
+      0,
+      internal.outreachRecovery.ensureTwitterManualReplyRecoveryForUserInternal,
+      { userId }
+    );
     return statusWithIssue;
   },
 });
@@ -1101,6 +1121,11 @@ export const completeTwitterConnection = action({
         { userId }
       );
     }
+    await ctx.scheduler.runAfter(
+      0,
+      internal.outreachRecovery.ensureTwitterManualReplyRecoveryForUserInternal,
+      { userId }
+    );
 
     const resultWithIssue = await attachXStyleSyncIssue(ctx, {
       userId,
@@ -1141,6 +1166,11 @@ export const disconnectTwitter = action({
       });
     }
     await disconnectXForUser(ctx, getXStoreRefs(), userId);
+    await ctx.scheduler.runAfter(
+      0,
+      internal.outreachRecovery.ensureTwitterManualReplyRecoveryForUserInternal,
+      { userId }
+    );
     return { success: true as const };
   },
 });
@@ -1446,7 +1476,7 @@ export const replyToPost = action({
       await createDirectXOutreachSentNotification(ctx, {
         userId,
         twitterUserId: args.parentAuthorId,
-        title: "Reply sent on X",
+        title: "Reply sent on X/Twitter",
         message: args.text.trim(),
         actionId: result.createdTweetId ?? args.tweetId,
       });
@@ -1484,9 +1514,9 @@ export const sendDm = action({
       await createDirectXOutreachSentNotification(ctx, {
         userId,
         twitterUserId: args.targetUserId,
-        title: "DM sent on X",
+        title: "DM sent on X/Twitter",
         message: args.text.trim(),
-        actionId: String(Date.now()),
+        actionId: String(getCurrentUTCTimestamp()),
       });
       return result;
     } catch (error) {
@@ -1548,7 +1578,7 @@ export const getProspectDmStateInternal = internalAction({
   },
 });
 
-/** Refresh and persist the real X DM conversation for an agent read. */
+/** Refresh and persist the real X/Twitter DM conversation for an agent read. */
 export const refreshProspectDmConversationInternal = internalAction({
   args: {
     userId: v.id("users"),
@@ -1761,7 +1791,7 @@ async function sendDmMessageForUser(
     );
   }
   if (mediaUrlsFiltered.length > 1) {
-    throw new Error("X DMs support exactly one media attachment.");
+    throw new Error("X/Twitter DMs support exactly one media attachment.");
   }
   if (trimmedText) {
     const limitError = getDmTextLimitError(trimmedText);
@@ -1835,7 +1865,7 @@ async function sendDmMessageForUser(
             actionKey,
             toolSlug: entry.toolSlug,
             toolVersion: entry.toolVersion,
-            completedAt: Date.now(),
+            completedAt: getCurrentUTCTimestamp(),
             targetUserId,
             postedTextPreview: trimmedText || undefined,
           },
@@ -1847,7 +1877,7 @@ async function sendDmMessageForUser(
         {
           actionRequestId: args.actionRequestId,
           type: "social_action_completed",
-          message: trimmedText || "X DM sent.",
+          message: trimmedText || "X/Twitter DM sent.",
         }
       );
     }
@@ -1903,7 +1933,7 @@ async function sendDmMessageForUser(
       {
         prospectId: args.prospectId,
         workspaceId: prospect.workspaceId,
-        description: "Sent a DM on X.",
+        description: "Sent a DM on X/Twitter.",
       }
     );
 
@@ -2017,7 +2047,7 @@ export const getHydratedTwitterProfile = action({
   args: {
     username: v.string(),
     mode: v.optional(userTimelineModeValidator),
-    /** When true, runs expensive X list-pagination for like/bookmark/follow state. Default false. */
+    /** When true, runs expensive X/Twitter list-pagination for like/bookmark/follow state. Default false. */
     includeViewerState: v.optional(v.boolean()),
   },
   handler: async (ctx, args): Promise<HydratedTwitterProfilePayload> => {
@@ -2045,7 +2075,7 @@ export const getHydratedTwitterProfile = action({
         mode,
         tweets,
         nextCursor: timeline.nextCursor,
-        fetchedAt: Date.now(),
+        fetchedAt: getCurrentUTCTimestamp(),
       },
     };
   },
@@ -2080,7 +2110,7 @@ export const getHydratedTwitterTimeline = action({
       mode: args.mode,
       tweets,
       nextCursor: timeline.nextCursor,
-      fetchedAt: Date.now(),
+      fetchedAt: getCurrentUTCTimestamp(),
     };
   },
 });
@@ -2097,7 +2127,7 @@ export const getHydratedTwitterPost = action({
     const includeViewerState = args.includeViewerState === true;
 
     if (!tweet) {
-      return { tweet: null, fetchedAt: Date.now() };
+      return { tweet: null, fetchedAt: getCurrentUTCTimestamp() };
     }
 
     const hydrated = includeViewerState
@@ -2106,7 +2136,7 @@ export const getHydratedTwitterPost = action({
 
     return {
       tweet: hydrated,
-      fetchedAt: Date.now(),
+      fetchedAt: getCurrentUTCTimestamp(),
     };
   },
 });
@@ -2158,7 +2188,7 @@ export const getTwitterConnectionIdentityInternal = internalAction({
 export const getHydratedTwitterPostsByIds = action({
   args: {
     tweetIds: v.array(v.string()),
-    /** When true, runs expensive X list-pagination for viewer state. Default false. */
+    /** When true, runs expensive X/Twitter list-pagination for viewer state. Default false. */
     includeViewerState: v.optional(v.boolean()),
   },
   handler: async (ctx, args): Promise<HydratedTwitterPostsPayload> => {
@@ -2171,7 +2201,7 @@ export const getHydratedTwitterPostsByIds = action({
       tweets: includeViewerState
         ? await attachViewerStateToTweets(ctx, userId, tweets)
         : tweets,
-      fetchedAt: Date.now(),
+      fetchedAt: getCurrentUTCTimestamp(),
     };
   },
 });

--- a/convex/xActivity.ts
+++ b/convex/xActivity.ts
@@ -1,7 +1,8 @@
 "use node";
 
 import { v } from "convex/values";
-import type { Id } from "./_generated/dataModel";
+import type { Doc, Id } from "./_generated/dataModel";
+import type { ActionCtx } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { internalAction } from "./lib/functionBuilders";
 import {
@@ -24,6 +25,7 @@ import { normalizeDmMessages } from "./lib/xDm";
 import { decryptXSecret } from "./lib/xdkCrypto";
 import { getXProviderContextForUser } from "./lib/xdkAuth";
 import { getDmEventsByConversationId } from "./lib/xdkTwitterProvider";
+import { getCurrentUTCTimestamp } from "../shared/lib/utils/time/timeUtils";
 
 const ACTIVITY_ENSURE_SUCCESS_TTL_MS = 6 * 60 * 60 * 1000;
 const ACTIVITY_ENSURE_RETRY_MS = 15 * 60 * 1000;
@@ -192,7 +194,7 @@ function normalizeWebhookEvents(
 }
 
 async function resolveUserIdForEvent(
-  ctx: any,
+  ctx: ActionCtx,
   args: {
     filteredUserId?: string;
     subscriptionId?: string;
@@ -224,7 +226,7 @@ async function resolveUserIdForEvent(
 }
 
 async function syncConversationSnapshot(
-  ctx: any,
+  ctx: ActionCtx,
   args: {
     userId: Id<"users">;
     conversationId: string;
@@ -279,7 +281,7 @@ async function syncConversationSnapshot(
       eligibilityEnabled: existingConversation?.eligibilityEnabled,
       eligibilityReasonCode: existingConversation?.eligibilityReasonCode,
       eligibilityReasonLabel: existingConversation?.eligibilityReasonLabel,
-      lastSyncedAt: Date.now(),
+      lastSyncedAt: getCurrentUTCTimestamp(),
       messages: messages.map((message) => ({
         messageId: message.id,
         direction: message.direction,
@@ -308,19 +310,19 @@ async function syncConversationSnapshot(
 }
 
 async function ensureWebhookAndSubscriptions(args: {
-  ctx: any;
+  ctx: ActionCtx;
   userId: Id<"users">;
   xUserId: string;
   eventTypes: readonly XActivityEventType[];
   userOAuthAccessToken?: string;
-}): Promise<{ webhookId: string }> {
+}): Promise<{ webhookId: string; authMode: "app" | "user" }> {
   const webhookUrl = getXWebhookCallbackUrl();
   const remoteWebhooks = await listXWebhooks();
   let webhook = remoteWebhooks.find(
     (candidate) => candidate.url === webhookUrl
   );
 
-  // Pay-per-use X apps allow a single webhook. Reuse the existing one when the
+  // Pay-per-use X/Twitter apps allow a single webhook. Reuse the existing one when the
   // exact URL is already registered, or when create would exceed the limit.
   if (!webhook && remoteWebhooks.length === 1) {
     webhook = remoteWebhooks[0];
@@ -342,14 +344,16 @@ async function ensureWebhookAndSubscriptions(args: {
   }
 
   if (!webhook) {
-    throw new Error("No X webhook is available for Activity subscriptions.");
+    throw new Error(
+      "No X/Twitter webhook is available for Activity subscriptions."
+    );
   }
 
   if (!webhook.valid) {
     webhook = await validateXWebhook(webhook.id);
   }
 
-  const now = Date.now();
+  const now = getCurrentUTCTimestamp();
   await args.ctx.runMutation(
     internal.platformConversations.upsertXWebhookInternal,
     {
@@ -362,6 +366,7 @@ async function ensureWebhookAndSubscriptions(args: {
   );
 
   let remoteSubscriptions = await listXActivitySubscriptions();
+  let authMode: "app" | "user" = "app";
   for (const eventType of args.eventTypes) {
     let subscription = findMatchingRemoteSubscription(remoteSubscriptions, {
       eventType,
@@ -379,6 +384,7 @@ async function ensureWebhookAndSubscriptions(args: {
           userOAuthAccessToken: args.userOAuthAccessToken,
         });
         subscription = created.subscription;
+        authMode = created.authMode;
         remoteSubscriptions = [...remoteSubscriptions, subscription];
       } catch (error) {
         if (!isDuplicateSubscriptionError(error)) {
@@ -411,7 +417,7 @@ async function ensureWebhookAndSubscriptions(args: {
     );
   }
 
-  return { webhookId: webhook.id };
+  return { webhookId: webhook.id, authMode };
 }
 
 export const ensureDmActivitySubscriptionsForUserInternal = internalAction({
@@ -426,7 +432,7 @@ export const ensureDmActivitySubscriptionsForUserInternal = internalAction({
     webhookId?: string;
     reason?: "missing_connection" | "missing_scopes";
   }> => {
-    const now = Date.now();
+    const now = getCurrentUTCTimestamp();
     const account = await ctx.runQuery(
       internal.xStore.getXAccountForUserInternal,
       {
@@ -442,12 +448,14 @@ export const ensureDmActivitySubscriptionsForUserInternal = internalAction({
     if (requiredScopes.some((scope) => !granted.has(scope))) {
       return { ensured: false, reason: "missing_scopes" as const };
     }
-    const webhookUrl = getXWebhookCallbackUrl();
-    const localWebhook: any = await ctx.runQuery(
-      internal.platformConversations.getXWebhookByUrlInternal,
-      {
-        url: webhookUrl,
-      }
+    const localWebhooks = await ctx.runQuery(
+      internal.platformConversations.listXWebhooksInternal,
+      {}
+    );
+    const validLocalWebhookIds = new Set(
+      localWebhooks
+        .filter((webhook: { valid: boolean }) => webhook.valid)
+        .map((webhook: { webhookId: string }) => webhook.webhookId)
     );
     const localSubscriptions = await ctx.runQuery(
       internal.platformConversations.listXActivitySubscriptionsForUserInternal,
@@ -461,10 +469,17 @@ export const ensureDmActivitySubscriptionsForUserInternal = internalAction({
           (subscription: any) =>
             subscription.eventType === eventType &&
             subscription.xUserId === account.xUserId &&
-            subscription.webhookId === localWebhook?.webhookId
+            typeof subscription.webhookId === "string" &&
+            validLocalWebhookIds.has(subscription.webhookId)
         )
     );
-    if (localWebhook?.valid && hasAllLocalSubscriptions) {
+    const localWebhookId = localSubscriptions.find(
+      (subscription: any) =>
+        subscription.xUserId === account.xUserId &&
+        typeof subscription.webhookId === "string" &&
+        validLocalWebhookIds.has(subscription.webhookId)
+    )?.webhookId;
+    if (localWebhookId && hasAllLocalSubscriptions) {
       await ctx.runMutation(internal.xStore.patchXAccountInternal, {
         userId: args.userId,
         patch: {
@@ -475,7 +490,7 @@ export const ensureDmActivitySubscriptionsForUserInternal = internalAction({
           activitySubscriptionsLastError: undefined,
         },
       });
-      return { ensured: true, webhookId: localWebhook.webhookId };
+      return { ensured: true, webhookId: localWebhookId };
     }
 
     const isPendingRetryWindow =
@@ -513,7 +528,7 @@ export const ensureDmActivitySubscriptionsForUserInternal = internalAction({
         accountForActivity.accessToken
       );
 
-      const { webhookId } = await ensureWebhookAndSubscriptions({
+      const { webhookId, authMode } = await ensureWebhookAndSubscriptions({
         ctx,
         userId: args.userId,
         xUserId: accountForActivity.xUserId,
@@ -530,7 +545,7 @@ export const ensureDmActivitySubscriptionsForUserInternal = internalAction({
           activitySubscriptionsNextRetryAt:
             now + ACTIVITY_ENSURE_SUCCESS_TTL_MS,
           activitySubscriptionsLastError: undefined,
-          activitySubscriptionsLastAuthMode: "user",
+          activitySubscriptionsLastAuthMode: authMode,
         },
       });
 
@@ -559,7 +574,7 @@ export const ensureDmActivitySubscriptionsForUserInternal = internalAction({
 });
 
 /**
- * Ensures a public `post.create` Activity subscription for the connected X
+ * Ensures a public `post.create` Activity subscription for the connected X/Twitter
  * account. Used to detect manual replies after API policy blocks — without
  * SocialAPI polling.
  */
@@ -592,13 +607,19 @@ export const ensurePostCreateActivitySubscriptionForUserInternal =
         return { ensured: false, reason: "missing_scopes" as const };
       }
 
-      const webhookUrl = getXWebhookCallbackUrl();
-      const localWebhook: any = await ctx.runQuery(
-        internal.platformConversations.getXWebhookByUrlInternal,
-        { url: webhookUrl }
+      const now = getCurrentUTCTimestamp();
+      const localWebhooks = await ctx.runQuery(
+        internal.platformConversations.listXWebhooksInternal,
+        {}
+      );
+      const validLocalWebhookIds = new Set(
+        localWebhooks
+          .filter((webhook: { valid: boolean }) => webhook.valid)
+          .map((webhook: { webhookId: string }) => webhook.webhookId)
       );
       const localSubscriptions = await ctx.runQuery(
-        internal.platformConversations.listXActivitySubscriptionsForUserInternal,
+        internal.platformConversations
+          .listXActivitySubscriptionsForUserInternal,
         { userId: args.userId }
       );
       const hasLocalPostCreate = X_POST_ACTIVITY_EVENT_TYPES.every(
@@ -607,25 +628,96 @@ export const ensurePostCreateActivitySubscriptionForUserInternal =
             (subscription: any) =>
               subscription.eventType === eventType &&
               subscription.xUserId === account.xUserId &&
-              subscription.webhookId === localWebhook?.webhookId
+              typeof subscription.webhookId === "string" &&
+              validLocalWebhookIds.has(subscription.webhookId)
           )
       );
-      if (localWebhook?.valid && hasLocalPostCreate) {
-        return { ensured: true, webhookId: localWebhook.webhookId };
+      const localWebhookId = localSubscriptions.find(
+        (subscription: any) =>
+          subscription.xUserId === account.xUserId &&
+          typeof subscription.webhookId === "string" &&
+          validLocalWebhookIds.has(subscription.webhookId)
+      )?.webhookId;
+      if (localWebhookId && hasLocalPostCreate) {
+        await ctx.runMutation(internal.xStore.patchXAccountInternal, {
+          userId: args.userId,
+          patch: {
+            activitySubscriptionStatus: "healthy",
+            activitySubscriptionsEnsuredAt: now,
+            activitySubscriptionsLastAttemptAt: now,
+            activitySubscriptionsNextRetryAt:
+              now + ACTIVITY_ENSURE_SUCCESS_TTL_MS,
+            activitySubscriptionsLastError: undefined,
+          },
+        });
+        return { ensured: true, webhookId: localWebhookId };
       }
 
+      const isPendingRetryWindow =
+        account.activitySubscriptionStatus === "pending_retry" &&
+        typeof account.activitySubscriptionsNextRetryAt === "number" &&
+        account.activitySubscriptionsNextRetryAt > now;
+      if (isPendingRetryWindow) {
+        return { ensured: false };
+      }
+
+      await ctx.runMutation(internal.xStore.patchXAccountInternal, {
+        userId: args.userId,
+        patch: {
+          activitySubscriptionsLastAttemptAt: now,
+        },
+      });
+
       try {
-        const { webhookId } = await ensureWebhookAndSubscriptions({
+        const accountForActivity = await ctx.runQuery(
+          internal.xStore.getXAccountForUserInternal,
+          { userId: args.userId }
+        );
+        if (!accountForActivity || accountForActivity.status !== "connected") {
+          return { ensured: false, reason: "missing_connection" as const };
+        }
+        const userOAuthAccessToken = decryptXSecret(
+          accountForActivity.accessToken
+        );
+        const { webhookId, authMode } = await ensureWebhookAndSubscriptions({
           ctx,
           userId: args.userId,
-          xUserId: account.xUserId,
+          xUserId: accountForActivity.xUserId,
           eventTypes: X_POST_ACTIVITY_EVENT_TYPES,
+          userOAuthAccessToken,
+        });
+        await ctx.runMutation(internal.xStore.patchXAccountInternal, {
+          userId: args.userId,
+          patch: {
+            activitySubscriptionStatus: "healthy",
+            activitySubscriptionsEnsuredAt: now,
+            activitySubscriptionsLastAttemptAt: now,
+            activitySubscriptionsNextRetryAt:
+              now + ACTIVITY_ENSURE_SUCCESS_TTL_MS,
+            activitySubscriptionsLastError: undefined,
+            activitySubscriptionsLastAuthMode: authMode,
+          },
         });
         return { ensured: true, webhookId };
       } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        const normalized = message.toLowerCase();
+        const nextRetryAt =
+          normalized.includes("429") || normalized.includes("rate limit")
+            ? now + ACTIVITY_ENSURE_RATE_LIMIT_RETRY_MS
+            : now + ACTIVITY_ENSURE_RETRY_MS;
+        await ctx.runMutation(internal.xStore.patchXAccountInternal, {
+          userId: args.userId,
+          patch: {
+            activitySubscriptionStatus: "pending_retry",
+            activitySubscriptionsLastAttemptAt: now,
+            activitySubscriptionsNextRetryAt: nextRetryAt,
+            activitySubscriptionsLastError: message,
+          },
+        });
         console.warn("[XActivity] Failed to ensure post.create subscription", {
           userId: String(args.userId),
-          error: error instanceof Error ? error.message : String(error),
+          error: message,
         });
         return { ensured: false };
       }
@@ -667,6 +759,7 @@ export const handleWebhookPayloadInternal = internalAction({
             });
             continue;
           }
+          const repliedToPostId = post.repliedToPostId;
 
           const account = await ctx.runQuery(
             internal.xStore.getXAccountForUserInternal,
@@ -680,33 +773,45 @@ export const handleWebhookPayloadInternal = internalAction({
             });
             continue;
           }
+          if (
+            event.filteredUserId &&
+            event.filteredUserId !== account.xUserId
+          ) {
+            results.push({
+              ignored: true,
+              eventType: event.eventType,
+              reason: "filtered_user_mismatch",
+            });
+            continue;
+          }
+          const matchedPost =
+            post.authorId || !event.filteredUserId
+              ? post
+              : { ...post, authorId: event.filteredUserId };
 
-          const monitors = await ctx.runQuery(
+          const monitor = (await ctx.runQuery(
             internal.outreachRecovery
-              .listActiveTwitterManualReplyMonitorsForUserInternal,
-            { userId }
-          );
-          const monitor = monitors.find(
-            (candidate: {
-              stage: string;
-              sourcePostId: string;
-              startedAt: number;
-            }) =>
-              candidate.stage === "detecting_outbound" &&
-              matchesTwitterManualReplyRecovery({
-                post,
-                sourcePostId: candidate.sourcePostId,
-                connectedXUserId: account.xUserId,
-                startedAt: candidate.startedAt,
-              })
-          );
+              .getActiveTwitterManualReplyMonitorForSourcePostInternal,
+            {
+              userId,
+              sourcePostId: repliedToPostId,
+            }
+          )) as Doc<"outreachRecoveryMonitors"> | null;
 
-          if (!monitor) {
+          if (
+            !monitor ||
+            !matchesTwitterManualReplyRecovery({
+              post: matchedPost,
+              sourcePostId: monitor.sourcePostId,
+              connectedXUserId: account.xUserId,
+              startedAt: monitor.startedAt,
+            })
+          ) {
             results.push({
               ignored: true,
               eventType: event.eventType,
               reason: "no_matching_recovery",
-              repliedToPostId: post.repliedToPostId,
+              repliedToPostId: matchedPost.repliedToPostId,
             });
             continue;
           }
@@ -715,9 +820,9 @@ export const handleWebhookPayloadInternal = internalAction({
             internal.outreachRecovery.confirmTwitterManualReply,
             {
               monitorId: monitor._id,
-              replyPostId: post.postId,
-              replyText: post.text,
-              repliedAt: post.createdAtMs ?? Date.now(),
+              replyPostId: matchedPost.postId,
+              replyText: matchedPost.text,
+              repliedAt: matchedPost.createdAtMs ?? getCurrentUTCTimestamp(),
             }
           );
 
@@ -732,18 +837,19 @@ export const handleWebhookPayloadInternal = internalAction({
               },
               replyPostRef: {
                 platform: "twitter",
-                postId: post.postId,
-                conversationId: post.conversationId ?? monitor.sourcePostId,
-                url: `https://x.com/i/web/status/${post.postId}`,
+                postId: matchedPost.postId,
+                conversationId:
+                  matchedPost.conversationId ?? monitor.sourcePostId,
+                url: `https://x.com/i/web/status/${matchedPost.postId}`,
               },
               threadId: monitor.sourcePostId,
-              repliedAt: post.createdAtMs ?? Date.now(),
+              repliedAt: matchedPost.createdAtMs ?? getCurrentUTCTimestamp(),
               origin: "external_x",
               discoveredVia: "x_activity",
               status: "active",
               direction: "outgoing",
-              discoveredAt: post.createdAtMs ?? Date.now(),
-              lastSeenAt: Date.now(),
+              discoveredAt: matchedPost.createdAtMs ?? getCurrentUTCTimestamp(),
+              lastSeenAt: getCurrentUTCTimestamp(),
             });
           }
 
@@ -751,7 +857,7 @@ export const handleWebhookPayloadInternal = internalAction({
             ignored: false,
             eventType: event.eventType,
             monitorId: String(monitor._id),
-            replyPostId: post.postId,
+            replyPostId: matchedPost.postId,
             confirmed: Boolean(confirmedTaskId),
           });
           continue;
@@ -772,7 +878,7 @@ export const handleWebhookPayloadInternal = internalAction({
             {
               userId,
               conversationId: event.conversationId,
-              readAt: Date.now(),
+              readAt: getCurrentUTCTimestamp(),
             }
           );
           results.push({

--- a/convex/xActivity.ts
+++ b/convex/xActivity.ts
@@ -6,14 +6,20 @@ import { internal } from "./_generated/api";
 import { internalAction } from "./lib/functionBuilders";
 import {
   X_DM_ACTIVITY_EVENT_TYPES,
+  X_POST_ACTIVITY_EVENT_TYPES,
   createXActivitySubscription,
   createXWebhook,
   getXWebhookCallbackUrl,
   listXActivitySubscriptions,
   listXWebhooks,
+  type XActivityEventType,
   type XDmActivityEventType,
   validateXWebhook,
 } from "./lib/xActivity";
+import {
+  extractActivityCreatedPost,
+  matchesTwitterManualReplyRecovery,
+} from "./lib/outreachRecoveryCore";
 import { normalizeDmMessages } from "./lib/xDm";
 import { decryptXSecret } from "./lib/xdkCrypto";
 import { getXProviderContextForUser } from "./lib/xdkAuth";
@@ -34,14 +40,14 @@ function isDuplicateSubscriptionError(error: unknown): boolean {
 
 function findMatchingRemoteSubscription(
   subscriptions: Array<{
-    eventType: XDmActivityEventType;
+    eventType: XActivityEventType;
     filterUserId?: string;
     webhookId?: string;
     subscriptionId: string;
     tag?: string;
   }>,
   args: {
-    eventType: XDmActivityEventType;
+    eventType: XActivityEventType;
     xUserId: string;
     webhookId: string;
   }
@@ -108,14 +114,27 @@ function extractMessageText(
   return asString(payload.text) ?? asString(message?.text);
 }
 
-function normalizeWebhookEvents(payload: unknown): Array<{
+type NormalizedDmActivityEvent = {
+  kind: "dm";
   eventType: XDmActivityEventType;
   filteredUserId?: string;
   subscriptionId?: string;
   conversationId?: string;
   messageId?: string;
   text?: string;
-}> {
+};
+
+type NormalizedPostActivityEvent = {
+  kind: "post";
+  eventType: "post.create";
+  filteredUserId?: string;
+  subscriptionId?: string;
+  envelope: Record<string, unknown>;
+};
+
+function normalizeWebhookEvents(
+  payload: unknown
+): Array<NormalizedDmActivityEvent | NormalizedPostActivityEvent> {
   const root = asRecord(payload);
   const entries = Array.isArray(root?.data)
     ? root?.data
@@ -123,14 +142,9 @@ function normalizeWebhookEvents(payload: unknown): Array<{
       ? [root.data]
       : [payload];
 
-  const normalized: Array<{
-    eventType: XDmActivityEventType;
-    filteredUserId?: string;
-    subscriptionId?: string;
-    conversationId?: string;
-    messageId?: string;
-    text?: string;
-  }> = [];
+  const normalized: Array<
+    NormalizedDmActivityEvent | NormalizedPostActivityEvent
+  > = [];
 
   for (const entry of entries) {
     const envelope = asRecord(entry);
@@ -139,14 +153,31 @@ function normalizeWebhookEvents(payload: unknown): Array<{
     }
     const eventType =
       asString(envelope.event_type) ?? asString(envelope.eventType);
+    if (!eventType) {
+      continue;
+    }
+
+    if (eventType === "post.create") {
+      normalized.push({
+        kind: "post",
+        eventType: "post.create",
+        filteredUserId: extractFilteredUserId(envelope),
+        subscriptionId:
+          asString(envelope.subscription_id) ??
+          asString(envelope.subscriptionId),
+        envelope,
+      });
+      continue;
+    }
+
     if (
-      !eventType ||
       !X_DM_ACTIVITY_EVENT_TYPES.includes(eventType as XDmActivityEventType)
     ) {
       continue;
     }
     const normalizedPayload = asRecord(envelope.payload) ?? envelope;
     normalized.push({
+      kind: "dm",
       eventType: eventType as XDmActivityEventType,
       filteredUserId: extractFilteredUserId(envelope),
       subscriptionId:
@@ -276,6 +307,113 @@ async function syncConversationSnapshot(
   };
 }
 
+async function ensureWebhookAndSubscriptions(args: {
+  ctx: any;
+  userId: Id<"users">;
+  xUserId: string;
+  eventTypes: readonly XActivityEventType[];
+  userOAuthAccessToken?: string;
+}): Promise<{ webhookId: string }> {
+  const webhookUrl = getXWebhookCallbackUrl();
+  const remoteWebhooks = await listXWebhooks();
+  let webhook = remoteWebhooks.find(
+    (candidate) => candidate.url === webhookUrl
+  );
+
+  // Pay-per-use X apps allow a single webhook. Reuse the existing one when the
+  // exact URL is already registered, or when create would exceed the limit.
+  if (!webhook && remoteWebhooks.length === 1) {
+    webhook = remoteWebhooks[0];
+  }
+
+  if (!webhook) {
+    try {
+      webhook = await createXWebhook(webhookUrl);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (
+        !message.toLowerCase().includes("webhooklimitexceeded") ||
+        remoteWebhooks.length === 0
+      ) {
+        throw error;
+      }
+      webhook = remoteWebhooks[0];
+    }
+  }
+
+  if (!webhook) {
+    throw new Error("No X webhook is available for Activity subscriptions.");
+  }
+
+  if (!webhook.valid) {
+    webhook = await validateXWebhook(webhook.id);
+  }
+
+  const now = Date.now();
+  await args.ctx.runMutation(
+    internal.platformConversations.upsertXWebhookInternal,
+    {
+      webhookId: webhook.id,
+      url: webhook.url,
+      valid: webhook.valid,
+      lastValidatedAt: now,
+      lastError: undefined,
+    }
+  );
+
+  let remoteSubscriptions = await listXActivitySubscriptions();
+  for (const eventType of args.eventTypes) {
+    let subscription = findMatchingRemoteSubscription(remoteSubscriptions, {
+      eventType,
+      xUserId: args.xUserId,
+      webhookId: webhook.id,
+    });
+
+    if (!subscription) {
+      try {
+        const created = await createXActivitySubscription({
+          eventType,
+          xUserId: args.xUserId,
+          webhookId: webhook.id,
+          tag: `reacherx:${args.userId}:${eventType}`,
+          userOAuthAccessToken: args.userOAuthAccessToken,
+        });
+        subscription = created.subscription;
+        remoteSubscriptions = [...remoteSubscriptions, subscription];
+      } catch (error) {
+        if (!isDuplicateSubscriptionError(error)) {
+          throw error;
+        }
+
+        remoteSubscriptions = await listXActivitySubscriptions();
+        subscription = findMatchingRemoteSubscription(remoteSubscriptions, {
+          eventType,
+          xUserId: args.xUserId,
+          webhookId: webhook.id,
+        });
+
+        if (!subscription) {
+          throw error;
+        }
+      }
+    }
+
+    await args.ctx.runMutation(
+      internal.platformConversations.upsertXActivitySubscriptionInternal,
+      {
+        userId: args.userId,
+        xUserId: args.xUserId,
+        eventType,
+        subscriptionId: subscription.subscriptionId,
+        webhookId: subscription.webhookId,
+        tag: subscription.tag,
+      }
+    );
+  }
+
+  return { webhookId: webhook.id };
+}
+
 export const ensureDmActivitySubscriptionsForUserInternal = internalAction({
   args: {
     userId: v.id("users"),
@@ -360,27 +498,6 @@ export const ensureDmActivitySubscriptionsForUserInternal = internalAction({
     });
 
     try {
-      const remoteWebhooks = await listXWebhooks();
-      let webhook = remoteWebhooks.find(
-        (candidate) => candidate.url === webhookUrl
-      );
-      if (!webhook) {
-        webhook = await createXWebhook(webhookUrl);
-      } else if (!webhook.valid) {
-        webhook = await validateXWebhook(webhook.id);
-      }
-
-      await ctx.runMutation(
-        internal.platformConversations.upsertXWebhookInternal,
-        {
-          webhookId: webhook.id,
-          url: webhook.url,
-          valid: webhook.valid,
-          lastValidatedAt: now,
-          lastError: undefined,
-        }
-      );
-
       await getXProviderContextForUser(ctx, internal.xStore, {
         userId: args.userId,
         requiredScopes,
@@ -396,57 +513,13 @@ export const ensureDmActivitySubscriptionsForUserInternal = internalAction({
         accountForActivity.accessToken
       );
 
-      let remoteSubscriptions = await listXActivitySubscriptions();
-      let lastAuthMode = accountForActivity.activitySubscriptionsLastAuthMode;
-      for (const eventType of X_DM_ACTIVITY_EVENT_TYPES) {
-        let subscription = findMatchingRemoteSubscription(remoteSubscriptions, {
-          eventType,
-          xUserId: accountForActivity.xUserId,
-          webhookId: webhook.id,
-        });
-
-        if (!subscription) {
-          try {
-            const created = await createXActivitySubscription({
-              eventType,
-              xUserId: accountForActivity.xUserId,
-              webhookId: webhook.id,
-              tag: `reacherx:${args.userId}:${eventType}`,
-              userOAuthAccessToken,
-            });
-            subscription = created.subscription;
-            lastAuthMode = created.authMode;
-            remoteSubscriptions = [...remoteSubscriptions, subscription];
-          } catch (error) {
-            if (!isDuplicateSubscriptionError(error)) {
-              throw error;
-            }
-
-            remoteSubscriptions = await listXActivitySubscriptions();
-            subscription = findMatchingRemoteSubscription(remoteSubscriptions, {
-              eventType,
-              xUserId: accountForActivity.xUserId,
-              webhookId: webhook.id,
-            });
-
-            if (!subscription) {
-              throw error;
-            }
-          }
-        }
-
-        await ctx.runMutation(
-          internal.platformConversations.upsertXActivitySubscriptionInternal,
-          {
-            userId: args.userId,
-            xUserId: accountForActivity.xUserId,
-            eventType,
-            subscriptionId: subscription.subscriptionId,
-            webhookId: subscription.webhookId,
-            tag: subscription.tag,
-          }
-        );
-      }
+      const { webhookId } = await ensureWebhookAndSubscriptions({
+        ctx,
+        userId: args.userId,
+        xUserId: accountForActivity.xUserId,
+        eventTypes: X_DM_ACTIVITY_EVENT_TYPES,
+        userOAuthAccessToken,
+      });
 
       await ctx.runMutation(internal.xStore.patchXAccountInternal, {
         userId: args.userId,
@@ -457,11 +530,11 @@ export const ensureDmActivitySubscriptionsForUserInternal = internalAction({
           activitySubscriptionsNextRetryAt:
             now + ACTIVITY_ENSURE_SUCCESS_TTL_MS,
           activitySubscriptionsLastError: undefined,
-          activitySubscriptionsLastAuthMode: lastAuthMode,
+          activitySubscriptionsLastAuthMode: "user",
         },
       });
 
-      return { ensured: true, webhookId: webhook.id };
+      return { ensured: true, webhookId };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       const normalized = message.toLowerCase();
@@ -485,6 +558,80 @@ export const ensureDmActivitySubscriptionsForUserInternal = internalAction({
   },
 });
 
+/**
+ * Ensures a public `post.create` Activity subscription for the connected X
+ * account. Used to detect manual replies after API policy blocks — without
+ * SocialAPI polling.
+ */
+export const ensurePostCreateActivitySubscriptionForUserInternal =
+  internalAction({
+    args: {
+      userId: v.id("users"),
+    },
+    handler: async (
+      ctx,
+      args
+    ): Promise<{
+      ensured: boolean;
+      webhookId?: string;
+      reason?: "missing_connection" | "missing_scopes";
+    }> => {
+      const account = await ctx.runQuery(
+        internal.xStore.getXAccountForUserInternal,
+        {
+          userId: args.userId,
+        }
+      );
+      if (!account || account.status !== "connected") {
+        return { ensured: false, reason: "missing_connection" as const };
+      }
+
+      const requiredScopes = ["tweet.read", "users.read"];
+      const granted = new Set(account.grantedScopes ?? []);
+      if (requiredScopes.some((scope) => !granted.has(scope))) {
+        return { ensured: false, reason: "missing_scopes" as const };
+      }
+
+      const webhookUrl = getXWebhookCallbackUrl();
+      const localWebhook: any = await ctx.runQuery(
+        internal.platformConversations.getXWebhookByUrlInternal,
+        { url: webhookUrl }
+      );
+      const localSubscriptions = await ctx.runQuery(
+        internal.platformConversations.listXActivitySubscriptionsForUserInternal,
+        { userId: args.userId }
+      );
+      const hasLocalPostCreate = X_POST_ACTIVITY_EVENT_TYPES.every(
+        (eventType) =>
+          localSubscriptions.some(
+            (subscription: any) =>
+              subscription.eventType === eventType &&
+              subscription.xUserId === account.xUserId &&
+              subscription.webhookId === localWebhook?.webhookId
+          )
+      );
+      if (localWebhook?.valid && hasLocalPostCreate) {
+        return { ensured: true, webhookId: localWebhook.webhookId };
+      }
+
+      try {
+        const { webhookId } = await ensureWebhookAndSubscriptions({
+          ctx,
+          userId: args.userId,
+          xUserId: account.xUserId,
+          eventTypes: X_POST_ACTIVITY_EVENT_TYPES,
+        });
+        return { ensured: true, webhookId };
+      } catch (error) {
+        console.warn("[XActivity] Failed to ensure post.create subscription", {
+          userId: String(args.userId),
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return { ensured: false };
+      }
+    },
+  });
+
 export const handleWebhookPayloadInternal = internalAction({
   args: {
     payload: v.any(),
@@ -501,6 +648,115 @@ export const handleWebhookPayloadInternal = internalAction({
 
     for (const event of events) {
       try {
+        if (event.kind === "post") {
+          const userId = await resolveUserIdForEvent(ctx, {
+            filteredUserId: event.filteredUserId,
+            subscriptionId: event.subscriptionId,
+          });
+          if (!userId) {
+            results.push({ ignored: true, eventType: event.eventType });
+            continue;
+          }
+
+          const post = extractActivityCreatedPost(event.envelope);
+          if (!post?.repliedToPostId) {
+            results.push({
+              ignored: true,
+              eventType: event.eventType,
+              reason: "not_a_reply",
+            });
+            continue;
+          }
+
+          const account = await ctx.runQuery(
+            internal.xStore.getXAccountForUserInternal,
+            { userId }
+          );
+          if (!account?.xUserId) {
+            results.push({
+              ignored: true,
+              eventType: event.eventType,
+              reason: "missing_x_account",
+            });
+            continue;
+          }
+
+          const monitors = await ctx.runQuery(
+            internal.outreachRecovery
+              .listActiveTwitterManualReplyMonitorsForUserInternal,
+            { userId }
+          );
+          const monitor = monitors.find(
+            (candidate: {
+              stage: string;
+              sourcePostId: string;
+              startedAt: number;
+            }) =>
+              candidate.stage === "detecting_outbound" &&
+              matchesTwitterManualReplyRecovery({
+                post,
+                sourcePostId: candidate.sourcePostId,
+                connectedXUserId: account.xUserId,
+                startedAt: candidate.startedAt,
+              })
+          );
+
+          if (!monitor) {
+            results.push({
+              ignored: true,
+              eventType: event.eventType,
+              reason: "no_matching_recovery",
+              repliedToPostId: post.repliedToPostId,
+            });
+            continue;
+          }
+
+          const confirmedTaskId = await ctx.runMutation(
+            internal.outreachRecovery.confirmTwitterManualReply,
+            {
+              monitorId: monitor._id,
+              replyPostId: post.postId,
+              replyText: post.text,
+              repliedAt: post.createdAtMs ?? Date.now(),
+            }
+          );
+
+          if (confirmedTaskId) {
+            await ctx.runMutation(internal.outreach.upsertTwitterInteraction, {
+              userId,
+              prospectId: monitor.prospectId,
+              sourcePostRef: {
+                platform: "twitter",
+                postId: monitor.sourcePostId,
+                conversationId: monitor.sourcePostId,
+              },
+              replyPostRef: {
+                platform: "twitter",
+                postId: post.postId,
+                conversationId: post.conversationId ?? monitor.sourcePostId,
+                url: `https://x.com/i/web/status/${post.postId}`,
+              },
+              threadId: monitor.sourcePostId,
+              repliedAt: post.createdAtMs ?? Date.now(),
+              origin: "external_x",
+              discoveredVia: "x_activity",
+              status: "active",
+              direction: "outgoing",
+              discoveredAt: post.createdAtMs ?? Date.now(),
+              lastSeenAt: Date.now(),
+            });
+          }
+
+          results.push({
+            ignored: false,
+            eventType: event.eventType,
+            monitorId: String(monitor._id),
+            replyPostId: post.postId,
+            confirmed: Boolean(confirmedTaskId),
+          });
+          continue;
+        }
+
         const userId = await resolveUserIdForEvent(ctx, {
           filteredUserId: event.filteredUserId,
           subscriptionId: event.subscriptionId,

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -38,7 +38,7 @@ const nextConfig = {
     formats: ["image/webp", "image/avif"],
     remotePatterns: [
       {
-        // Twitter/X profile images and tweet media
+        // X/Twitter profile images and tweet media
         protocol: "https",
         hostname: "pbs.twimg.com",
       },

--- a/shared/lib/twitter/contracts.ts
+++ b/shared/lib/twitter/contracts.ts
@@ -77,7 +77,8 @@ export type TwitterInteractionDiscoverySource =
   | "socialapi_incremental"
   | "socialapi_webhook"
   | "outreach_task"
-  | "action_request";
+  | "action_request"
+  | "x_activity";
 
 export type TwitterInteractionStatus =
   | "active"

--- a/tests/outreach-recovery-core.test.ts
+++ b/tests/outreach-recovery-core.test.ts
@@ -1,11 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  extractActivityCreatedPost,
   getNewRecoveryArtifactIds,
   getRecoveryNextCheckDelayMs,
+  matchesTwitterManualReplyRecovery,
   parseRecoveryArtifactIds,
   serializeRecoveryArtifactIds,
-  TWITTER_MANUAL_REPLY_POLL_INTERVAL_MS,
 } from "../convex/lib/outreachRecoveryCore";
 
 test("manual X reconciliation only considers reply ids created after handoff", () => {
@@ -26,21 +27,9 @@ test("recovery artifact snapshots are bounded and tolerate invalid data", () => 
   assert.deepEqual([...parseRecoveryArtifactIds("not-json")], []);
 });
 
-test("manual detection starts quickly while response monitoring backs off", () => {
+test("LinkedIn outbound detection starts quickly while response monitoring backs off", () => {
   assert.equal(getRecoveryNextCheckDelayMs("detecting_outbound", 1), 15_000);
   assert.equal(getRecoveryNextCheckDelayMs("detecting_outbound", 20), 900_000);
-  assert.equal(
-    getRecoveryNextCheckDelayMs("detecting_outbound", 1, "twitter_manual_reply"),
-    TWITTER_MANUAL_REPLY_POLL_INTERVAL_MS
-  );
-  assert.equal(
-    getRecoveryNextCheckDelayMs(
-      "detecting_outbound",
-      20,
-      "twitter_manual_reply"
-    ),
-    TWITTER_MANUAL_REPLY_POLL_INTERVAL_MS
-  );
   assert.equal(getRecoveryNextCheckDelayMs("awaiting_response", 1), 300_000);
   assert.equal(getRecoveryNextCheckDelayMs("awaiting_response", 12), 1_800_000);
 });
@@ -53,5 +42,65 @@ test("LinkedIn connection recovery uses sparse webhook-safe fallback checks", ()
   assert.equal(
     getRecoveryNextCheckDelayMs("awaiting_connection", 12),
     259_200_000
+  );
+});
+
+test("Activity post.create envelopes extract replied_to targets", () => {
+  const post = extractActivityCreatedPost({
+    event_type: "post.create",
+    filter: { user_id: "1743216568451125248" },
+    payload: {
+      id: "2081000000000000001",
+      author_id: "1743216568451125248",
+      text: "Thanks for sharing this",
+      created_at: "2026-08-06T12:00:00.000Z",
+      conversation_id: "2080000000000000000",
+      referenced_tweets: [{ type: "replied_to", id: "2080000000000000000" }],
+    },
+  });
+
+  assert.ok(post);
+  assert.equal(post.postId, "2081000000000000001");
+  assert.equal(post.repliedToPostId, "2080000000000000000");
+  assert.equal(post.authorId, "1743216568451125248");
+  assert.equal(post.createdAtMs, Date.parse("2026-08-06T12:00:00.000Z"));
+});
+
+test("Activity reply matching requires connected author and target tweet", () => {
+  const post = {
+    postId: "2081000000000000001",
+    authorId: "1743216568451125248",
+    repliedToPostId: "2080000000000000000",
+    createdAtMs: Date.parse("2026-08-06T12:00:00.000Z"),
+  };
+
+  assert.equal(
+    matchesTwitterManualReplyRecovery({
+      post,
+      sourcePostId: "2080000000000000000",
+      connectedXUserId: "1743216568451125248",
+      startedAt: Date.parse("2026-08-06T11:59:00.000Z"),
+    }),
+    true
+  );
+
+  assert.equal(
+    matchesTwitterManualReplyRecovery({
+      post,
+      sourcePostId: "2080000000000000000",
+      connectedXUserId: "999",
+      startedAt: Date.parse("2026-08-06T11:59:00.000Z"),
+    }),
+    false
+  );
+
+  assert.equal(
+    matchesTwitterManualReplyRecovery({
+      post: { ...post, repliedToPostId: undefined },
+      sourcePostId: "2080000000000000000",
+      connectedXUserId: "1743216568451125248",
+      startedAt: Date.parse("2026-08-06T11:59:00.000Z"),
+    }),
+    false
   );
 });

--- a/tests/outreach-recovery-core.test.ts
+++ b/tests/outreach-recovery-core.test.ts
@@ -2,30 +2,9 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   extractActivityCreatedPost,
-  getNewRecoveryArtifactIds,
   getRecoveryNextCheckDelayMs,
   matchesTwitterManualReplyRecovery,
-  parseRecoveryArtifactIds,
-  serializeRecoveryArtifactIds,
 } from "../convex/lib/outreachRecoveryCore";
-
-test("manual X reconciliation only considers reply ids created after handoff", () => {
-  const baseline = serializeRecoveryArtifactIds(["old-1", "old-2"]);
-
-  assert.deepEqual(
-    getNewRecoveryArtifactIds(["old-2", "new-1", "new-1", "new-2"], baseline),
-    ["new-1", "new-2"]
-  );
-});
-
-test("recovery artifact snapshots are bounded and tolerate invalid data", () => {
-  const ids = Array.from({ length: 150 }, (_, index) => `reply-${index}`);
-  assert.equal(
-    parseRecoveryArtifactIds(serializeRecoveryArtifactIds(ids)).size,
-    100
-  );
-  assert.deepEqual([...parseRecoveryArtifactIds("not-json")], []);
-});
 
 test("LinkedIn outbound detection starts quickly while response monitoring backs off", () => {
   assert.equal(getRecoveryNextCheckDelayMs("detecting_outbound", 1), 15_000);
@@ -45,7 +24,7 @@ test("LinkedIn connection recovery uses sparse webhook-safe fallback checks", ()
   );
 });
 
-test("Activity post.create envelopes extract replied_to targets", () => {
+test("X/Twitter Activity post.create envelopes extract replied_to targets", () => {
   const post = extractActivityCreatedPost({
     event_type: "post.create",
     filter: { user_id: "1743216568451125248" },
@@ -66,7 +45,7 @@ test("Activity post.create envelopes extract replied_to targets", () => {
   assert.equal(post.createdAtMs, Date.parse("2026-08-06T12:00:00.000Z"));
 });
 
-test("Activity reply matching requires connected author and target tweet", () => {
+test("X/Twitter Activity reply matching requires connected author and target tweet", () => {
   const post = {
     postId: "2081000000000000001",
     authorId: "1743216568451125248",
@@ -97,6 +76,16 @@ test("Activity reply matching requires connected author and target tweet", () =>
   assert.equal(
     matchesTwitterManualReplyRecovery({
       post: { ...post, repliedToPostId: undefined },
+      sourcePostId: "2080000000000000000",
+      connectedXUserId: "1743216568451125248",
+      startedAt: Date.parse("2026-08-06T11:59:00.000Z"),
+    }),
+    false
+  );
+
+  assert.equal(
+    matchesTwitterManualReplyRecovery({
+      post: { ...post, authorId: undefined },
       sourcePostId: "2080000000000000000",
       connectedXUserId: "1743216568451125248",
       startedAt: Date.parse("2026-08-06T11:59:00.000Z"),


### PR DESCRIPTION
## Summary

Replaces SocialAPI `commented_by` polling for Twitter manual-reply recovery with an event-driven X Activity `post.create` subscription on the connected user account.

This is the durable fix for a production SocialAPI credit bleed. A temporary brake already landed on `main` (`7521f85a`: poll Twitter manual-reply recovery once per day). **This PR supersedes that temporary throttle** for the Twitter path: detection becomes webhook-driven, so we no longer need high-frequency (or even daily) SocialAPI polls for “did I reply yet?”.

## Problem (production context)

### Symptom
- SocialAPI balance dropped quickly after a ~$10 top-up.
- Prospecting workspaces were paused, but credits kept draining.

### Root cause (not prospecting)
Bleed came from **`outreachRecovery.verifyUserCommented`** (SocialAPI `commented_by` search), not from prospecting discovery.

When automated X reply posting fails with `api_policy_forbidden`, the product assumes the user may post the prepared reply manually and starts a `twitter_manual_reply` recovery monitor in stage `detecting_outbound`. Historically that path **polled SocialAPI** on a short backoff (seconds → minutes) asking “has this user commented on the target tweet yet?”

### Why pause did not stop the bleed
Workspace / prospecting pause stopped local discovery monitors, but **did not cancel active outreach recovery monitors**. Those pollers kept running.

### Scale / cost (observed)
- ~121 active `twitter_manual_reply` monitors in `detecting_outbound` on workspace **ReacherX (Leads)** (`ks76wdkah15gxj05hatyk5hxjx88y6dj`), created ~2026-08-06.
- SocialAPI real rates were far higher than our internal estimate (`$0.0002`), on the order of **~$0.02/entity** and **~$0.69/hr** for related `user_tweets` monitors.
- At the old ~15-minute cadence, recovery polling alone could burn on the order of **~$10/hr**, plus live style monitors.

### Temporary mitigation already on main
`7521f85a` reduced Twitter `detecting_outbound` SocialAPI checks to **once per day** so prod stops hemorrhaging while this rewrite ships. LinkedIn detecting_outbound polling was intentionally left alone.

## Solution in this PR

### Design
For Twitter manual-reply recovery:
1. Ensure an X Activity **`post.create`** subscription for the connected authenticated user (reuse existing Activity webhook infrastructure; avoid creating a second webhook — X has a hard webhook limit).
2. On each `post.create` webhook event, extract the created post and match it to active `twitter_manual_reply` / `detecting_outbound` monitors (author must be the connected X user; post must reply to the monitor’s `sourcePostId`; created after handoff).
3. On match, continue the plan the same way the old poller would have (mark reply detected, resume).
4. **Do not** schedule SocialAPI `commented_by` / `verifyUserCommented` polling for this path.
5. Schedule **expiry only** (48h window) via `expireTwitterManualReplyDetection` so silent failures do not linger forever.
6. Keep `cancelTwitterManualReplyRecoveriesInternal` as a one-shot cleanup helper for leftover SocialAPI-era pollers after deploy.

### Explicit non-goals / clarifications
- Activity **detects** that the connected user posted a reply. It does **not** bypass X API policy for automated posting.
- Pause must **not** cancel recovery monitors as a cost control. Cost is fixed by removing SocialAPI polling; cancelling on pause would be the wrong UX once detection is event-driven.
- LinkedIn recovery paths are unchanged and may still use sparse polling where appropriate.

## Key files

| Area | Files |
|------|-------|
| Recovery orchestration | `convex/outreachRecovery.ts` |
| Matching / helpers | `convex/lib/outreachRecoveryCore.ts` |
| Activity subscription + webhook handling | `convex/xActivity.ts`, `convex/lib/xActivity.ts` |
| Validators / schema | `convex/validators.ts` (`post.create`, discovery source), `convex/schema.ts` (`outreachRecoveryMonitors.by_user_and_status`) |
| Contracts | `shared/lib/twitter/contracts.ts` |
| Tests | `tests/outreach-recovery-core.test.ts` |

## Relationship to main’s temporary 24h poll

| Branch / commit | Behavior |
|-----------------|----------|
| `main` @ `7521f85a` | Temporary: Twitter `detecting_outbound` next-check delay = 24h (still SocialAPI) |
| This PR | Permanent: no SocialAPI poll for Twitter manual reply; Activity `post.create` + expiry |

After this merges and deploys, the temporary 24h Twitter poll constant/path from `7521f85a` is obsolete for that flow and should not be reintroduced.

## Post-deploy cleanup (prod)

After this is deployed to production, cancel leftover SocialAPI-era Twitter manual-reply monitors that may still be scheduled from before the rewrite:

```bash
npx convex run --prod internal.outreachRecovery.cancelTwitterManualReplyRecoveriesInternal \
  '{"workspaceId":"ks76wdkah15gxj05hatyk5hxjx88y6dj"}'
```

(Adjust `workspaceId` if cleaning other workspaces.)

Also confirm `post.create` Activity subscription is present for affected connected X users (ensure path runs when starting recovery / connecting accounts as implemented).

## Test plan

- [ ] Unit tests: `node --import tsx --test tests/outreach-recovery-core.test.ts` (Activity envelope extraction + reply matching + LinkedIn delay helpers)
- [ ] Convex typecheck / deploy to a non-prod deployment
- [ ] Force or simulate an X automated reply failure → `waiting_manual` + recovery monitor created
- [ ] Confirm **no** SocialAPI `commented_by` / `verifyUserCommented` schedule for that monitor
- [ ] Confirm Activity `post.create` subscription ensure succeeds (watch for `WebhookLimitExceeded` regressions — must reuse single webhook)
- [ ] Manually post the prepared reply from the connected account → webhook matches → plan continues
- [ ] No reply within window → expiry path cancels/expires cleanly
- [ ] LinkedIn comment / connection recovery still works (unchanged)
- [ ] After prod deploy: run `cancelTwitterManualReplyRecoveriesInternal` for workspaces that still have pre-rewrite active Twitter pollers
- [ ] Verify SocialAPI spend no longer tracks Twitter manual-reply recovery cadence

## Reviewer notes (AI + human)

1. Prefer reading the production incident narrative above before nitpicking naming — the change is a cost/architecture fix, not a cosmetic refactor.
2. Do **not** “helpfully” re-add SocialAPI polling for Twitter `detecting_outbound` as a fallback unless there is a concrete product requirement and a hard cost budget; that is what burned credits.
3. Do **not** couple workspace pause to canceling recovery monitors in this PR; that coupling was considered and rejected after the Activity rewrite.
4. Watch webhook/subscription dedup carefully — X Activity webhook limits are real; this PR intentionally extends the existing Activity path rather than adding a parallel webhook.
