### PR TITLE
fix: prevent LinkedIn self-messages from appearing as replies

### DIFF
--- a/convex/lib/linkedinWebhookCore.ts
+++ b/convex/lib/linkedinWebhookCore.ts
@@ -1,0 +1,151 @@
+import { getNestedRecord, isRecord } from "./typeGuards";
+
+type LinkedInWebhookAccount = {
+  providerId?: string | null;
+};
+
+export type LinkedInWebhookMessageDirection = "sent" | "received";
+
+export function getWebhookString(
+  value: unknown,
+  ...keys: string[]
+): string | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  for (const key of keys) {
+    const candidate = value[key];
+    if (typeof candidate === "string" && candidate.trim().length > 0) {
+      return candidate.trim();
+    }
+  }
+
+  return undefined;
+}
+
+export function getWebhookArray(value: unknown, key: string): unknown[] {
+  if (!isRecord(value)) {
+    return [];
+  }
+
+  const candidate = value[key];
+  return Array.isArray(candidate) ? candidate : [];
+}
+
+function getWebhookBoolean(
+  value: unknown,
+  ...keys: string[]
+): boolean | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  for (const key of keys) {
+    const candidate = value[key];
+    if (
+      candidate === true ||
+      candidate === 1 ||
+      candidate === "1" ||
+      candidate === "true"
+    ) {
+      return true;
+    }
+    if (
+      candidate === false ||
+      candidate === 0 ||
+      candidate === "0" ||
+      candidate === "false"
+    ) {
+      return false;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Extract the LinkedIn participant from Unipile webhook payloads.
+ *
+ * `new_relation` events identify the other LinkedIn user with the top-level
+ * `user_provider_id` field. Messaging events use sender/attendee fields, so
+ * those remain as fallbacks for the other webhook sources.
+ */
+export function getWebhookParticipantProviderId(
+  payload: unknown,
+  linkedAccount: LinkedInWebhookAccount
+): string | undefined {
+  const accountProviderId = linkedAccount.providerId?.trim();
+  const userProviderId = getWebhookString(
+    payload,
+    "user_provider_id",
+    "userProviderId"
+  );
+  if (userProviderId && userProviderId !== accountProviderId) {
+    return userProviderId;
+  }
+
+  const sender = getNestedRecord(payload, "sender");
+  const senderProviderId = getWebhookString(sender, "provider_id", "id");
+  if (senderProviderId && senderProviderId !== accountProviderId) {
+    return senderProviderId;
+  }
+
+  const attendees = getWebhookArray(payload, "attendees");
+  for (const attendee of attendees) {
+    const providerId = getWebhookString(attendee, "provider_id", "id");
+    if (providerId && providerId !== accountProviderId) {
+      return providerId;
+    }
+  }
+
+  const attendeeProviderId = getWebhookString(
+    payload,
+    "attendee_provider_id",
+    "attendee_id"
+  );
+  if (attendeeProviderId && attendeeProviderId !== accountProviderId) {
+    return attendeeProviderId;
+  }
+
+  return undefined;
+}
+
+/**
+ * Resolve message direction without turning ReacherX's own outbound message
+ * webhook into a prospect response.
+ *
+ * Unipile may include `is_sender` while some payloads only identify the
+ * sender. A previously persisted outbound message is also authoritative when
+ * the provider omits the explicit sender flag.
+ */
+export function getWebhookMessageDirection(
+  payload: unknown,
+  linkedAccount: LinkedInWebhookAccount,
+  knownDirection?: LinkedInWebhookMessageDirection
+): LinkedInWebhookMessageDirection {
+  const explicitDirection =
+    getWebhookBoolean(payload, "is_sender", "isSender") ??
+    getWebhookBoolean(
+      getNestedRecord(payload, "message"),
+      "is_sender",
+      "isSender"
+    );
+  if (explicitDirection !== undefined) {
+    return explicitDirection ? "sent" : "received";
+  }
+
+  if (knownDirection) {
+    return knownDirection;
+  }
+
+  const senderProviderId = getWebhookString(
+    getNestedRecord(payload, "sender"),
+    "provider_id",
+    "id"
+  );
+  return senderProviderId &&
+    senderProviderId === linkedAccount.providerId?.trim()
+    ? "sent"
+    : "received";
+}

--- a/convex/lib/outreachRecoveryCore.ts
+++ b/convex/lib/outreachRecoveryCore.ts
@@ -8,6 +8,12 @@ export type OutreachRecoveryKind =
   | "linkedin_comment_reply"
   | "linkedin_connection_then_dm";
 
+export function normalizeOutreachMessageText(
+  value: string | undefined
+): string | undefined {
+  return value?.replace(/\r\n?/g, "\n").trim();
+}
+
 /**
  * Only target-resolution failures are safe to retry automatically. A provider
  * error after the comment write may still leave an external comment, so those

--- a/convex/linkedin.ts
+++ b/convex/linkedin.ts
@@ -70,7 +70,12 @@ import {
 } from "./lib/styleSourceCore";
 import { linkedinProfileIdentityValidator } from "./validators";
 import type { LinkedInProfileIdentity } from "../shared/lib/linkedin/profile";
-import { getCurrentUTCTimestamp } from "../shared/lib/utils/time/timeUtils";
+import {
+  getWebhookArray,
+  getWebhookMessageDirection,
+  getWebhookParticipantProviderId,
+  getWebhookString,
+} from "./lib/linkedinWebhookCore";
 
 async function getAccessibleDefaultWorkspaceForUserAction(
   ctx: any,
@@ -1616,62 +1621,6 @@ function toCachedMessages(snapshot: any): LinkedInConversationMessage[] {
     messageType: message.messageType,
     isEvent: message.isEvent,
   }));
-}
-
-function getWebhookString(
-  value: unknown,
-  ...keys: string[]
-): string | undefined {
-  if (!value || typeof value !== "object") {
-    return undefined;
-  }
-
-  for (const key of keys) {
-    const candidate = (value as Record<string, unknown>)[key];
-    if (typeof candidate === "string" && candidate.trim().length > 0) {
-      return candidate.trim();
-    }
-  }
-
-  return undefined;
-}
-
-function getWebhookArray(value: unknown, key: string): unknown[] {
-  if (!value || typeof value !== "object") {
-    return [];
-  }
-  const candidate = (value as Record<string, unknown>)[key];
-  return Array.isArray(candidate) ? candidate : [];
-}
-
-function getWebhookParticipantProviderId(
-  payload: any,
-  linkedAccount: any
-): string | undefined {
-  const sender = payload?.sender;
-  const senderProviderId = getWebhookString(sender, "provider_id", "id");
-  if (senderProviderId && senderProviderId !== linkedAccount.providerId) {
-    return senderProviderId;
-  }
-
-  const attendees = getWebhookArray(payload, "attendees");
-  for (const attendee of attendees) {
-    const providerId = getWebhookString(attendee, "provider_id", "id");
-    if (providerId && providerId !== linkedAccount.providerId) {
-      return providerId;
-    }
-  }
-
-  const attendeeProviderId = getWebhookString(
-    payload,
-    "attendee_provider_id",
-    "attendee_id"
-  );
-  if (attendeeProviderId && attendeeProviderId !== linkedAccount.providerId) {
-    return attendeeProviderId;
-  }
-
-  return undefined;
 }
 
 function getWebhookParticipantName(payload: any): string | undefined {
@@ -5131,32 +5080,40 @@ export const handleUnipileWebhookPayloadInternal = internalAction({
       linkedAccount
     );
     if (event === "new_relation") {
-      const prospect = participantProviderId
-        ? await ctx.runQuery(
-            internalProspectsApi.getProspectByLinkedInUserUrnInternal,
-            {
-              userId: linkedAccount.userId,
-              linkedinUserUrn: participantProviderId,
-            }
-          )
-        : null;
-
-      if (prospect) {
-        await ctx.runMutation(
-          internal.outreachRecovery.onLinkedInConnectionAccepted,
-          {
-            prospectId: prospect._id,
-          }
-        );
-        await ctx.runMutation(internal.outreach.onProspectLinkedInResponse, {
-          prospectId: prospect._id,
-          responseType: "invite",
-          responseMessageId:
-            getWebhookString(payload, "provider_id", "relationship_id") ??
-            `${accountId}:new_relation:${getCurrentUTCTimestamp()}`,
+      if (!participantProviderId) {
+        console.warn("[LinkedIn] new_relation webhook missing participant", {
+          accountId,
+          event,
         });
+        return { processed: true as const };
       }
 
+      const prospect = await ctx.runQuery(
+        internalProspectsApi.getProspectByLinkedInUserUrnInternal,
+        {
+          userId: linkedAccount.userId,
+          linkedinUserUrn: participantProviderId,
+        }
+      );
+
+      if (!prospect) {
+        console.warn(
+          "[LinkedIn] new_relation webhook could not resolve prospect",
+          {
+            accountId,
+            participantProviderId,
+            userId: String(linkedAccount.userId),
+          }
+        );
+        return { processed: true as const };
+      }
+
+      await ctx.runMutation(
+        internal.outreachRecovery.onLinkedInConnectionAccepted,
+        {
+          prospectId: prospect._id,
+        }
+      );
       return { processed: true as const };
     }
 
@@ -5226,15 +5183,27 @@ export const handleUnipileWebhookPayloadInternal = internalAction({
     const timestamp =
       getWebhookString(payload, "timestamp") ?? new Date().toISOString();
     const attachments = normalizeWebhookAttachments(payload);
+    const providerMessageId = getWebhookString(payload, "provider_id");
+    const knownMessage = existingSnapshot?.messages?.find(
+      (message: any) =>
+        message.messageId === messageId ||
+        (providerMessageId && message.providerMessageId === providerMessageId)
+    );
+    const knownDirection =
+      knownMessage?.direction === "sent" ||
+      knownMessage?.direction === "received"
+        ? knownMessage.direction
+        : undefined;
     const senderProviderId = getWebhookString(
       payload?.sender,
       "provider_id",
       "id"
     );
-    const direction =
-      senderProviderId && senderProviderId === linkedAccount.providerId
-        ? "sent"
-        : "received";
+    const direction = getWebhookMessageDirection(
+      payload,
+      linkedAccount,
+      knownDirection
+    );
 
     await ctx.runMutation(
       internal.platformConversations.upsertConversationSnapshotInternal,
@@ -5292,7 +5261,7 @@ export const handleUnipileWebhookPayloadInternal = internalAction({
         messages: [
           {
             messageId,
-            providerMessageId: getWebhookString(payload, "provider_id"),
+            providerMessageId,
             direction,
             senderUserId: senderProviderId,
             senderAttendeeId: getWebhookString(

--- a/convex/outreachRecovery.integration.test.ts
+++ b/convex/outreachRecovery.integration.test.ts
@@ -107,7 +107,7 @@ async function seedOutreach(
       status: "failed",
       errorMessage: "Legacy LinkedIn task failure",
     });
-    return { planId, prospectId, taskId: task._id, workspaceId };
+    return { planId, prospectId, taskId: task._id, userId, workspaceId };
   });
 }
 
@@ -142,6 +142,114 @@ describe("LinkedIn outreach recovery safeguards", () => {
     }));
     expect(state.plan?.status).toBe("paused");
     expect(state.task?.status).toBe("failed");
+  });
+
+  test("reconciles a LinkedIn self-message webhook without sending again", async () => {
+    const t = createRecoveryTest();
+    const seeded = await seedOutreach(t, "dm", "self-message");
+
+    const eventId = await t.run(async (ctx) => {
+      const task = await ctx.db.get("outreachTasks", seeded.taskId);
+      if (!task) throw new Error("Expected seeded task");
+
+      await ctx.db.patch("outreachPlans", seeded.planId, {
+        status: "completed",
+      });
+      await ctx.db.patch("outreachTasks", seeded.taskId, {
+        status: "completed",
+        resultData: {
+          messageId: "outbound-message-1",
+          postedText: "A useful observation.\nSecond line.",
+        },
+      });
+
+      const notificationId = await ctx.db.insert("outreachNotifications", {
+        userId: seeded.userId,
+        workspaceId: seeded.workspaceId,
+        type: "prospect_replied",
+        title: "Reply from Recovery self-message",
+        message: '"A useful observation.\r\nSecond line."',
+        status: "pending",
+        prospectId: seeded.prospectId,
+        planId: seeded.planId,
+      });
+      const notification = await ctx.db.get(
+        "outreachNotifications",
+        notificationId
+      );
+      if (!notification) throw new Error("Expected seeded notification");
+
+      await ctx.db.insert("prospectActivityLog", {
+        prospectId: seeded.prospectId,
+        workspaceId: seeded.workspaceId,
+        type: "responded",
+        title: "DM response received",
+        description: "A useful observation.\r\nSecond line.",
+        metadata: {
+          responseDmMessageId: "outbound-message-1",
+          planId: seeded.planId,
+        },
+      });
+
+      return await ctx.db.insert("outreachInteractionEvents", {
+        eventKey: "self-message-event",
+        prospectId: seeded.prospectId,
+        workspaceId: seeded.workspaceId,
+        userId: seeded.userId,
+        planId: seeded.planId,
+        channel: "linkedin_dm",
+        responseMessageId: "outbound-message-1",
+        responseText: "A useful observation.\r\nSecond line.",
+        status: "completed",
+        attemptCount: 0,
+        createdAt: notification._creationTime,
+        updatedAt: notification._creationTime,
+        completedAt: notification._creationTime,
+      });
+    });
+
+    const first = await t.mutation(
+      internal.outreachRecovery.reconcileFalseLinkedInDmResponse,
+      {
+        eventId,
+        prospectId: seeded.prospectId,
+      }
+    );
+    const second = await t.mutation(
+      internal.outreachRecovery.reconcileFalseLinkedInDmResponse,
+      {
+        eventId,
+        prospectId: seeded.prospectId,
+      }
+    );
+
+    expect(first).toMatchObject({
+      applied: true,
+      dismissedNotificationCount: 1,
+      deletedActivityCount: 1,
+      restoredProspect: true,
+    });
+    expect(second.applied).toBe(false);
+
+    const state = await t.run(async (ctx) => ({
+      prospect: await ctx.db.get("prospects", seeded.prospectId),
+      event: await ctx.db.get("outreachInteractionEvents", eventId),
+      notifications: await ctx.db
+        .query("outreachNotifications")
+        .withIndex("by_plan", (q) => q.eq("planId", seeded.planId))
+        .take(10),
+      activity: await ctx.db
+        .query("prospectActivityLog")
+        .withIndex("by_prospect", (q) => q.eq("prospectId", seeded.prospectId))
+        .take(10),
+    }));
+
+    expect(state.prospect?.status).toBe("contacted");
+    expect(state.event?.status).toBe("ignored");
+    expect(state.notifications[0]?.status).toBe("dismissed");
+    expect(
+      state.activity.filter((entry) => entry.type === "responded")
+    ).toHaveLength(0);
   });
 
   test("failed DM reset and resume are idempotent", async () => {

--- a/convex/outreachRecovery.ts
+++ b/convex/outreachRecovery.ts
@@ -26,6 +26,7 @@ import {
 import {
   getRecoveryNextCheckDelayMs,
   isSafeLinkedInCommentTargetRecoveryError,
+  normalizeOutreachMessageText,
 } from "./lib/outreachRecoveryCore";
 import { getPostedOutreachArtifactId } from "./lib/outreachResultCore";
 import {
@@ -62,6 +63,190 @@ type SocialApiSearchResponse = {
 
 const MANUAL_OUTBOUND_DETECTION_WINDOW_MS = 48 * 60 * 60 * 1000;
 const TWITTER_ACTIVITY_RETRY_DELAY_MS = 15 * 60 * 1000;
+
+/**
+ * Repair a LinkedIn self-message webhook that was incorrectly recorded as a
+ * prospect response. This is deliberately guarded by the outbound task's
+ * persisted message ID and requires that no other non-ignored interaction
+ * exists for the prospect.
+ */
+export const reconcileFalseLinkedInDmResponse = internalMutation({
+  args: {
+    eventId: v.id("outreachInteractionEvents"),
+    prospectId: v.id("prospects"),
+  },
+  returns: v.object({
+    applied: v.boolean(),
+    reason: v.optional(v.string()),
+    dismissedNotificationCount: v.number(),
+    deletedActivityCount: v.number(),
+    restoredProspect: v.boolean(),
+  }),
+  handler: async (ctx, args) => {
+    const emptyResult = {
+      applied: false,
+      dismissedNotificationCount: 0,
+      deletedActivityCount: 0,
+      restoredProspect: false,
+    };
+    const event = await ctx.db.get("outreachInteractionEvents", args.eventId);
+    if (
+      !event ||
+      event.prospectId !== args.prospectId ||
+      event.channel !== "linkedin_dm"
+    ) {
+      return { ...emptyResult, reason: "interaction_event_not_linkedin_dm" };
+    }
+
+    const plan = event.planId
+      ? await ctx.db.get("outreachPlans", event.planId)
+      : null;
+    if (!plan || plan.prospectId !== args.prospectId) {
+      return { ...emptyResult, reason: "outreach_plan_not_found" };
+    }
+
+    const tasks = await ctx.db
+      .query("outreachTasks")
+      .withIndex("by_plan_order", (q) => q.eq("planId", plan._id))
+      .take(50);
+    const outboundTask = tasks.find(
+      (task) =>
+        task.type === "dm" &&
+        getStringProperty(task.resultData, "messageId") ===
+          event.responseMessageId
+    );
+    const outboundMessageText = outboundTask
+      ? getStringProperty(outboundTask.resultData, "postedText")
+      : undefined;
+    const normalizedOutboundMessageText =
+      normalizeOutreachMessageText(outboundMessageText);
+    const normalizedResponseText = normalizeOutreachMessageText(
+      event.responseText
+    );
+    if (
+      !outboundTask ||
+      (normalizedOutboundMessageText !== undefined &&
+        normalizedResponseText !== undefined &&
+        normalizedOutboundMessageText !== normalizedResponseText)
+    ) {
+      return { ...emptyResult, reason: "outbound_message_not_confirmed" };
+    }
+
+    const interactionEvents = await ctx.db
+      .query("outreachInteractionEvents")
+      .withIndex("by_prospect_and_created_at", (q) =>
+        q.eq("prospectId", args.prospectId)
+      )
+      .take(50);
+    const hasOtherInteraction = interactionEvents.some(
+      (candidate) =>
+        candidate._id !== event._id && candidate.status !== "ignored"
+    );
+    if (hasOtherInteraction) {
+      return { ...emptyResult, reason: "other_interaction_requires_review" };
+    }
+
+    const now = getCurrentUTCTimestamp();
+    let applied = event.status !== "ignored";
+    if (event.status !== "ignored") {
+      await ctx.db.patch("outreachInteractionEvents", event._id, {
+        status: "ignored",
+        decisionSummary:
+          "Ignored because the provider event matched ReacherX's outbound LinkedIn DM.",
+        completedAt: event.completedAt ?? now,
+        updatedAt: now,
+      });
+    }
+
+    let dismissedNotificationCount = 0;
+    const notifications = await ctx.db
+      .query("outreachNotifications")
+      .withIndex("by_plan", (q) => q.eq("planId", plan._id))
+      .take(50);
+    for (const notification of notifications) {
+      if (
+        notification.prospectId !== args.prospectId ||
+        notification.type !== "prospect_replied" ||
+        notification.status === "dismissed" ||
+        notification._creationTime < event.createdAt ||
+        notification._creationTime > event.createdAt + 1000
+      ) {
+        continue;
+      }
+      await ctx.db.patch("outreachNotifications", notification._id, {
+        status: "dismissed",
+        dismissedAt: now,
+      });
+      applied = true;
+      dismissedNotificationCount += 1;
+    }
+
+    let deletedActivityCount = 0;
+    const activityEntries = await ctx.db
+      .query("prospectActivityLog")
+      .withIndex("by_prospect", (q) => q.eq("prospectId", args.prospectId))
+      .take(50);
+    for (const activity of activityEntries) {
+      if (
+        activity.type !== "responded" ||
+        getStringProperty(activity.metadata, "responseDmMessageId") !==
+          event.responseMessageId
+      ) {
+        continue;
+      }
+      await ctx.db.delete("prospectActivityLog", activity._id);
+      applied = true;
+      deletedActivityCount += 1;
+    }
+
+    const memoryEvents = await ctx.db
+      .query("memoryWorkflowEvents")
+      .withIndex("by_prospect_occurred_at", (q) =>
+        q.eq("prospectId", args.prospectId)
+      )
+      .take(50);
+    for (const memoryEvent of memoryEvents) {
+      if (
+        memoryEvent.eventType !== "prospect_responded" ||
+        getStringProperty(memoryEvent.payload, "responseMessageId") !==
+          event.responseMessageId
+      ) {
+        continue;
+      }
+      await ctx.db.patch("memoryWorkflowEvents", memoryEvent._id, {
+        status: "ignored",
+        processedAt: now,
+      });
+      applied = true;
+    }
+
+    const prospect = await ctx.db.get("prospects", args.prospectId);
+    let restoredProspect = false;
+    if (prospect?.status === "in_progress") {
+      const timestamps = prospect.stageTimestamps;
+      await ctx.db.patch("prospects", prospect._id, {
+        status: "contacted",
+        pipelineStage: "contacted",
+        stageTimestamps: {
+          new: timestamps?.new,
+          contacted: timestamps?.contacted ?? now,
+          converted: timestamps?.converted,
+          archived: timestamps?.archived,
+        },
+        updatedAt: now,
+      });
+      applied = true;
+      restoredProspect = true;
+    }
+
+    return {
+      applied,
+      dismissedNotificationCount,
+      deletedActivityCount,
+      restoredProspect,
+    };
+  },
+});
 
 /**
  * Lists only paused, failed LinkedIn DM/comment tasks. This is intentionally

--- a/tests/linkedin-webhook-core.test.ts
+++ b/tests/linkedin-webhook-core.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  getWebhookMessageDirection,
+  getWebhookParticipantProviderId,
+} from "../convex/lib/linkedinWebhookCore";
+
+test("extracts user_provider_id from Unipile's new_relation payload", () => {
+  const payload = {
+    event: "new_relation",
+    account_id: "unipile-account-1",
+    user_provider_id: "urn:li:fsd_profile:adam-tahir",
+    user_public_identifier: "adam-tahir",
+    user_name: "Adam Tahir",
+    user_profile_url: "https://www.linkedin.com/in/adam-tahir",
+  };
+
+  assert.equal(
+    getWebhookParticipantProviderId(payload, {
+      providerId: "urn:li:fsd_profile:me",
+    }),
+    "urn:li:fsd_profile:adam-tahir"
+  );
+});
+
+test("does not classify a persisted outbound message as a prospect reply", () => {
+  const payload = {
+    event: "message_received",
+    account_id: "unipile-account-1",
+    chat_id: "chat-1",
+    message_id: "outbound-message-1",
+    message: "The outbound message text",
+  };
+
+  assert.equal(
+    getWebhookMessageDirection(
+      payload,
+      { providerId: "urn:li:fsd_profile:me" },
+      "sent"
+    ),
+    "sent"
+  );
+});
+
+test("prefers Unipile's explicit sender flag when available", () => {
+  assert.equal(
+    getWebhookMessageDirection(
+      {
+        event: "message_received",
+        is_sender: 1,
+      },
+      { providerId: "urn:li:fsd_profile:me" }
+    ),
+    "sent"
+  );
+  assert.equal(
+    getWebhookMessageDirection(
+      {
+        event: "message_received",
+        is_sender: 0,
+      },
+      { providerId: "urn:li:fsd_profile:me" },
+      "sent"
+    ),
+    "received"
+  );
+});


### PR DESCRIPTION
## Summary
- Parse Unipile `new_relation.user_provider_id` payloads and log when the participant or prospect cannot be resolved.
- Preserve outbound LinkedIn message direction using provider sender metadata and persisted outbound messages, preventing false prospect responses.
- Add a guarded, idempotent reconciliation mutation for false self-message events without sending another DM.

## Test plan
- [x] LinkedIn webhook regression tests
- [x] Outreach recovery integration tests (10 passing)
- [x] Convex TypeScript check
- [x] oxlint
- [x] Prettier
- [x] Production build

After merge and deployment, the Adam/Tiya production reconciliation can be run explicitly with the deployed mutation.

Made with [Cursor](https://cursor.com)