### PR TITLE
fix: retry failed workspace memory embeddings

### DIFF
--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -39,4 +39,10 @@ crons.interval(
   internal.ragMaintenance.cleanupLegacyProspectRagCron
 );
 
+crons.interval(
+  "retry failed workspace memory embeddings",
+  { minutes: 2 },
+  internal.memory.retryFailedCanonicalWorkspaceMemoryIndexesCron
+);
+
 export default crons;

--- a/convex/lib/workspaceMemoryCore.ts
+++ b/convex/lib/workspaceMemoryCore.ts
@@ -813,21 +813,18 @@ export async function claimFailedCanonicalWorkspaceMemoryIndexRetries(
   const scanLimit = limit * WORKSPACE_MEMORY_INDEX_RETRY_SCAN_MULTIPLIER;
   const dueRows = await db
     .query("workspaceMemories")
-    .withIndex(
-      "by_status_and_index_status_and_index_retryable_and_index_retry_at",
-      (query: any) =>
-        query
-          .eq("status", "active")
-          .eq("indexStatus", "failed")
-          .eq("indexRetryable", true)
-          .lte("indexRetryAt", now)
+    .withIndex("by_status_index_retry", (query: any) =>
+      query
+        .eq("status", "active")
+        .eq("indexStatus", "failed")
+        .eq("indexRetryable", true)
+        .lte("indexRetryAt", now)
     )
     .take(scanLimit);
   const legacyCandidates = await db
     .query("workspaceMemories")
-    .withIndex(
-      "by_status_and_index_status_and_index_retryable_and_index_retry_at",
-      (query: any) => query.eq("status", "active").eq("indexStatus", "failed")
+    .withIndex("by_status_index_retry", (query: any) =>
+      query.eq("status", "active").eq("indexStatus", "failed")
     )
     .take(scanLimit);
   const legacyRows = legacyCandidates.filter(

--- a/convex/lib/workspaceMemoryCore.ts
+++ b/convex/lib/workspaceMemoryCore.ts
@@ -25,6 +25,14 @@ export const MAX_OPERATOR_MEMORY_CANDIDATES = 200;
 export const MAX_LEARNED_MEMORY_CANDIDATES = 160;
 export const MAX_CONTEXT_OPERATOR_MEMORIES = 32;
 export const MAX_CONTEXT_LEARNED_MEMORIES = 8;
+/** Limit recovery to six embedding requests per minute. */
+export const WORKSPACE_MEMORY_INDEX_RETRY_BATCH_SIZE = 12;
+export const WORKSPACE_MEMORY_INDEX_RETRY_STAGGER_MS = 5_000;
+export const WORKSPACE_MEMORY_INDEX_RETRY_LEASE_MS = 15 * 60 * 1_000;
+export const WORKSPACE_MEMORY_INDEX_RETRY_BASE_DELAY_MS = 5 * 60 * 1_000;
+export const WORKSPACE_MEMORY_INDEX_RETRY_MAX_DELAY_MS = 24 * 60 * 60 * 1_000;
+export const WORKSPACE_MEMORY_INDEX_RETRY_MAX_FAILURES = 12;
+const WORKSPACE_MEMORY_INDEX_RETRY_SCAN_MULTIPLIER = 4;
 
 export type WorkspaceMemoryAuthority = "operator" | "learned";
 export type WorkspaceMemoryStatus = "active" | "superseded" | "disabled";
@@ -69,6 +77,13 @@ export type CanonicalWorkspaceMemory = {
   contentHash: string;
   indexedAt?: number;
   indexError?: string;
+  indexRetryable?: boolean;
+  indexRetryCount?: number;
+  indexRetryAt?: number;
+  indexRetryClaimToken?: string;
+  indexRetryClaimedAt?: number;
+  indexRetryLeaseUntil?: number;
+  indexRetryExhaustedAt?: number;
   createdAt: number;
   updatedAt: number;
 };
@@ -394,6 +409,13 @@ export function toCanonicalWorkspaceMemory(row: any): CanonicalWorkspaceMemory {
     contentHash: row.contentHash,
     indexedAt: row.indexedAt,
     indexError: row.indexError,
+    indexRetryable: row.indexRetryable,
+    indexRetryCount: row.indexRetryCount,
+    indexRetryAt: row.indexRetryAt,
+    indexRetryClaimToken: row.indexRetryClaimToken,
+    indexRetryClaimedAt: row.indexRetryClaimedAt,
+    indexRetryLeaseUntil: row.indexRetryLeaseUntil,
+    indexRetryExhaustedAt: row.indexRetryExhaustedAt,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
@@ -508,7 +530,17 @@ export async function upsertCanonicalWorkspaceMemory(
     await db.patch("workspaceMemories", existing._id, {
       ...shared,
       ...(shouldIndex
-        ? { indexStatus: "pending" as const, indexError: undefined }
+        ? {
+            indexStatus: "pending" as const,
+            indexError: undefined,
+            indexRetryable: undefined,
+            indexRetryCount: undefined,
+            indexRetryAt: undefined,
+            indexRetryClaimToken: undefined,
+            indexRetryClaimedAt: undefined,
+            indexRetryLeaseUntil: undefined,
+            indexRetryExhaustedAt: undefined,
+          }
         : {}),
     });
     const updated = await db.get("workspaceMemories", existing._id);
@@ -690,22 +722,148 @@ export async function markCanonicalWorkspaceMemoryIndexResult(
     contentHash: string;
     indexed: boolean;
     error?: string;
+    retryable?: boolean;
+    retryClaimToken?: string;
+    now?: number;
   }
 ): Promise<boolean> {
   const memory = await db.get("workspaceMemories", args.memoryId);
   if (!memory || memory.contentHash !== args.contentHash) {
     return false;
   }
-  const now = getCurrentUTCTimestamp();
+  if (
+    memory.indexRetryClaimToken !== args.retryClaimToken &&
+    (memory.indexRetryClaimToken !== undefined ||
+      args.retryClaimToken !== undefined)
+  ) {
+    return false;
+  }
+  const now = args.now ?? getCurrentUTCTimestamp();
+  const retryCount =
+    (memory.indexRetryCount ?? 0) + (args.retryClaimToken ? 1 : 0);
+  const retryExhausted =
+    !args.indexed &&
+    args.retryable === true &&
+    retryCount >= WORKSPACE_MEMORY_INDEX_RETRY_MAX_FAILURES;
   await db.patch("workspaceMemories", args.memoryId, {
     indexStatus: args.indexed ? "ready" : "failed",
     indexedAt: args.indexed ? now : undefined,
     indexError: args.indexed
       ? undefined
       : (args.error ?? "Unknown indexing error"),
+    indexRetryable: args.indexed
+      ? undefined
+      : retryExhausted
+        ? false
+        : args.retryable === true,
+    indexRetryCount: retryCount,
+    indexRetryAt:
+      !args.indexed && args.retryable === true && !retryExhausted
+        ? now + getWorkspaceMemoryIndexRetryDelayMs(retryCount)
+        : undefined,
+    indexRetryClaimToken: undefined,
+    indexRetryClaimedAt: undefined,
+    indexRetryLeaseUntil: undefined,
+    indexRetryExhaustedAt: retryExhausted ? now : undefined,
     updatedAt: now,
   });
   return true;
+}
+
+export function getWorkspaceMemoryIndexRetryDelayMs(
+  retryCount: number
+): number {
+  const exponent = Math.max(0, Math.floor(retryCount));
+  return Math.min(
+    WORKSPACE_MEMORY_INDEX_RETRY_MAX_DELAY_MS,
+    WORKSPACE_MEMORY_INDEX_RETRY_BASE_DELAY_MS * 2 ** exponent
+  );
+}
+
+export type WorkspaceMemoryIndexRetryClaim = {
+  memoryId: Id<"workspaceMemories">;
+  claimToken: string;
+  leaseUntil: number;
+};
+
+/**
+ * Atomically claims a small due batch. Moving `indexRetryAt` to the lease
+ * boundary makes an abandoned action eligible again without a cleanup job.
+ */
+export async function claimFailedCanonicalWorkspaceMemoryIndexRetries(
+  db: MemoryDbWriter,
+  args: {
+    now?: number;
+    limit?: number;
+    leaseMs?: number;
+  } = {}
+): Promise<WorkspaceMemoryIndexRetryClaim[]> {
+  const now = args.now ?? getCurrentUTCTimestamp();
+  const limit = Math.min(
+    WORKSPACE_MEMORY_INDEX_RETRY_BATCH_SIZE,
+    Math.max(
+      1,
+      Math.floor(args.limit ?? WORKSPACE_MEMORY_INDEX_RETRY_BATCH_SIZE)
+    )
+  );
+  const leaseMs = Math.max(
+    1,
+    args.leaseMs ?? WORKSPACE_MEMORY_INDEX_RETRY_LEASE_MS
+  );
+  const scanLimit = limit * WORKSPACE_MEMORY_INDEX_RETRY_SCAN_MULTIPLIER;
+  const dueRows = await db
+    .query("workspaceMemories")
+    .withIndex(
+      "by_status_and_index_status_and_index_retryable_and_index_retry_at",
+      (query: any) =>
+        query
+          .eq("status", "active")
+          .eq("indexStatus", "failed")
+          .eq("indexRetryable", true)
+          .lte("indexRetryAt", now)
+    )
+    .take(scanLimit);
+  const legacyCandidates = await db
+    .query("workspaceMemories")
+    .withIndex(
+      "by_status_and_index_status_and_index_retryable_and_index_retry_at",
+      (query: any) => query.eq("status", "active").eq("indexStatus", "failed")
+    )
+    .take(scanLimit);
+  const legacyRows = legacyCandidates.filter(
+    (row) => row.indexRetryable === undefined && row.indexRetryAt === undefined
+  );
+  const rows = [...dueRows, ...legacyRows];
+  const claims: WorkspaceMemoryIndexRetryClaim[] = [];
+  for (const row of rows) {
+    if (claims.length >= limit) {
+      break;
+    }
+    const retryCount = row.indexRetryCount ?? 0;
+    if (retryCount >= WORKSPACE_MEMORY_INDEX_RETRY_MAX_FAILURES) {
+      await db.patch("workspaceMemories", row._id, {
+        indexRetryable: false,
+        indexRetryAt: undefined,
+        indexRetryExhaustedAt: now,
+      });
+      continue;
+    }
+    if ((row.indexRetryLeaseUntil ?? 0) > now) {
+      continue;
+    }
+    const claimToken = `workspace-memory-index:${String(row._id)}:${now}`;
+    const leaseUntil = now + leaseMs;
+    await db.patch("workspaceMemories", row._id, {
+      indexRetryable: true,
+      indexRetryAt: leaseUntil,
+      indexRetryClaimToken: claimToken,
+      indexRetryClaimedAt: now,
+      indexRetryLeaseUntil: leaseUntil,
+      indexRetryExhaustedAt: undefined,
+    });
+    claims.push({ memoryId: row._id, claimToken, leaseUntil });
+  }
+  return claims;
 }
 
 export async function disableCanonicalWorkspaceMemoriesBySourceCategory(

--- a/convex/memory.ts
+++ b/convex/memory.ts
@@ -42,6 +42,7 @@ import {
 import {
   buildCanonicalWorkspaceMemoryRagText,
   buildWorkspaceMemoryContext as buildCanonicalWorkspaceMemoryContext,
+  claimFailedCanonicalWorkspaceMemoryIndexRetries,
   listCanonicalWorkspaceMemoryCandidates,
   listCanonicalLegacyMemoryIds,
   markCanonicalWorkspaceMemoryIndexResult,
@@ -51,6 +52,7 @@ import {
   type WorkspaceMemoryContext,
   type WorkspaceMemoryContextRequest,
   type WorkspaceMemoryProvenanceKind,
+  WORKSPACE_MEMORY_INDEX_RETRY_STAGGER_MS,
 } from "./lib/workspaceMemoryCore";
 import {
   distillEnrichmentLearning,
@@ -582,6 +584,8 @@ export const markCanonicalWorkspaceMemoryIndexResultInternal = internalMutation(
       contentHash: v.string(),
       indexed: v.boolean(),
       error: v.optional(v.string()),
+      retryable: v.optional(v.boolean()),
+      retryClaimToken: v.optional(v.string()),
     },
     handler: async (ctx, args): Promise<boolean> =>
       await markCanonicalWorkspaceMemoryIndexResult(ctx.db, args),
@@ -598,6 +602,8 @@ export const indexCanonicalWorkspaceMemoryInternal = internalAction({
   args: {
     memoryId: v.id("workspaceMemories"),
     attempt: v.optional(v.number()),
+    inlineRetries: v.optional(v.boolean()),
+    retryClaimToken: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const memory = await ctx.runQuery(
@@ -605,6 +611,12 @@ export const indexCanonicalWorkspaceMemoryInternal = internalAction({
       { memoryId: args.memoryId }
     );
     if (!memory || memory.status !== "active") {
+      return { indexed: false, skipped: true };
+    }
+    if (
+      args.retryClaimToken !== undefined &&
+      memory.indexRetryClaimToken !== args.retryClaimToken
+    ) {
       return { indexed: false, skipped: true };
     }
     if (memory.indexStatus === "ready") {
@@ -632,7 +644,7 @@ export const indexCanonicalWorkspaceMemoryInternal = internalAction({
       category: memory.category,
       source: memory.source,
     });
-    await ctx.runMutation(
+    const resultRecorded = await ctx.runMutation(
       internal.memory.markCanonicalWorkspaceMemoryIndexResultInternal,
       {
         memoryId: memory._id,
@@ -641,18 +653,60 @@ export const indexCanonicalWorkspaceMemoryInternal = internalAction({
         error: indexResult.indexed
           ? undefined
           : (indexResult.error ?? "Unknown indexing error"),
+        retryable: indexResult.retryable,
+        retryClaimToken: args.retryClaimToken,
       }
     );
     const attempt = args.attempt ?? 0;
-    if (!indexResult.indexed && indexResult.retryable && attempt < 3) {
+    if (
+      resultRecorded &&
+      !indexResult.indexed &&
+      indexResult.retryable &&
+      args.inlineRetries !== false &&
+      args.retryClaimToken === undefined &&
+      attempt < 3
+    ) {
       await ctx.scheduler.runAfter(
         1_000 * 2 ** attempt,
         internal.memory.indexCanonicalWorkspaceMemoryInternal,
-        { memoryId: memory._id, attempt: attempt + 1 }
+        {
+          memoryId: memory._id,
+          attempt: attempt + 1,
+          inlineRetries: true,
+        }
       );
       return { indexed: false, retryScheduled: true };
     }
     return { indexed: indexResult.indexed, retryScheduled: false };
+  },
+});
+
+/**
+ * Claims and schedules one bounded retry batch atomically. The action itself
+ * performs one attempt; durable backoff is recorded when that attempt fails.
+ */
+export const retryFailedCanonicalWorkspaceMemoryIndexesCron = internalMutation({
+  args: {},
+  returns: v.object({
+    claimed: v.number(),
+    scheduled: v.number(),
+  }),
+  handler: async (ctx) => {
+    const claims = await claimFailedCanonicalWorkspaceMemoryIndexRetries(
+      ctx.db
+    );
+    for (const [index, claim] of claims.entries()) {
+      await ctx.scheduler.runAfter(
+        index * WORKSPACE_MEMORY_INDEX_RETRY_STAGGER_MS,
+        internal.memory.indexCanonicalWorkspaceMemoryInternal,
+        {
+          memoryId: claim.memoryId,
+          retryClaimToken: claim.claimToken,
+          inlineRetries: false,
+        }
+      );
+    }
+    return { claimed: claims.length, scheduled: claims.length };
   },
 });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2052,10 +2052,12 @@ export default defineSchema({
       "legacyMemoryId",
     ])
     .index("by_legacy_memory_id", ["legacyMemoryId"])
-    .index(
-      "by_status_and_index_status_and_index_retryable_and_index_retry_at",
-      ["status", "indexStatus", "indexRetryable", "indexRetryAt"]
-    )
+    .index("by_status_index_retry", [
+      "status",
+      "indexStatus",
+      "indexRetryable",
+      "indexRetryAt",
+    ])
     .searchIndex("search_canonical_content", {
       searchField: "canonicalSearchText",
       filterFields: ["workspaceId", "authority", "status"],

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2007,6 +2007,14 @@ export default defineSchema({
     contentHash: v.string(),
     indexedAt: v.optional(v.number()),
     indexError: v.optional(v.string()),
+    /** Durable retry state for failed canonical RAG embeddings. */
+    indexRetryable: v.optional(v.boolean()),
+    indexRetryCount: v.optional(v.number()),
+    indexRetryAt: v.optional(v.number()),
+    indexRetryClaimToken: v.optional(v.string()),
+    indexRetryClaimedAt: v.optional(v.number()),
+    indexRetryLeaseUntil: v.optional(v.number()),
+    indexRetryExhaustedAt: v.optional(v.number()),
     supersededById: v.optional(v.id("workspaceMemories")),
     createdAt: v.number(),
     updatedAt: v.number(),
@@ -2044,6 +2052,10 @@ export default defineSchema({
       "legacyMemoryId",
     ])
     .index("by_legacy_memory_id", ["legacyMemoryId"])
+    .index(
+      "by_status_and_index_status_and_index_retryable_and_index_retry_at",
+      ["status", "indexStatus", "indexRetryable", "indexRetryAt"]
+    )
     .searchIndex("search_canonical_content", {
       searchField: "canonicalSearchText",
       filterFields: ["workspaceId", "authority", "status"],

--- a/convex/workspaceMemoryIndexRetry.integration.test.ts
+++ b/convex/workspaceMemoryIndexRetry.integration.test.ts
@@ -1,0 +1,326 @@
+/// <reference types="vite/client" />
+
+import { convexTest } from "convex-test";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type { Id } from "./_generated/dataModel";
+import { internal } from "./_generated/api";
+import schema from "./schema";
+import {
+  claimFailedCanonicalWorkspaceMemoryIndexRetries,
+  getWorkspaceMemoryIndexRetryDelayMs,
+  markCanonicalWorkspaceMemoryIndexResult,
+  upsertCanonicalWorkspaceMemory,
+  WORKSPACE_MEMORY_INDEX_RETRY_BASE_DELAY_MS,
+  WORKSPACE_MEMORY_INDEX_RETRY_MAX_DELAY_MS,
+  WORKSPACE_MEMORY_INDEX_RETRY_MAX_FAILURES,
+  WORKSPACE_MEMORY_INDEX_RETRY_STAGGER_MS,
+} from "./lib/workspaceMemoryCore";
+
+const modules = import.meta.glob("./**/*.ts");
+
+async function seedWorkspace(t: ReturnType<typeof convexTest>) {
+  return await t.run(async (ctx) => {
+    const userId = await ctx.db.insert("users", {
+      workosUserId: "workspace-memory-index-retry-user",
+      email: "workspace-memory-index-retry@example.com",
+    });
+    const workspaceId = await ctx.db.insert("workspaces", {
+      userId,
+      name: "Workspace memory index retry test",
+      description: "Workspace memory index retry test",
+      isDefault: true,
+      entitlementSlot: 1,
+      updatedAt: 1,
+    });
+    return { userId, workspaceId };
+  });
+}
+
+async function insertCanonicalMemory(
+  t: ReturnType<typeof convexTest>,
+  seeded: Awaited<ReturnType<typeof seedWorkspace>>,
+  label: string
+): Promise<Id<"workspaceMemories">> {
+  return await t.run(async (ctx) => {
+    const result = await upsertCanonicalWorkspaceMemory(ctx.db, {
+      ...seeded,
+      source: "operator",
+      category: "operator_instruction",
+      namespace: "lessons",
+      kind: "retry_test",
+      title: label,
+      summary: label,
+      canonicalContent: `Exact canonical memory: ${label}`,
+      confidence: 1,
+      impactScore: 1,
+    });
+    const memoryId = ctx.db.normalizeId(
+      "workspaceMemories",
+      result.memory.memoryId
+    );
+    if (!memoryId) {
+      throw new Error("Expected a canonical workspace memory ID");
+    }
+    return memoryId;
+  });
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("workspace memory embedding retry", () => {
+  test("uses deterministic capped exponential backoff", () => {
+    expect(getWorkspaceMemoryIndexRetryDelayMs(0)).toBe(
+      WORKSPACE_MEMORY_INDEX_RETRY_BASE_DELAY_MS
+    );
+    expect(getWorkspaceMemoryIndexRetryDelayMs(1)).toBe(
+      WORKSPACE_MEMORY_INDEX_RETRY_BASE_DELAY_MS * 2
+    );
+    expect(getWorkspaceMemoryIndexRetryDelayMs(100)).toBe(
+      WORKSPACE_MEMORY_INDEX_RETRY_MAX_DELAY_MS
+    );
+  });
+
+  test("claims due and legacy failures without selecting ineligible rows", async () => {
+    const t = convexTest(schema, modules);
+    const seeded = await seedWorkspace(t);
+    const now = 1_000_000;
+    const exhaustedId = await insertCanonicalMemory(t, seeded, "exhausted");
+    const dueId = await insertCanonicalMemory(t, seeded, "due");
+    const futureId = await insertCanonicalMemory(t, seeded, "future");
+    const nonRetryableId = await insertCanonicalMemory(
+      t,
+      seeded,
+      "non-retryable"
+    );
+    const readyId = await insertCanonicalMemory(t, seeded, "ready");
+    const disabledId = await insertCanonicalMemory(t, seeded, "disabled");
+    const legacyId = await insertCanonicalMemory(t, seeded, "legacy");
+
+    const beforeUpdatedAt = await t.run(async (ctx) => {
+      await ctx.db.patch(exhaustedId, {
+        indexStatus: "failed",
+        indexRetryable: true,
+        indexRetryCount: WORKSPACE_MEMORY_INDEX_RETRY_MAX_FAILURES,
+        indexRetryAt: now - 200,
+      });
+      await ctx.db.patch(dueId, {
+        indexStatus: "failed",
+        indexRetryable: true,
+        indexRetryCount: 0,
+        indexRetryAt: now - 100,
+      });
+      await ctx.db.patch(futureId, {
+        indexStatus: "failed",
+        indexRetryable: true,
+        indexRetryAt: now + 1,
+      });
+      await ctx.db.patch(nonRetryableId, {
+        indexStatus: "failed",
+        indexRetryable: false,
+      });
+      await ctx.db.patch(readyId, {
+        indexStatus: "ready",
+        indexRetryable: true,
+        indexRetryAt: now - 1,
+      });
+      await ctx.db.patch(disabledId, {
+        status: "disabled",
+        indexStatus: "failed",
+        indexRetryable: true,
+        indexRetryAt: now - 1,
+      });
+      await ctx.db.patch(legacyId, {
+        indexStatus: "failed",
+        indexRetryable: undefined,
+        indexRetryAt: undefined,
+      });
+      return (await ctx.db.get(dueId))?.updatedAt;
+    });
+
+    const claims = await t.run(
+      async (ctx) =>
+        await claimFailedCanonicalWorkspaceMemoryIndexRetries(ctx.db, {
+          now,
+          limit: 4,
+          leaseMs: 1_000,
+        })
+    );
+    expect(new Set(claims.map((claim) => claim.memoryId))).toEqual(
+      new Set([dueId, legacyId])
+    );
+
+    const state = await t.run(async (ctx) => ({
+      exhausted: await ctx.db.get(exhaustedId),
+      due: await ctx.db.get(dueId),
+      legacy: await ctx.db.get(legacyId),
+      future: await ctx.db.get(futureId),
+      nonRetryable: await ctx.db.get(nonRetryableId),
+      ready: await ctx.db.get(readyId),
+      disabled: await ctx.db.get(disabledId),
+    }));
+    expect(state.exhausted?.indexRetryable).toBe(false);
+    expect(state.exhausted?.indexRetryExhaustedAt).toBe(now);
+    expect(state.due?.indexRetryAt).toBe(now + 1_000);
+    expect(state.legacy?.indexRetryAt).toBe(now + 1_000);
+    expect(state.due?.updatedAt).toBe(beforeUpdatedAt);
+    expect(state.future?.indexRetryClaimToken).toBeUndefined();
+    expect(state.nonRetryable?.indexRetryClaimToken).toBeUndefined();
+    expect(state.ready?.indexRetryClaimToken).toBeUndefined();
+    expect(state.disabled?.indexRetryClaimToken).toBeUndefined();
+  });
+
+  test("prevents duplicate claims until lease expiry and rejects stale results", async () => {
+    const t = convexTest(schema, modules);
+    const seeded = await seedWorkspace(t);
+    const memoryId = await insertCanonicalMemory(t, seeded, "lease and CAS");
+    const firstNow = 2_000_000;
+    const leaseMs = 1_000;
+    await t.run(async (ctx) => {
+      await ctx.db.patch(memoryId, {
+        indexStatus: "failed",
+        indexRetryable: true,
+        indexRetryAt: firstNow,
+      });
+    });
+
+    const firstClaim = await t.run(
+      async (ctx) =>
+        (
+          await claimFailedCanonicalWorkspaceMemoryIndexRetries(ctx.db, {
+            now: firstNow,
+            limit: 1,
+            leaseMs,
+          })
+        )[0]
+    );
+    expect(firstClaim).toBeDefined();
+
+    const duplicateClaims = await t.run(
+      async (ctx) =>
+        await claimFailedCanonicalWorkspaceMemoryIndexRetries(ctx.db, {
+          now: firstNow + leaseMs - 1,
+          limit: 1,
+          leaseMs,
+        })
+    );
+    expect(duplicateClaims).toEqual([]);
+
+    const secondClaim = await t.run(
+      async (ctx) =>
+        (
+          await claimFailedCanonicalWorkspaceMemoryIndexRetries(ctx.db, {
+            now: firstNow + leaseMs,
+            limit: 1,
+            leaseMs,
+          })
+        )[0]
+    );
+    expect(secondClaim.claimToken).not.toBe(firstClaim.claimToken);
+
+    const result = await t.run(async (ctx) => {
+      const memory = await ctx.db.get(memoryId);
+      if (!memory) {
+        throw new Error("Expected claimed memory");
+      }
+      const staleRecorded = await markCanonicalWorkspaceMemoryIndexResult(
+        ctx.db,
+        {
+          memoryId,
+          contentHash: memory.contentHash,
+          indexed: false,
+          error: "stale failure",
+          retryable: true,
+          retryClaimToken: firstClaim.claimToken,
+          now: firstNow + leaseMs + 1,
+        }
+      );
+      const currentRecorded = await markCanonicalWorkspaceMemoryIndexResult(
+        ctx.db,
+        {
+          memoryId,
+          contentHash: memory.contentHash,
+          indexed: false,
+          error: "current failure",
+          retryable: true,
+          retryClaimToken: secondClaim.claimToken,
+          now: firstNow + leaseMs + 2,
+        }
+      );
+      return {
+        staleRecorded,
+        currentRecorded,
+        memory: await ctx.db.get(memoryId),
+      };
+    });
+
+    expect(result.staleRecorded).toBe(false);
+    expect(result.currentRecorded).toBe(true);
+    expect(result.memory?.indexRetryCount).toBe(1);
+    expect(result.memory?.indexRetryAt).toBe(
+      firstNow + leaseMs + 2 + getWorkspaceMemoryIndexRetryDelayMs(1)
+    );
+    expect(result.memory?.indexRetryClaimToken).toBeUndefined();
+    expect(result.memory?.canonicalContent).toBe(
+      "Exact canonical memory: lease and CAS"
+    );
+  });
+
+  test("schedules only one bounded, staggered batch with inline retries disabled", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-10T12:00:00.000Z"));
+    const t = convexTest(schema, modules);
+    const seeded = await seedWorkspace(t);
+    const memoryIds: Id<"workspaceMemories">[] = [];
+    for (let index = 0; index < 14; index += 1) {
+      memoryIds.push(
+        await insertCanonicalMemory(t, seeded, `scheduled ${index}`)
+      );
+    }
+    await t.run(async (ctx) => {
+      for (const memoryId of memoryIds) {
+        await ctx.db.patch(memoryId, {
+          indexStatus: "failed",
+          indexRetryable: true,
+          indexRetryAt: 1,
+        });
+      }
+    });
+
+    const result = await t.mutation(
+      internal.memory.retryFailedCanonicalWorkspaceMemoryIndexesCron,
+      {}
+    );
+    expect(result).toEqual({ claimed: 12, scheduled: 12 });
+
+    const scheduled = await t.run(async (ctx) =>
+      (await ctx.db.system.query("_scheduled_functions").collect())
+        .filter((job) =>
+          job.name.includes("indexCanonicalWorkspaceMemoryInternal")
+        )
+        .sort((left, right) => left.scheduledTime - right.scheduledTime)
+    );
+    expect(scheduled).toHaveLength(12);
+    expect(
+      scheduled.map((job) => job.scheduledTime - scheduled[0].scheduledTime)
+    ).toEqual([
+      0,
+      WORKSPACE_MEMORY_INDEX_RETRY_STAGGER_MS,
+      WORKSPACE_MEMORY_INDEX_RETRY_STAGGER_MS * 2,
+      WORKSPACE_MEMORY_INDEX_RETRY_STAGGER_MS * 3,
+      WORKSPACE_MEMORY_INDEX_RETRY_STAGGER_MS * 4,
+      WORKSPACE_MEMORY_INDEX_RETRY_STAGGER_MS * 5,
+      WORKSPACE_MEMORY_INDEX_RETRY_STAGGER_MS * 6,
+      WORKSPACE_MEMORY_INDEX_RETRY_STAGGER_MS * 7,
+      WORKSPACE_MEMORY_INDEX_RETRY_STAGGER_MS * 8,
+      WORKSPACE_MEMORY_INDEX_RETRY_STAGGER_MS * 9,
+      WORKSPACE_MEMORY_INDEX_RETRY_STAGGER_MS * 10,
+      WORKSPACE_MEMORY_INDEX_RETRY_STAGGER_MS * 11,
+    ]);
+    for (const job of scheduled) {
+      expect(job.args[0]).toMatchObject({ inlineRetries: false });
+      expect(job.args[0]).toHaveProperty("retryClaimToken");
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a bounded, throttled cron for failed historical workspace-memory embeddings
- persist retry claims, leases, exponential backoff, exhaustion, and stale-result protection
- include legacy failed rows without retry metadata and add Convex integration coverage

## Verification
- `pnpm test:convex` (29 files, 166 tests)
- `npx tsc --noEmit --pretty false`
- `pnpm lint:strict`
- Prettier check
- `git diff --check`

No production deployment or migration rerun is included. The completed migration remains complete; this cron handles embedding retries after deployment.