### PR TITLE
fix: stop Main Agent hangs from unfinished askHuman turns

### DIFF
--- a/convex/agents/index.ts
+++ b/convex/agents/index.ts
@@ -47,7 +47,6 @@ import {
 } from "./tools/workspaceProfileChanges";
 import { approveSocialActionRequest } from "./outreach/tools/approveSocialActionRequest";
 import { approveTask } from "./outreach/tools/approveTask";
-import { askHuman } from "./outreach/tools/askHuman";
 import { displayEntity } from "./outreach/tools/displayEntity";
 import { getProspectInteractionHistory } from "./outreach/tools/getProspectInteractionHistory";
 import { getProspectPlan } from "./outreach/tools/getProspectPlan";
@@ -149,7 +148,6 @@ const mainAgentBaseTools = {
   socialAction,
   approveSocialActionRequest,
   approveTask,
-  askHuman,
   // Memory
   rememberWorkspaceMemory,
   searchWorkspaceMemories,

--- a/convex/agents/prompts.ts
+++ b/convex/agents/prompts.ts
@@ -260,6 +260,7 @@ ${buildUseCaseContextBlock(useCase)}
 - You cannot start global discovery or prospecting workflows from this surface. Those capabilities are setup-only and are intentionally not available to this agent.
 - Before proposing strategy for a selected ${entitySingularLower}, call \`inspectWorkspace\` when you need the latest workspace offer, ICP, connected-account, or autonomy details.
 - If the user explicitly asks you to confirm your understanding before acting, answer with your understanding only and do not call any action tool in that turn. When they later say to proceed, execute the confirmed request normally.
+- When clarification is required, ask one short question as a normal assistant response and end the turn. Do not call a tool merely to wait for the user's answer.
 - For create-plan or revise-plan requests from this workspace thread, call \`managePlanBatch\` even when exactly one ${entitySingularLower} is selected. Use scope.kind=\`tagged\`; a single selected prospect is a batch of one.
 - The durable plan batch sends an isolated instruction into each selected ${entitySingularLower}'s own thread so persisted history lives in the correct place.
 - Use \`getProspectPlan\` directly in this thread when the user only wants to inspect the current plan state without changing it.
@@ -349,7 +350,6 @@ ${buildUseCaseContextBlock(useCase)}
 - socialAction
 - approveSocialActionRequest
 - approveTask
-- askHuman
 
 **Memory tools:**
 - rememberWorkspaceMemory

--- a/convex/chat.ts
+++ b/convex/chat.ts
@@ -1030,6 +1030,8 @@ const TIMED_OUT_ERROR_MESSAGE =
   "That response took too long and stopped before it finished.";
 const TIMED_OUT_VISIBLE_MESSAGE =
   "That response took too long and stopped before it finished. Please try again.";
+const GENERATION_FAILED_VISIBLE_MESSAGE =
+  "That response stopped because of an unexpected error. Please try again.";
 const DEFAULT_AGENT_STREAM_DELTAS = {
   chunking: "word" as const,
   throttleMs: 100,
@@ -3238,6 +3240,24 @@ export const reconcileThreadGenerationFailure = mutation({
   },
 });
 
+export const finalizeWorkspaceAgentGenerationFailureInternal = internalMutation(
+  {
+    args: {
+      threadId: v.string(),
+      order: v.number(),
+      errorMessage: v.string(),
+    },
+    handler: async (ctx, args) => {
+      return await finalizePendingAssistantMessageForOrder(ctx, {
+        threadId: args.threadId,
+        order: args.order,
+        errorMessage: args.errorMessage,
+        userVisibleMessage: GENERATION_FAILED_VISIBLE_MESSAGE,
+      });
+    },
+  }
+);
+
 // ============================================================================
 // Message Sending (Streaming Pattern)
 // ============================================================================
@@ -3499,6 +3519,40 @@ export const streamAgentResponse = internalAction({
       };
     } catch (error) {
       const normalizedError = normalizeUnknownError(error);
+      try {
+        const promptMessage = await getThreadMessageById(
+          ctx,
+          args.promptMessageId
+        );
+        if (promptMessage) {
+          const finalized: boolean = await ctx.runMutation(
+            internal.chat.finalizeWorkspaceAgentGenerationFailureInternal,
+            {
+              threadId: args.threadId,
+              order: promptMessage.order,
+              errorMessage: stringifyUnknownError(normalizedError),
+            }
+          );
+          if (!finalized) {
+            chatLogger.warn(
+              "Workspace agent stream failed without a pending assistant message",
+              {
+                threadId: args.threadId,
+                promptMessageId: args.promptMessageId,
+              }
+            );
+          }
+        }
+      } catch (finalizationError) {
+        chatLogger.error(
+          "Workspace agent stream failure could not be finalized",
+          {
+            threadId: args.threadId,
+            promptMessageId: args.promptMessageId,
+          },
+          normalizeUnknownError(finalizationError)
+        );
+      }
       chatLogger.error(
         "Workspace agent stream error",
         {

--- a/convex/lib/planBatchCore.ts
+++ b/convex/lib/planBatchCore.ts
@@ -48,6 +48,28 @@ export type PlanBatchReferenceCatalogItem = {
   createdAt: number;
 };
 
+export function selectLatestPlanBatchReferences<
+  T extends PlanBatchReferenceCatalogItem & { targetIds: string[] },
+>(items: T[]): T[] {
+  const seenTargetSets = new Set<string>();
+
+  return [...items]
+    .sort((left, right) => right.createdAt - left.createdAt)
+    .filter((item) => {
+      if (item.targetIds.length === 0) {
+        return true;
+      }
+
+      const targetSetKey = [...item.targetIds].sort().join("\u0000");
+      if (seenTargetSets.has(targetSetKey)) {
+        return false;
+      }
+
+      seenTargetSets.add(targetSetKey);
+      return true;
+    });
+}
+
 function getModelMessageText(message: ModelMessage): string {
   if (typeof message.content === "string") {
     return message.content.trim();

--- a/convex/planBatches.ts
+++ b/convex/planBatches.ts
@@ -20,6 +20,7 @@ import {
   getPlanBatchWorkflowEventName,
   instructionReferencesPlanBatchTarget,
   resolvePlanBatchTargetInstructions,
+  selectLatestPlanBatchReferences,
   type PlanBatchAttachment,
   type PlanBatchPerProspectInstruction,
   type PlanBatchTaggedTarget,
@@ -571,16 +572,38 @@ export const listPlanBatchReferencesForThreadInternal = internalQuery({
         ["completed", "partial", "cancelled"].includes(run.status)
     );
 
-    return await Promise.all(
-      ownedRuns.map(async (run) => ({
-        reference: run.referenceKey as string,
-        operation: run.operation,
-        status: run.status,
-        targetCount: run.targetCount,
-        prospectNames: await getSmallPlanBatchTargetNames(ctx, run),
-        createdAt: run.createdAt,
-      }))
+    const catalogItems = await Promise.all(
+      ownedRuns.map(async (run) => {
+        const [prospectNames, succeededItems] = await Promise.all([
+          getSmallPlanBatchTargetNames(ctx, run),
+          ctx.db
+            .query("planBatchItems")
+            .withIndex("by_run_and_status", (q) =>
+              q.eq("runId", run._id).eq("status", "succeeded")
+            )
+            .take(Math.max(1, Math.min(run.targetCount, 200))),
+        ]);
+
+        return {
+          reference: run.referenceKey as string,
+          operation: run.operation,
+          status: run.status,
+          targetCount: run.targetCount,
+          prospectNames,
+          createdAt: run.createdAt,
+          targetIds: succeededItems.map((item) => String(item.prospectId)),
+        };
+      })
     );
+
+    return selectLatestPlanBatchReferences(catalogItems).map((item) => ({
+      reference: item.reference,
+      operation: item.operation,
+      status: item.status,
+      targetCount: item.targetCount,
+      prospectNames: item.prospectNames,
+      createdAt: item.createdAt,
+    }));
   },
 });
 

--- a/tests/agent-capability-grounding.test.ts
+++ b/tests/agent-capability-grounding.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 import {
   buildMainAgentPrompt,
@@ -11,6 +12,19 @@ test("main agent prompt requires live workspace reads for mutable facts", () => 
   assert.match(prompt, /call `queryWorkspace` before answering/);
   assert.match(prompt, /plan count is not qualification count/);
   assert.match(prompt, /getProspectInteractionHistory/);
+});
+
+test("main agent asks clarifying questions without entering a pending tool state", () => {
+  const prompt = buildMainAgentPrompt();
+  const source = readFileSync("convex/agents/index.ts", "utf8");
+  const mainTools = source.match(
+    /const mainAgentBaseTools = \{([\s\S]*?)\n\} as const;/
+  )?.[1];
+
+  assert.ok(mainTools, "Expected to find the Main Agent tool registry");
+  assert.doesNotMatch(mainTools, /\baskHuman\b/);
+  assert.doesNotMatch(prompt, /\n- askHuman\n/);
+  assert.match(prompt, /ask one short question as a normal assistant response/);
 });
 
 test("prospect agent prompt routes real conversation questions to interaction history", () => {

--- a/tests/plan-batch-core.test.ts
+++ b/tests/plan-batch-core.test.ts
@@ -15,6 +15,7 @@ import {
   resolvePlanBatchApplication,
   resolvePlanBatchEligibility,
   resolvePlanBatchTargetInstructions,
+  selectLatestPlanBatchReferences,
 } from "../convex/lib/planBatchCore";
 import {
   createDeferredAgentExecution,
@@ -243,6 +244,40 @@ test("plan groups use safe references and expose only compact context", () => {
   assert.match(context ?? "", /Nick LoPiccolo and Logan Gott/);
   assert.match(context ?? "", /safe aliases, not database IDs/);
   assert.doesNotMatch(context ?? "", /prospectId|runId|storage/i);
+});
+
+test("plan reference catalog keeps only the latest run per target set", () => {
+  const older = {
+    reference: "plans_aaaaaaaaaaaaaaaa",
+    operation: "create" as const,
+    status: "completed" as const,
+    targetCount: 2,
+    prospectNames: ["Nick LoPiccolo", "Logan Gott"],
+    createdAt: 1,
+    targetIds: ["p1", "p2"],
+  };
+  const newer = {
+    ...older,
+    reference: "plans_bbbbbbbbbbbbbbbb",
+    operation: "update" as const,
+    createdAt: 2,
+  };
+  const unrelated = {
+    reference: "plans_cccccccccccccccc",
+    operation: "create" as const,
+    status: "completed" as const,
+    targetCount: 1,
+    prospectNames: ["Michel Lieben"],
+    createdAt: 3,
+    targetIds: ["p3"],
+  };
+
+  const selected = selectLatestPlanBatchReferences([older, newer, unrelated]);
+
+  assert.deepEqual(
+    selected.map((item) => item.reference),
+    ["plans_cccccccccccccccc", "plans_bbbbbbbbbbbbbbbb"]
+  );
 });
 
 test("tool prompt message resolution supports the installed Agent runtime", () => {


### PR DESCRIPTION
## Summary
- Remove the half-wired `askHuman` tool from Main Agent so clarifications are normal assistant text instead of orphaned pending tool states.
- Collapse historical plan-group references to the latest run per target set, reducing ambiguous “which plans?” loops.
- Finalize failed workspace agent streams server-side immediately, so genuine errors no longer look like client-side timeouts.

## Test plan
- [x] `pnpm exec tsc --noEmit -p convex/tsconfig.json`
- [x] oxlint on touched files
- [x] `pnpm exec tsx --test tests/agent-capability-grounding.test.ts tests/plan-batch-core.test.ts`
- [x] `pnpm exec tsx --test tests/prospect-profile-agent-context.test.ts`
- [ ] Smoke: ask Main Agent an ambiguous plan-group question and confirm it replies with a short clarification instead of hanging
- [ ] Smoke: force a Main Agent stream failure and confirm the assistant message finalizes with the unexpected-error copy (not a false timeout)


Made with [Cursor](https://cursor.com)