### PR TITLE
Fix X/Twitter and LinkedIn DM history and agent recovery

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -109,6 +109,7 @@ import type * as lib_analyticsCore from "../lib/analyticsCore.js";
 import type * as lib_autoPlanCore from "../lib/autoPlanCore.js";
 import type * as lib_autoPlanGroundingCacheCore from "../lib/autoPlanGroundingCacheCore.js";
 import type * as lib_contactDiscoveryCore from "../lib/contactDiscoveryCore.js";
+import type * as lib_conversationHistoryPaginationCore from "../lib/conversationHistoryPaginationCore.js";
 import type * as lib_deferredAgentTurn from "../lib/deferredAgentTurn.js";
 import type * as lib_deleteWorkspaceCascade from "../lib/deleteWorkspaceCascade.js";
 import type * as lib_deleteWorkspaceCore from "../lib/deleteWorkspaceCore.js";
@@ -236,6 +237,7 @@ import type * as lib_workspaceStyleProfileCore from "../lib/workspaceStyleProfil
 import type * as lib_workspaceSystem from "../lib/workspaceSystem.js";
 import type * as lib_workspaceThreadHelpers from "../lib/workspaceThreadHelpers.js";
 import type * as lib_xActivity from "../lib/xActivity.js";
+import type * as lib_xActivityReconciliationCore from "../lib/xActivityReconciliationCore.js";
 import type * as lib_xConnectionStateCore from "../lib/xConnectionStateCore.js";
 import type * as lib_xConversationDiscoveryCore from "../lib/xConversationDiscoveryCore.js";
 import type * as lib_xDm from "../lib/xDm.js";
@@ -436,6 +438,7 @@ declare const fullApi: ApiFromModules<{
   "lib/autoPlanCore": typeof lib_autoPlanCore;
   "lib/autoPlanGroundingCacheCore": typeof lib_autoPlanGroundingCacheCore;
   "lib/contactDiscoveryCore": typeof lib_contactDiscoveryCore;
+  "lib/conversationHistoryPaginationCore": typeof lib_conversationHistoryPaginationCore;
   "lib/deferredAgentTurn": typeof lib_deferredAgentTurn;
   "lib/deleteWorkspaceCascade": typeof lib_deleteWorkspaceCascade;
   "lib/deleteWorkspaceCore": typeof lib_deleteWorkspaceCore;
@@ -563,6 +566,7 @@ declare const fullApi: ApiFromModules<{
   "lib/workspaceSystem": typeof lib_workspaceSystem;
   "lib/workspaceThreadHelpers": typeof lib_workspaceThreadHelpers;
   "lib/xActivity": typeof lib_xActivity;
+  "lib/xActivityReconciliationCore": typeof lib_xActivityReconciliationCore;
   "lib/xConnectionStateCore": typeof lib_xConnectionStateCore;
   "lib/xConversationDiscoveryCore": typeof lib_xConversationDiscoveryCore;
   "lib/xDm": typeof lib_xDm;

--- a/convex/agents/outreach/tools/getProspectInteractionHistory.ts
+++ b/convex/agents/outreach/tools/getProspectInteractionHistory.ts
@@ -9,10 +9,13 @@ import { z } from "zod";
 import { internal } from "../../../_generated/api";
 import type { Id } from "../../../_generated/dataModel";
 import type { ProspectInteractionHistoryItem } from "../../../lib/prospectInteractionHistoryCore";
+import { isCurrentConversationHistoryCursor } from "../../../lib/conversationHistoryPaginationCore";
+import { parseIsoToTimestamp } from "../../../../shared/lib/utils/time/timeUtils";
 import {
   AMBIGUOUS_PROSPECT_SELECTION_MESSAGE,
   MISSING_PROSPECT_SELECTION_MESSAGE,
   resolveSelectedThreadContext,
+  type ToolContext,
 } from "./helpers";
 
 /**
@@ -22,6 +25,39 @@ import {
 const platformSchema = z.enum(["all", "twitter", "linkedin"]);
 const kindSchema = z.enum(["dm", "comment", "reply"]);
 const directionSchema = z.enum(["all", "sent", "received"]);
+const MAX_AGENT_PROVIDER_HISTORY_PAGES = 4;
+const AGENT_PROVIDER_HISTORY_PAGE_SIZE = 25;
+
+type ProviderDmMessage = {
+  id: string;
+  createdAt?: string;
+  direction: "sent" | "received";
+  text?: string;
+  attachments?: unknown[];
+};
+
+type ProviderHistoryPage = {
+  messages: ProviderDmMessage[];
+  history: {
+    nextCursor?: string;
+    hasMore: boolean;
+    boundary?: "complete" | "x_30_day_limit";
+  };
+} | null;
+
+type InteractionHistoryCoverage = {
+  platform: "twitter" | "linkedin";
+  hasConversation: boolean;
+  lastSyncSuccessAt?: number;
+  lastSyncAttemptAt?: number;
+  syncError?: string;
+  historyNextCursor?: string;
+  historyHasMore: boolean;
+  historyBoundary?: "complete" | "x_30_day_limit";
+  historyOldestLoadedAt?: number;
+  providerPagesFetched?: number;
+  providerPageLimitReached?: boolean;
+};
 
 type ProspectInteractionHistoryResult = {
   prospect: {
@@ -30,13 +66,7 @@ type ProspectInteractionHistoryResult = {
   };
   items: ProspectInteractionHistoryItem[];
   truncated: boolean;
-  coverage: Array<{
-    platform: "twitter" | "linkedin";
-    hasConversation: boolean;
-    lastSyncSuccessAt?: number;
-    lastSyncAttemptAt?: number;
-    syncError?: string;
-  }>;
+  coverage: InteractionHistoryCoverage[];
   queriedAt: number;
 };
 
@@ -52,9 +82,160 @@ type GetProspectInteractionHistoryResult =
       error: string;
     };
 
+function normalizeProviderMessage(
+  platform: "twitter" | "linkedin",
+  message: ProviderDmMessage
+): ProspectInteractionHistoryItem {
+  return {
+    id: `${platform}:${message.id}`,
+    kind: "dm",
+    platform,
+    direction: message.direction,
+    occurredAt: message.createdAt
+      ? (parseIsoToTimestamp(message.createdAt) ?? 0)
+      : 0,
+    text: message.text?.trim() || undefined,
+    attachmentCount: Array.isArray(message.attachments)
+      ? message.attachments.length
+      : 0,
+  };
+}
+
+function mergeHistoryItems(args: {
+  cached: ProspectInteractionHistoryItem[];
+  provider: ProspectInteractionHistoryItem[];
+  direction: "all" | "sent" | "received";
+  limit: number;
+}) {
+  const deduplicated = new Map<string, ProspectInteractionHistoryItem>();
+  for (const item of [...args.cached, ...args.provider]) {
+    // Cached DM ids are provider ids, while live page ids include the platform
+    // prefix. Normalize both forms before merging the two sources.
+    const normalizedId = item.id.includes(":")
+      ? item.id
+      : `${item.platform}:${item.id}`;
+    deduplicated.set(normalizedId, { ...item, id: normalizedId });
+  }
+  const items = [...deduplicated.values()]
+    .filter(
+      (item) => args.direction === "all" || item.direction === args.direction
+    )
+    .sort((left, right) => right.occurredAt - left.occurredAt);
+
+  return {
+    items: items.slice(0, args.limit),
+    truncated: items.length > args.limit,
+  };
+}
+
+async function readProviderDmPages(args: {
+  ctx: ToolContext;
+  userId: Id<"users">;
+  prospectId: Id<"prospects">;
+  platform: "all" | "twitter" | "linkedin";
+  cursor?: string;
+  sinceMs?: number;
+  cachedCoverage: InteractionHistoryCoverage[];
+}) {
+  const platforms =
+    args.platform === "all"
+      ? (["twitter", "linkedin"] as const)
+      : ([args.platform] as const);
+  const providerItems: ProspectInteractionHistoryItem[] = [];
+  const pagination = new Map<
+    "twitter" | "linkedin",
+    Pick<
+      InteractionHistoryCoverage,
+      | "historyNextCursor"
+      | "historyHasMore"
+      | "historyBoundary"
+      | "providerPagesFetched"
+      | "providerPageLimitReached"
+    >
+  >();
+
+  for (const platform of platforms) {
+    const cached = args.cachedCoverage.find(
+      (coverage) => coverage.platform === platform
+    );
+    let cursor = args.cursor ?? cached?.historyNextCursor;
+    let pagesFetched = 0;
+    let page: ProviderHistoryPage = null;
+    const pageBudget =
+      typeof args.sinceMs === "number" ? MAX_AGENT_PROVIDER_HISTORY_PAGES : 1;
+
+    // A recent cached page already satisfies an ordinary read. We only issue
+    // provider requests for an explicit continuation or date-range request.
+    if (!args.cursor && typeof args.sinceMs !== "number") {
+      continue;
+    }
+    if (!cursor) {
+      pagination.set(platform, {
+        historyNextCursor: undefined,
+        historyHasMore: false,
+        historyBoundary: cached?.historyBoundary,
+        providerPagesFetched: 0,
+      });
+      continue;
+    }
+
+    while (cursor && pagesFetched < pageBudget) {
+      page =
+        platform === "twitter"
+          ? await args.ctx.runAction(
+              internal.x.getDmConversationHistoryPageInternal,
+              {
+                userId: args.userId,
+                prospectId: args.prospectId,
+                cursor,
+                limit: AGENT_PROVIDER_HISTORY_PAGE_SIZE,
+                ...(typeof args.sinceMs === "number"
+                  ? { sinceMs: args.sinceMs }
+                  : {}),
+              }
+            )
+          : await args.ctx.runAction(
+              internal.linkedin.getLinkedInConversationHistoryPageInternal,
+              {
+                userId: args.userId,
+                prospectId: args.prospectId,
+                cursor,
+                limit: AGENT_PROVIDER_HISTORY_PAGE_SIZE,
+                ...(typeof args.sinceMs === "number"
+                  ? { sinceMs: args.sinceMs }
+                  : {}),
+              }
+            );
+      pagesFetched += 1;
+      if (!page) {
+        break;
+      }
+      providerItems.push(
+        ...page.messages.map((message) =>
+          normalizeProviderMessage(platform, message)
+        )
+      );
+      cursor = page.history.nextCursor;
+      if (typeof args.sinceMs !== "number" || !page.history.hasMore) {
+        break;
+      }
+    }
+
+    pagination.set(platform, {
+      historyNextCursor: page?.history.nextCursor,
+      historyHasMore: page?.history.hasMore ?? false,
+      historyBoundary: page?.history.boundary ?? cached?.historyBoundary,
+      providerPagesFetched: pagesFetched,
+      providerPageLimitReached: Boolean(cursor) && pagesFetched >= pageBudget,
+    });
+  }
+
+  return { providerItems, pagination };
+}
+
 export const getProspectInteractionHistory = createTool({
   description:
-    "Read the actual interaction history between the workspace user and the selected prospect: X/LinkedIn DMs, comments, and replies, including direction and timestamps. Use this before answering what was said, what happened, who replied, or how the relationship has progressed. The selected prospect is resolved from the current prospect thread or an explicit tag in the main workspace thread.",
+    "Read the actual interaction history between the workspace user and the selected prospect: X/Twitter or LinkedIn DMs, comments, and replies, including direction and timestamps. Use this before answering what was said, what happened, who replied, or how the relationship has progressed. For older DMs, pass the opaque cursor returned in coverage with exactly one platform; for a date range, pass since and inspect coverage for provider limits. You must disclose x_30_day_limit when X/Twitter coverage reports it. The selected prospect is resolved from the current prospect thread or an explicit tag in the main workspace thread.",
   inputSchema: z.object({
     platform: platformSchema
       .optional()
@@ -78,6 +259,20 @@ export const getProspectInteractionHistory = createTool({
       .optional()
       .default(20)
       .describe("Maximum number of interactions to return."),
+    since: z
+      .string()
+      .datetime({ offset: true })
+      .optional()
+      .describe(
+        "Optional ISO-8601 lower time boundary. The tool deliberately reads up to four bounded older DM pages to reach it."
+      ),
+    cursor: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "Opaque older-DM cursor returned in coverage. Only valid with one platform and when DMs are included."
+      ),
     refresh: z
       .boolean()
       .optional()
@@ -112,8 +307,31 @@ export const getProspectInteractionHistory = createTool({
 
       const userId = ctx.userId as Id<"users">;
       const prospectId = selected.prospectId;
+      if (args.cursor && args.platform === "all") {
+        return {
+          success: false as const,
+          history: null,
+          error:
+            "An older-DM cursor is scoped to one platform. Choose X/Twitter or LinkedIn.",
+        };
+      }
+      if (args.cursor && !args.kinds.includes("dm")) {
+        return {
+          success: false as const,
+          history: null,
+          error: "An older-DM cursor can only be used when DMs are included.",
+        };
+      }
+      const sinceMs = args.since ? parseIsoToTimestamp(args.since) : undefined;
+      if (args.since && typeof sinceMs !== "number") {
+        return {
+          success: false as const,
+          history: null,
+          error: "The since value must be a valid ISO-8601 timestamp.",
+        };
+      }
       const refreshWarnings: string[] = [];
-      if (args.refresh && args.kinds.includes("dm")) {
+      if (args.refresh && !args.cursor && args.kinds.includes("dm")) {
         const refreshes: Array<Promise<unknown>> = [];
         if (args.platform === "all" || args.platform === "twitter") {
           refreshes.push(
@@ -154,6 +372,7 @@ export const getProspectInteractionHistory = createTool({
             kinds: args.kinds,
             direction: args.direction,
             limit: args.limit,
+            sinceMs,
           }
         );
       if (!history) {
@@ -164,9 +383,59 @@ export const getProspectInteractionHistory = createTool({
         };
       }
 
+      if (args.cursor) {
+        if (
+          args.platform === "all" ||
+          !isCurrentConversationHistoryCursor({
+            cursor: args.cursor,
+            platform: args.platform,
+            coverage: history.coverage,
+          })
+        ) {
+          return {
+            success: false as const,
+            history: null,
+            error:
+              "That older-DM cursor is no longer valid. Start a fresh history read.",
+          };
+        }
+      }
+
+      const providerRead = await readProviderDmPages({
+        ctx,
+        userId,
+        prospectId,
+        platform: args.platform,
+        cursor: args.cursor,
+        sinceMs,
+        cachedCoverage: history.coverage,
+      });
+      const merged = mergeHistoryItems({
+        cached: history.items,
+        provider: providerRead.providerItems,
+        direction: args.direction,
+        limit: args.limit,
+      });
+      const coverage = history.coverage.map((coverageItem) => {
+        const providerPagination = providerRead.pagination.get(
+          coverageItem.platform
+        );
+        return providerPagination
+          ? { ...coverageItem, ...providerPagination }
+          : coverageItem;
+      });
+
       return {
         success: true as const,
-        history,
+        history: {
+          ...history,
+          ...merged,
+          truncated:
+            history.truncated ||
+            merged.truncated ||
+            coverage.some((coverageItem) => coverageItem.historyHasMore),
+          coverage,
+        },
         refreshWarnings,
       };
     } catch (error) {

--- a/convex/chat.ts
+++ b/convex/chat.ts
@@ -1645,45 +1645,132 @@ async function finalizePendingAssistantMessageForOrder(
   );
 
   if (!pendingMessage) {
+    await deleteAbortedStreamsForOrder(ctx, {
+      threadId: args.threadId,
+      order: args.order,
+    });
     return false;
   }
 
-  await ctx.runMutation(components.agent.messages.finalizeMessage, {
-    messageId: pendingMessage._id,
-    result: {
-      status: "failed",
-      error: args.errorMessage,
-    },
-  });
-
-  const [updatedMessage] = await ctx.runQuery(
-    components.agent.messages.getMessagesByIds,
-    {
-      messageIds: [pendingMessage._id],
-    }
-  );
-
   const visibleMessage = args.userVisibleMessage?.trim();
-  if (
-    updatedMessage &&
-    visibleMessage &&
-    (!updatedMessage.text || updatedMessage.text.trim().length === 0)
-  ) {
+
+  try {
+    await ctx.runMutation(components.agent.messages.finalizeMessage, {
+      messageId: pendingMessage._id,
+      result: {
+        status: "failed",
+        error: args.errorMessage,
+      },
+    });
+
+    const [updatedMessage] = await ctx.runQuery(
+      components.agent.messages.getMessagesByIds,
+      {
+        messageIds: [pendingMessage._id],
+      }
+    );
+
+    if (
+      updatedMessage &&
+      visibleMessage &&
+      (!updatedMessage.text || updatedMessage.text.trim().length === 0)
+    ) {
+      await ctx.runMutation(components.agent.messages.updateMessage, {
+        messageId: pendingMessage._id,
+        patch: {
+          status: "failed",
+          error: args.errorMessage,
+          finishReason: "error",
+          message: {
+            role: "assistant",
+            content: visibleMessage,
+          },
+        },
+      });
+    }
+
+    return true;
+  } catch (error) {
+    // Agent's finalizeMessage replays any stored stream deltas when the
+    // pending message has no text. An already-failed AI SDK stream contains
+    // an `error` delta, which makes that replay throw again. Mark the message
+    // failed directly so recovery itself cannot remain stuck on the original
+    // stream error.
+    chatLogger.warn(
+      "Could not replay failed assistant stream; marking it failed directly",
+      {
+        threadId: args.threadId,
+        order: args.order,
+        messageId: pendingMessage._id,
+        errorMessage: stringifyUnknownError(error),
+      }
+    );
+
     await ctx.runMutation(components.agent.messages.updateMessage, {
       messageId: pendingMessage._id,
       patch: {
         status: "failed",
         error: args.errorMessage,
         finishReason: "error",
-        message: {
-          role: "assistant",
-          content: visibleMessage,
-        },
+        ...(visibleMessage
+          ? {
+              message: {
+                role: "assistant" as const,
+                content: visibleMessage,
+              },
+            }
+          : {}),
       },
     });
+
+    await deleteAbortedStreamsForOrder(ctx, {
+      threadId: args.threadId,
+      order: args.order,
+    });
+
+    return true;
+  }
+}
+
+async function deleteAbortedStreamsForOrder(
+  ctx: MutationCtx,
+  args: { threadId: string; order: number }
+) {
+  let abortedStreams: Awaited<
+    ReturnType<typeof ctx.runQuery<typeof components.agent.streams.list>>
+  >;
+  try {
+    abortedStreams = await ctx.runQuery(components.agent.streams.list, {
+      threadId: args.threadId,
+      statuses: ["aborted"],
+    });
+  } catch (error) {
+    chatLogger.warn("Could not list aborted assistant streams", {
+      threadId: args.threadId,
+      order: args.order,
+      errorMessage: stringifyUnknownError(error),
+    });
+    return;
   }
 
-  return true;
+  for (const stream of abortedStreams) {
+    if (stream.order !== args.order) continue;
+
+    try {
+      await ctx.runMutation(components.agent.streams.deleteStreamSync, {
+        streamId: stream.streamId,
+      });
+    } catch (error) {
+      // Stream cleanup is best effort. The failed message is already
+      // recoverable, and a cleanup race must not resurrect the original error.
+      chatLogger.warn("Could not clean up an aborted assistant stream", {
+        threadId: args.threadId,
+        order: args.order,
+        streamId: stream.streamId,
+        errorMessage: stringifyUnknownError(error),
+      });
+    }
+  }
 }
 
 type ThreadHistoryLinkRow = Pick<

--- a/convex/chatGenerationRecovery.integration.test.ts
+++ b/convex/chatGenerationRecovery.integration.test.ts
@@ -1,0 +1,124 @@
+/// <reference types="vite/client" />
+
+import { convexTest } from "convex-test";
+import agentTest from "@convex-dev/agent/test";
+import { createThread, saveMessages } from "@convex-dev/agent";
+import { describe, expect, test, vi } from "vitest";
+import { api, components } from "./_generated/api";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+
+vi.stubEnv("OPENROUTER_API_KEY", "generation-recovery-test-key");
+vi.stubEnv("OPENAI_API_KEY", "generation-recovery-test-key");
+
+describe("agent generation recovery", () => {
+  test("marks a pending message failed when stream replay contains an error chunk", async () => {
+    const t = convexTest(schema, modules);
+    agentTest.register(t);
+
+    const seeded = await t.run(async (ctx) => {
+      const userId = await ctx.db.insert("users", {
+        workosUserId: "generation-recovery-user",
+        email: "generation-recovery@example.com",
+      });
+      const threadId = await createThread(ctx, components.agent, {
+        userId: String(userId),
+      });
+      const saved = await saveMessages(ctx, components.agent, {
+        threadId,
+        userId: String(userId),
+        messages: [
+          { role: "user", content: "Trigger a generation." },
+          { role: "assistant", content: [] },
+        ],
+        metadata: [{}, { status: "pending" }],
+      });
+      const pendingMessage = saved.messages[saved.messages.length - 1];
+      if (!pendingMessage) {
+        throw new Error("Expected a pending assistant message.");
+      }
+
+      return {
+        workosUserId: "generation-recovery-user",
+        threadId,
+        messageId: pendingMessage._id,
+        order: pendingMessage.order,
+        stepOrder: pendingMessage.stepOrder,
+        userId: String(userId),
+      };
+    });
+
+    const streamId = await t.mutation(components.agent.streams.create, {
+      threadId: seeded.threadId,
+      order: seeded.order,
+      stepOrder: seeded.stepOrder,
+      format: "UIMessageChunk",
+      userId: seeded.userId,
+    });
+    await t.mutation(components.agent.streams.addDelta, {
+      streamId,
+      start: 0,
+      end: 1,
+      parts: [{ type: "start" }],
+    });
+    await t.mutation(components.agent.streams.addDelta, {
+      streamId,
+      start: 1,
+      end: 2,
+      parts: [{ type: "error", errorText: "An error occurred." }],
+    });
+    await t.mutation(components.agent.streams.abort, {
+      streamId,
+      reason: "Uncaught Error: An error occurred.",
+    });
+
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const consoleWarn = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    let result: {
+      resolved: boolean;
+      order?: number;
+      reason?: "still_streaming" | "no_pending_message";
+    };
+    try {
+      result = await t
+        .withIdentity({ subject: seeded.workosUserId })
+        .mutation(api.chat.reconcileThreadGenerationFailure, {
+          threadId: seeded.threadId,
+          order: seeded.order,
+        });
+    } finally {
+      consoleError.mockRestore();
+      consoleWarn.mockRestore();
+    }
+
+    expect(result).toEqual({
+      resolved: true,
+      order: seeded.order,
+    });
+
+    const [message] = await t.run((ctx) =>
+      ctx.runQuery(components.agent.messages.getMessagesByIds, {
+        messageIds: [seeded.messageId],
+      })
+    );
+    expect(message).toMatchObject({
+      _id: seeded.messageId,
+      status: "failed",
+      finishReason: "error",
+      text: "That response took too long and stopped before it finished. Please try again.",
+    });
+
+    const abortedStreams = await t.query(components.agent.streams.list, {
+      threadId: seeded.threadId,
+      statuses: ["aborted"],
+    });
+    expect(
+      abortedStreams.filter((stream) => stream.order === seeded.order)
+    ).toEqual([]);
+  });
+});

--- a/convex/interactions.ts
+++ b/convex/interactions.ts
@@ -42,6 +42,7 @@ export const getProspectInteractionHistoryInternal = internalQuery({
     kinds: v.array(prospectInteractionHistoryKindValidator),
     direction: prospectInteractionHistoryDirectionValidator,
     limit: v.number(),
+    sinceMs: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     const prospect = await ctx.db.get(args.prospectId);
@@ -88,9 +89,14 @@ export const getProspectInteractionHistoryInternal = internalQuery({
           ctx.db
             .query("platformConversationMessages")
             .withIndex("by_user_conversation_created_at", (q) =>
-              q
-                .eq("userId", args.userId)
-                .eq("conversationId", conversation.conversationId)
+              typeof args.sinceMs === "number"
+                ? q
+                    .eq("userId", args.userId)
+                    .eq("conversationId", conversation.conversationId)
+                    .gte("createdAtMs", args.sinceMs)
+                : q
+                    .eq("userId", args.userId)
+                    .eq("conversationId", conversation.conversationId)
             )
             .order("desc")
             .take(candidateLimit)
@@ -101,8 +107,13 @@ export const getProspectInteractionHistoryInternal = internalQuery({
     const publicInteractions = includePublicInteractions
       ? await ctx.db
           .query("prospectInteractions")
-          .withIndex("by_prospect_replied", (q) =>
-            q.eq("prospectId", args.prospectId)
+          .withIndex("by_user_prospect_replied", (q) =>
+            typeof args.sinceMs === "number"
+              ? q
+                  .eq("userId", args.userId)
+                  .eq("prospectId", args.prospectId)
+                  .gte("repliedAt", args.sinceMs)
+              : q.eq("userId", args.userId).eq("prospectId", args.prospectId)
           )
           .order("desc")
           .take(candidateLimit)
@@ -111,9 +122,7 @@ export const getProspectInteractionHistoryInternal = internalQuery({
     const filtered = filterProspectInteractionHistory({
       items: [
         ...conversationMessages.map(normalizeConversationMessage),
-        ...publicInteractions
-          .filter((interaction) => interaction.userId === args.userId)
-          .map(normalizePublicInteraction),
+        ...publicInteractions.map(normalizePublicInteraction),
       ],
       platform: args.platform,
       kinds: args.kinds,
@@ -137,6 +146,13 @@ export const getProspectInteractionHistoryInternal = internalQuery({
           lastSyncSuccessAt: conversation?.lastSyncSuccessAt,
           lastSyncAttemptAt: conversation?.lastSyncAttemptAt,
           syncError: conversation?.lastSyncErrorMessage,
+          historyNextCursor:
+            conversation?.historyHasMore === true
+              ? conversation.historyNextCursor
+              : undefined,
+          historyHasMore: conversation?.historyHasMore === true,
+          historyBoundary: conversation?.historyBoundary,
+          historyOldestLoadedAt: conversation?.historyOldestLoadedAt,
         };
       }),
       queriedAt: getCurrentUTCTimestamp(),

--- a/convex/lib/conversationHistoryPaginationCore.test.ts
+++ b/convex/lib/conversationHistoryPaginationCore.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "vitest";
+import {
+  DEFAULT_CONVERSATION_HISTORY_PAGE_SIZE,
+  applyConversationHistorySince,
+  buildConversationHistoryPageMetadata,
+  getProviderPageCursor,
+  isCurrentConversationHistoryCursor,
+  normalizeConversationHistoryPageLimit,
+  selectDeterministicLinkedInChat,
+  shouldPersistRecentConversationHistoryPage,
+} from "./conversationHistoryPaginationCore";
+
+describe("conversation history pagination", () => {
+  test("keeps provider pages bounded and preserves opaque cursors", () => {
+    expect(normalizeConversationHistoryPageLimit()).toBe(
+      DEFAULT_CONVERSATION_HISTORY_PAGE_SIZE
+    );
+    expect(normalizeConversationHistoryPageLimit(500)).toBe(50);
+    expect(normalizeConversationHistoryPageLimit(0)).toBe(1);
+    expect(
+      getProviderPageCursor({ meta: { next_token: "x-provider-cursor" } })
+    ).toBe("x-provider-cursor");
+    expect(getProviderPageCursor({ cursor: "unipile-cursor" })).toBe(
+      "unipile-cursor"
+    );
+  });
+
+  test("stops a date-range read at the requested lower boundary", () => {
+    const result = applyConversationHistorySince(
+      [
+        { createdAt: "2026-01-01T00:00:00.000Z", id: "old" },
+        { createdAt: "2026-02-01T00:00:00.000Z", id: "new" },
+      ],
+      Date.parse("2026-01-15T00:00:00.000Z")
+    );
+
+    expect(result).toEqual({
+      items: [{ createdAt: "2026-02-01T00:00:00.000Z", id: "new" }],
+      reachedSince: true,
+    });
+    expect(
+      buildConversationHistoryPageMetadata({
+        providerCursor: "ignored-after-boundary",
+        reachedSince: true,
+        platform: "linkedin",
+      })
+    ).toEqual({ hasMore: false, boundary: "complete" });
+  });
+
+  test("reports the X 30-day boundary only after the provider is exhausted", () => {
+    expect(
+      buildConversationHistoryPageMetadata({
+        providerCursor: "next",
+        reachedSince: false,
+        platform: "twitter",
+      })
+    ).toEqual({ nextCursor: "next", hasMore: true });
+    expect(
+      buildConversationHistoryPageMetadata({
+        reachedSince: false,
+        platform: "twitter",
+      })
+    ).toEqual({ hasMore: false, boundary: "x_30_day_limit" });
+  });
+
+  test("selects the exact LinkedIn attendee chat deterministically", () => {
+    const selected = selectDeterministicLinkedInChat(
+      [
+        {
+          id: "other-person",
+          attendee_provider_id: "other",
+          timestamp: "2026-02-03T00:00:00.000Z",
+        },
+        {
+          id: "older-match",
+          attendee_provider_id: "prospect",
+          timestamp: "2026-02-01T00:00:00.000Z",
+        },
+        {
+          id: "newer-match",
+          attendee_provider_id: "prospect",
+          timestamp: "2026-02-02T00:00:00.000Z",
+        },
+      ],
+      "prospect"
+    );
+
+    expect(selected?.id).toBe("newer-match");
+  });
+
+  test("never persists a continuation or date-range provider page", () => {
+    expect(shouldPersistRecentConversationHistoryPage({})).toBe(true);
+    expect(
+      shouldPersistRecentConversationHistoryPage({ cursor: "older-page" })
+    ).toBe(false);
+    expect(shouldPersistRecentConversationHistoryPage({ sinceMs: 1 })).toBe(
+      false
+    );
+  });
+
+  test("accepts only the current cursor for the selected platform", () => {
+    const coverage = [
+      { platform: "twitter" as const, historyNextCursor: "x-next" },
+      { platform: "linkedin" as const, historyNextCursor: "li-next" },
+    ];
+
+    expect(
+      isCurrentConversationHistoryCursor({
+        cursor: "x-next",
+        platform: "twitter",
+        coverage,
+      })
+    ).toBe(true);
+    expect(
+      isCurrentConversationHistoryCursor({
+        cursor: "li-next",
+        platform: "twitter",
+        coverage,
+      })
+    ).toBe(false);
+    expect(
+      isCurrentConversationHistoryCursor({
+        cursor: "hallucinated",
+        platform: "linkedin",
+        coverage,
+      })
+    ).toBe(false);
+  });
+});

--- a/convex/lib/conversationHistoryPaginationCore.ts
+++ b/convex/lib/conversationHistoryPaginationCore.ts
@@ -1,0 +1,169 @@
+import { parseIsoToTimestamp } from "../../shared/lib/utils/time/timeUtils";
+import { getNestedRecord, getStringProperty } from "./typeGuards";
+
+/** Keep provider reads small enough for panels and agent tools. */
+export const DEFAULT_CONVERSATION_HISTORY_PAGE_SIZE = 25;
+export const MAX_CONVERSATION_HISTORY_PAGE_SIZE = 50;
+
+export type ConversationHistoryBoundary = "complete" | "x_30_day_limit";
+
+export type ConversationHistoryPageMetadata = {
+  nextCursor?: string;
+  hasMore: boolean;
+  boundary?: ConversationHistoryBoundary;
+};
+
+export type ConversationHistoryCoverageCursor = {
+  platform: "twitter" | "linkedin";
+  historyNextCursor?: string;
+};
+
+type DatedConversationItem = {
+  createdAt?: string;
+};
+
+type LinkedInChatLike = {
+  id: string;
+  attendee_provider_id?: string;
+  timestamp?: string | null;
+};
+
+/** Normalize callers to one bounded provider page. */
+export function normalizeConversationHistoryPageLimit(limit?: number): number {
+  if (!Number.isFinite(limit)) {
+    return DEFAULT_CONVERSATION_HISTORY_PAGE_SIZE;
+  }
+
+  return Math.min(
+    MAX_CONVERSATION_HISTORY_PAGE_SIZE,
+    Math.max(1, Math.trunc(limit ?? DEFAULT_CONVERSATION_HISTORY_PAGE_SIZE))
+  );
+}
+
+/** Only the current recent page is a panel/realtime cache; older pages stay provider-sourced. */
+export function shouldPersistRecentConversationHistoryPage(args: {
+  cursor?: string;
+  sinceMs?: number;
+}): boolean {
+  return !args.cursor && typeof args.sinceMs !== "number";
+}
+
+/**
+ * Provider cursors are opaque and only remain valid for the platform/page
+ * snapshot that produced them. Reject stale or cross-platform values before
+ * they reach a provider API.
+ */
+export function isCurrentConversationHistoryCursor(args: {
+  cursor: string;
+  platform: "twitter" | "linkedin";
+  coverage: ConversationHistoryCoverageCursor[];
+}): boolean {
+  return (
+    args.coverage.find((item) => item.platform === args.platform)
+      ?.historyNextCursor === args.cursor
+  );
+}
+
+/**
+ * XDK exposes X `meta.next_token` as either camelCase or snake_case. Unipile
+ * exposes its opaque cursor at the top level. Keep the provider token opaque.
+ */
+export function getProviderPageCursor(payload: unknown): string | undefined {
+  const meta = getNestedRecord(payload, "meta");
+  const candidates = [
+    getStringProperty(meta, "nextToken"),
+    getStringProperty(meta, "next_token"),
+    getStringProperty(meta, "paginationToken"),
+    getStringProperty(payload, "cursor"),
+    getStringProperty(payload, "nextCursor"),
+    getStringProperty(payload, "next_cursor"),
+  ];
+  return candidates
+    .map((candidate) => candidate?.trim())
+    .find((candidate): candidate is string => Boolean(candidate));
+}
+
+/**
+ * Stop at a caller's lower date boundary without pretending that older provider
+ * history was read. Items remain in ascending chronological order.
+ */
+export function applyConversationHistorySince<T extends DatedConversationItem>(
+  items: T[],
+  sinceMs?: number
+): { items: T[]; reachedSince: boolean } {
+  if (typeof sinceMs !== "number" || !Number.isFinite(sinceMs)) {
+    return { items, reachedSince: false };
+  }
+
+  let reachedSince = false;
+  const filtered = items.filter((item) => {
+    const occurredAt = item.createdAt
+      ? parseIsoToTimestamp(item.createdAt)
+      : undefined;
+    if (typeof occurredAt !== "number") {
+      return true;
+    }
+    if (occurredAt < sinceMs) {
+      reachedSince = true;
+      return false;
+    }
+    return true;
+  });
+
+  return { items: filtered, reachedSince };
+}
+
+/** Build a consistent panel contract while retaining platform limits. */
+export function buildConversationHistoryPageMetadata(args: {
+  providerCursor?: string;
+  reachedSince: boolean;
+  platform: "twitter" | "linkedin";
+}): ConversationHistoryPageMetadata {
+  const hasMore = Boolean(args.providerCursor) && !args.reachedSince;
+  return {
+    nextCursor: hasMore ? args.providerCursor : undefined,
+    hasMore,
+    ...(hasMore
+      ? {}
+      : {
+          boundary: args.platform === "twitter" ? "x_30_day_limit" : "complete",
+        }),
+  };
+}
+
+/**
+ * A provider attendee result can contain multiple chats. Never trust provider
+ * ordering: use the exact attendee provider id, then newest timestamp, then a
+ * stable id tie-breaker.
+ */
+export function selectDeterministicLinkedInChat<T extends LinkedInChatLike>(
+  chats: T[],
+  attendeeProviderId: string
+): T | null {
+  const target = attendeeProviderId.trim();
+  if (!target) {
+    return null;
+  }
+
+  const matching = chats.filter(
+    (chat) => chat.attendee_provider_id?.trim() === target
+  );
+  if (matching.length === 0) {
+    return null;
+  }
+
+  return (
+    [...matching].sort((left, right) => {
+      const rightMs = right.timestamp
+        ? (parseIsoToTimestamp(right.timestamp) ?? 0)
+        : 0;
+      const leftMs = left.timestamp
+        ? (parseIsoToTimestamp(left.timestamp) ?? 0)
+        : 0;
+      if (rightMs !== leftMs) {
+        return rightMs - leftMs;
+      }
+      return left.id.localeCompare(right.id);
+    })[0] ?? null
+  );
+}

--- a/convex/lib/linkedinWebhookCore.test.ts
+++ b/convex/lib/linkedinWebhookCore.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "vitest";
+import {
+  getWebhookMessageDirection,
+  getWebhookParticipantProviderId,
+} from "./linkedinWebhookCore";
+
+describe("Unipile v1 message_received payloads", () => {
+  const account = { providerId: "stored-account-provider" };
+
+  test("classifies a sent message from documented account_info and sender fields", () => {
+    const payload = {
+      event: "message_received",
+      account_info: { user_id: "mailbox-owner" },
+      sender: { attendee_provider_id: "mailbox-owner" },
+      attendees: [{ attendee_provider_id: "prospect-provider" }],
+    };
+
+    expect(getWebhookMessageDirection(payload, account)).toBe("sent");
+    expect(getWebhookParticipantProviderId(payload, account)).toBe(
+      "prospect-provider"
+    );
+  });
+
+  test("classifies an inbound message and maps the sender as the prospect", () => {
+    const payload = {
+      event: "message_received",
+      account_info: { user_id: "mailbox-owner" },
+      sender: { attendee_provider_id: "prospect-provider" },
+    };
+
+    expect(getWebhookMessageDirection(payload, account)).toBe("received");
+    expect(getWebhookParticipantProviderId(payload, account)).toBe(
+      "prospect-provider"
+    );
+  });
+
+  test("honors an explicit sender flag before fallback state", () => {
+    expect(
+      getWebhookMessageDirection(
+        { is_sender: 1, sender: { attendee_provider_id: "prospect-provider" } },
+        account,
+        "received"
+      )
+    ).toBe("sent");
+  });
+});

--- a/convex/lib/linkedinWebhookCore.ts
+++ b/convex/lib/linkedinWebhookCore.ts
@@ -75,26 +75,46 @@ export function getWebhookParticipantProviderId(
   payload: unknown,
   linkedAccount: LinkedInWebhookAccount
 ): string | undefined {
-  const accountProviderId = linkedAccount.providerId?.trim();
+  const accountInfo = getNestedRecord(payload, "account_info");
+  const ownProviderIds = new Set(
+    [
+      linkedAccount.providerId,
+      getWebhookString(accountInfo, "user_id", "provider_id", "id"),
+    ]
+      .map((value) => value?.trim())
+      .filter((value): value is string => Boolean(value))
+  );
+  const isOtherParticipant = (value?: string) =>
+    Boolean(value && !ownProviderIds.has(value));
   const userProviderId = getWebhookString(
     payload,
     "user_provider_id",
     "userProviderId"
   );
-  if (userProviderId && userProviderId !== accountProviderId) {
+  if (isOtherParticipant(userProviderId)) {
     return userProviderId;
   }
 
   const sender = getNestedRecord(payload, "sender");
-  const senderProviderId = getWebhookString(sender, "provider_id", "id");
-  if (senderProviderId && senderProviderId !== accountProviderId) {
+  const senderProviderId = getWebhookString(
+    sender,
+    "attendee_provider_id",
+    "provider_id",
+    "id"
+  );
+  if (isOtherParticipant(senderProviderId)) {
     return senderProviderId;
   }
 
   const attendees = getWebhookArray(payload, "attendees");
   for (const attendee of attendees) {
-    const providerId = getWebhookString(attendee, "provider_id", "id");
-    if (providerId && providerId !== accountProviderId) {
+    const providerId = getWebhookString(
+      attendee,
+      "attendee_provider_id",
+      "provider_id",
+      "id"
+    );
+    if (isOtherParticipant(providerId)) {
       return providerId;
     }
   }
@@ -104,7 +124,7 @@ export function getWebhookParticipantProviderId(
     "attendee_provider_id",
     "attendee_id"
   );
-  if (attendeeProviderId && attendeeProviderId !== accountProviderId) {
+  if (isOtherParticipant(attendeeProviderId)) {
     return attendeeProviderId;
   }
 
@@ -135,17 +155,27 @@ export function getWebhookMessageDirection(
     return explicitDirection ? "sent" : "received";
   }
 
-  if (knownDirection) {
-    return knownDirection;
+  const event = getWebhookString(payload, "event", "type", "name");
+  if (event === "message_sent") {
+    return "sent";
   }
 
+  // Unipile's documented v1 messaging shape identifies the mailbox owner at
+  // account_info.user_id and the sender at sender.attendee_provider_id.
+  const accountInfo = getNestedRecord(payload, "account_info");
+  const accountProviderId =
+    getWebhookString(accountInfo, "user_id", "provider_id", "id") ??
+    linkedAccount.providerId?.trim();
+  const sender = getNestedRecord(payload, "sender");
   const senderProviderId = getWebhookString(
-    getNestedRecord(payload, "sender"),
+    sender,
+    "attendee_provider_id",
     "provider_id",
     "id"
   );
-  return senderProviderId &&
-    senderProviderId === linkedAccount.providerId?.trim()
-    ? "sent"
-    : "received";
+  if (senderProviderId && accountProviderId) {
+    return senderProviderId === accountProviderId ? "sent" : "received";
+  }
+
+  return knownDirection ?? "received";
 }

--- a/convex/lib/prospectInteractionHistoryCore.ts
+++ b/convex/lib/prospectInteractionHistoryCore.ts
@@ -17,6 +17,8 @@ export type ProspectInteractionHistoryDirection = Infer<
 >;
 
 export type ProspectInteractionHistoryItem = {
+  /** Stable provider/document id used to deduplicate cached and live pages. */
+  id: string;
   kind: ProspectInteractionHistoryKind;
   platform: "twitter" | "linkedin";
   direction: "sent" | "received";
@@ -37,6 +39,7 @@ type ConversationMessage = Pick<
   | "attachments"
   | "readAt"
   | "deliveredAt"
+  | "messageId"
 >;
 
 type PublicInteraction = Pick<
@@ -51,6 +54,7 @@ type PublicInteraction = Pick<
   | "replyPostRef"
   | "sourceUrl"
   | "status"
+  | "_id"
 >;
 
 function normalizeOptionalText(value: string | undefined) {
@@ -71,6 +75,7 @@ export function normalizeConversationMessage(
       : "received";
 
   return {
+    id: message.messageId,
     kind: "dm",
     platform: message.platform,
     direction: message.direction,
@@ -90,6 +95,7 @@ export function normalizePublicInteraction(
   const direction = interaction.direction === "incoming" ? "received" : "sent";
 
   return {
+    id: String(interaction._id),
     kind,
     platform: interaction.platform,
     direction,

--- a/convex/lib/unipileClient.ts
+++ b/convex/lib/unipileClient.ts
@@ -5,6 +5,7 @@ import {
   UnipileClient,
   UnipileError as SdkUnipileError,
 } from "unipile-node-sdk";
+import { normalizeConversationHistoryPageLimit } from "./conversationHistoryPaginationCore";
 
 const DEFAULT_HOSTED_AUTH_EXPIRY_MS = 1000 * 60 * 30;
 
@@ -192,6 +193,11 @@ export type UnipileMessage = {
   quoted?: {
     message_id?: string;
   } | null;
+};
+
+export type UnipilePage<T> = {
+  items: T[];
+  cursor?: string;
 };
 
 export type LinkedInUnipilePost = {
@@ -688,33 +694,60 @@ export async function getLinkedInOwnProfile(accountId: string) {
   });
 }
 
-export async function listLinkedInChats(args: {
+export async function listLinkedInChatsPage(args: {
   accountId: string;
   limit?: number;
-}): Promise<UnipileChat[]> {
+  cursor?: string;
+}): Promise<UnipilePage<UnipileChat>> {
   return await withUnipileErrorHandling(async () => {
     const payload = await getUnipileClient().messaging.getAllChats({
       account_type: "LINKEDIN",
       account_id: args.accountId,
       limit: args.limit ?? 100,
+      cursor: args.cursor,
     });
-    return payload.items as UnipileChat[];
+    return {
+      items: payload.items as UnipileChat[],
+      cursor: typeof payload.cursor === "string" ? payload.cursor : undefined,
+    };
   });
 }
 
-export async function listLinkedInChatsForAttendee(args: {
-  attendeeId: string;
+/** @deprecated Use listLinkedInChatsPage so callers retain the provider cursor. */
+export async function listLinkedInChats(args: {
   accountId: string;
   limit?: number;
 }): Promise<UnipileChat[]> {
+  return (await listLinkedInChatsPage(args)).items;
+}
+
+export async function listLinkedInChatsForAttendeePage(args: {
+  attendeeId: string;
+  accountId: string;
+  limit?: number;
+  cursor?: string;
+}): Promise<UnipilePage<UnipileChat>> {
   return await withUnipileErrorHandling(async () => {
     const payload = await getUnipileClient().messaging.getAllChatsFromAttendee({
       attendee_id: args.attendeeId,
       account_id: args.accountId,
       limit: args.limit ?? 50,
+      cursor: args.cursor,
     });
-    return payload.items as UnipileChat[];
+    return {
+      items: payload.items as UnipileChat[],
+      cursor: typeof payload.cursor === "string" ? payload.cursor : undefined,
+    };
   });
+}
+
+/** @deprecated Use listLinkedInChatsForAttendeePage so callers retain the provider cursor. */
+export async function listLinkedInChatsForAttendee(args: {
+  attendeeId: string;
+  accountId: string;
+  limit?: number;
+}): Promise<UnipileChat[]> {
+  return (await listLinkedInChatsForAttendeePage(args)).items;
 }
 
 /**
@@ -736,17 +769,34 @@ export async function listLinkedInChatsForAttendeeOrEmpty(args: {
   }
 }
 
+export async function listLinkedInChatMessagesPage(args: {
+  chatId: string;
+  limit?: number;
+  cursor?: string;
+  before?: string;
+  after?: string;
+}): Promise<UnipilePage<UnipileMessage>> {
+  return await withUnipileErrorHandling(async () => {
+    const payload = await getUnipileClient().messaging.getAllMessagesFromChat({
+      chat_id: args.chatId,
+      limit: normalizeConversationHistoryPageLimit(args.limit),
+      cursor: args.cursor,
+      before: args.before,
+      after: args.after,
+    });
+    return {
+      items: payload.items as unknown as UnipileMessage[],
+      cursor: typeof payload.cursor === "string" ? payload.cursor : undefined,
+    };
+  });
+}
+
+/** @deprecated Use listLinkedInChatMessagesPage so callers retain the provider cursor. */
 export async function listLinkedInChatMessages(args: {
   chatId: string;
   limit?: number;
 }): Promise<UnipileMessage[]> {
-  return await withUnipileErrorHandling(async () => {
-    const payload = await getUnipileClient().messaging.getAllMessagesFromChat({
-      chat_id: args.chatId,
-      limit: args.limit ?? 100,
-    });
-    return payload.items as unknown as UnipileMessage[];
-  });
+  return (await listLinkedInChatMessagesPage(args)).items;
 }
 
 export async function startLinkedInChat(args: {

--- a/convex/lib/xActivity.ts
+++ b/convex/lib/xActivity.ts
@@ -1,3 +1,5 @@
+import { isRecord } from "./typeGuards";
+
 export const X_DM_ACTIVITY_EVENT_TYPES = [
   "dm.sent",
   "dm.received",
@@ -75,7 +77,7 @@ type XWebhookRecord = {
   createdAt?: string;
 };
 
-type XActivitySubscriptionRecord = {
+export type XActivitySubscriptionRecord = {
   subscriptionId: string;
   eventType: XActivityEventType;
   filterUserId?: string;
@@ -150,7 +152,7 @@ function normalizeSubscription(
     return null;
   }
 
-  const filter = input.filter as Record<string, unknown> | undefined;
+  const filter = isRecord(input.filter) ? input.filter : undefined;
   return {
     subscriptionId,
     eventType: eventType as XActivityEventType,
@@ -301,15 +303,86 @@ export async function validateXWebhook(
   return webhook;
 }
 
+const MAX_X_ACTIVITY_SUBSCRIPTION_PAGES = 10;
+
+/**
+ * X Activity lists are paginated. Reconcile a bounded complete listing so a
+ * duplicate that lives past the first page is found instead of retried forever.
+ */
 export async function listXActivitySubscriptions(): Promise<
   XActivitySubscriptionRecord[]
 > {
+  const subscriptions: XActivitySubscriptionRecord[] = [];
+  const seenTokens = new Set<string>();
+  let paginationToken: string | undefined;
+
+  for (
+    let pageNumber = 0;
+    pageNumber < MAX_X_ACTIVITY_SUBSCRIPTION_PAGES;
+    pageNumber += 1
+  ) {
+    const params = new URLSearchParams({ max_results: "100" });
+    if (paginationToken) {
+      params.set("pagination_token", paginationToken);
+    }
+    const response = await xActivityAppRequest<{
+      data?: Record<string, unknown>[];
+      meta?: { next_token?: string; nextToken?: string };
+      next_token?: string;
+      nextToken?: string;
+    }>(`/2/activity/subscriptions?${params.toString()}`);
+    subscriptions.push(
+      ...(response.data ?? [])
+        .map((item) => normalizeSubscription(item))
+        .filter((item): item is XActivitySubscriptionRecord => Boolean(item))
+    );
+
+    const nextToken =
+      typeof response.meta?.next_token === "string"
+        ? response.meta.next_token
+        : typeof response.meta?.nextToken === "string"
+          ? response.meta.nextToken
+          : typeof response.next_token === "string"
+            ? response.next_token
+            : typeof response.nextToken === "string"
+              ? response.nextToken
+              : undefined;
+    if (!nextToken || seenTokens.has(nextToken)) {
+      break;
+    }
+    seenTokens.add(nextToken);
+    paginationToken = nextToken;
+  }
+
+  return subscriptions;
+}
+
+export async function updateXActivitySubscription(args: {
+  subscriptionId: string;
+  webhookId: string;
+  tag: string;
+}): Promise<XActivitySubscriptionRecord> {
   const response = await xActivityAppRequest<{
-    data?: Record<string, unknown>[];
-  }>("/2/activity/subscriptions");
-  return (response.data ?? [])
-    .map((item) => normalizeSubscription(item))
-    .filter((item): item is XActivitySubscriptionRecord => Boolean(item));
+    data?: Record<string, unknown> | { subscription?: Record<string, unknown> };
+  }>(`/2/activity/subscriptions/${args.subscriptionId}`, {
+    method: "PUT",
+    body: JSON.stringify({ webhook_id: args.webhookId, tag: args.tag }),
+  });
+  const data = response.data;
+  const subscriptionPayload = isRecord(data)
+    ? isRecord(data.subscription)
+      ? data.subscription
+      : data
+    : undefined;
+  const subscription = subscriptionPayload
+    ? normalizeSubscription(subscriptionPayload)
+    : null;
+  if (!subscription) {
+    throw new Error(
+      "X/Twitter returned an invalid activity subscription update."
+    );
+  }
+  return subscription;
 }
 
 export async function createXActivitySubscription(args: {

--- a/convex/lib/xActivityReconciliationCore.test.ts
+++ b/convex/lib/xActivityReconciliationCore.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "vitest";
+import {
+  findMatchingXActivitySubscription,
+  isDuplicateXActivitySubscriptionError,
+} from "./xActivityReconciliationCore";
+
+describe("X Activity subscription reconciliation", () => {
+  const identity = {
+    eventType: "dm.sent" as const,
+    xUserId: "x-user",
+    webhookId: "target-webhook",
+    expectedTag: "reacher-x:x-user:dm.sent",
+  };
+
+  test("reconciles a matching subscription when X omits webhook_id from list", () => {
+    const match = findMatchingXActivitySubscription(
+      [
+        {
+          subscriptionId: "wrong-user",
+          eventType: "dm.sent",
+          filterUserId: "another-user",
+          webhookId: "target-webhook",
+        },
+        {
+          subscriptionId: "missing-webhook-id",
+          eventType: "dm.sent",
+          filterUserId: "x-user",
+        },
+      ],
+      identity
+    );
+
+    expect(match?.subscriptionId).toBe("missing-webhook-id");
+  });
+
+  test("prefers a known delivery target over a stale duplicate", () => {
+    const match = findMatchingXActivitySubscription(
+      [
+        {
+          subscriptionId: "stale",
+          eventType: "dm.sent",
+          filterUserId: "x-user",
+          webhookId: "stale-webhook",
+        },
+        {
+          subscriptionId: "current",
+          eventType: "dm.sent",
+          filterUserId: "x-user",
+          webhookId: "target-webhook",
+        },
+      ],
+      identity
+    );
+
+    expect(match?.subscriptionId).toBe("current");
+  });
+
+  test.each([
+    new Error("Duplicate subscription"),
+    new Error("Subscription already exists"),
+  ])("recognizes provider duplicate responses", (error) => {
+    expect(isDuplicateXActivitySubscriptionError(error)).toBe(true);
+  });
+});

--- a/convex/lib/xActivityReconciliationCore.ts
+++ b/convex/lib/xActivityReconciliationCore.ts
@@ -1,0 +1,46 @@
+export type XActivitySubscriptionCandidate<TEvent extends string = string> = {
+  eventType: TEvent;
+  filterUserId?: string;
+  webhookId?: string;
+  subscriptionId: string;
+  tag?: string;
+};
+
+/**
+ * Select an X Activity subscription by its immutable identity first. X's list
+ * response may omit `webhook_id`, so webhook equality cannot be a requirement
+ * for duplicate reconciliation.
+ */
+export function findMatchingXActivitySubscription<TEvent extends string>(
+  subscriptions: XActivitySubscriptionCandidate<TEvent>[],
+  args: {
+    eventType: TEvent;
+    xUserId: string;
+    webhookId: string;
+    expectedTag: string;
+  }
+): XActivitySubscriptionCandidate<TEvent> | undefined {
+  const candidates = subscriptions.filter(
+    (subscription) =>
+      subscription.eventType === args.eventType &&
+      subscription.filterUserId === args.xUserId
+  );
+
+  return (
+    candidates.find(
+      (subscription) => subscription.webhookId === args.webhookId
+    ) ??
+    candidates.find((subscription) => subscription.tag === args.expectedTag) ??
+    candidates.find((subscription) => !subscription.webhookId) ??
+    candidates[0]
+  );
+}
+
+export function isDuplicateXActivitySubscriptionError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  const normalized = message.toLowerCase();
+  return (
+    (normalized.includes("duplicate") && normalized.includes("subscription")) ||
+    normalized.includes("subscription already exists")
+  );
+}

--- a/convex/linkedin.ts
+++ b/convex/linkedin.ts
@@ -15,7 +15,7 @@ import {
   getLinkedInUserProfile,
   listLinkedInAccounts,
   listLinkedInPostComments,
-  listLinkedInChatMessages,
+  listLinkedInChatMessagesPage,
   listLinkedInChatsForAttendeeOrEmpty,
   reactToLinkedInPost,
   commentOnLinkedInPost,
@@ -30,6 +30,14 @@ import {
   type UnipileMessage,
   normalizeLinkedInReactionType,
 } from "./lib/unipileClient";
+import {
+  applyConversationHistorySince,
+  buildConversationHistoryPageMetadata,
+  getProviderPageCursor,
+  selectDeterministicLinkedInChat,
+  shouldPersistRecentConversationHistoryPage,
+  type ConversationHistoryPageMetadata,
+} from "./lib/conversationHistoryPaginationCore";
 import { getTwitterActionCatalogEntry } from "./lib/twitterActionCatalog";
 import type {
   LinkedInConversationAttachmentSummary,
@@ -76,6 +84,11 @@ import {
   getWebhookParticipantProviderId,
   getWebhookString,
 } from "./lib/linkedinWebhookCore";
+import { getNestedRecord } from "./lib/typeGuards";
+import {
+  getCurrentUTCTimestamp,
+  parseIsoToTimestamp,
+} from "../shared/lib/utils/time/timeUtils";
 
 async function getAccessibleDefaultWorkspaceForUserAction(
   ctx: any,
@@ -283,8 +296,7 @@ function toMs(timestamp?: string | number | null) {
   if (!timestamp) {
     return 0;
   }
-  const parsed = Date.parse(timestamp);
-  return Number.isFinite(parsed) ? parsed : 0;
+  return parseIsoToTimestamp(timestamp) ?? 0;
 }
 
 function logLinkedInWriteTiming(
@@ -907,7 +919,9 @@ async function selectRemoteAccountForUser(
     }
   }
 
-  return sorted[0] ?? null;
+  // Every remote account belongs to another local user. Never fall back to an
+  // arbitrary account: doing so would cross-wire a user's LinkedIn history.
+  return null;
 }
 
 function getLinkedInDisplayName(profile?: LinkedInOwnProfile | null) {
@@ -1581,6 +1595,51 @@ function normalizeMessage(
   };
 }
 
+type LinkedInConversationHistoryPage = {
+  messages: LinkedInConversationMessage[];
+  history: ConversationHistoryPageMetadata;
+  oldestLoadedAt?: number;
+};
+
+async function loadLinkedInConversationHistoryPage(args: {
+  chatId: string;
+  cursor?: string;
+  limit?: number;
+  sinceMs?: number;
+}): Promise<LinkedInConversationHistoryPage> {
+  const page = await listLinkedInChatMessagesPage({
+    chatId: args.chatId,
+    cursor: args.cursor,
+    limit: args.limit,
+  });
+  const normalized = page.items
+    .map(normalizeMessage)
+    .sort((left, right) => toMs(left.createdAt) - toMs(right.createdAt));
+  const { items: messages, reachedSince } = applyConversationHistorySince(
+    normalized,
+    args.sinceMs
+  );
+  const history = buildConversationHistoryPageMetadata({
+    providerCursor: getProviderPageCursor(page),
+    reachedSince,
+    platform: "linkedin",
+  });
+  const oldestLoadedAt = messages.reduce<number | undefined>(
+    (oldest, message) => {
+      const createdAtMs = toMs(message.createdAt);
+      if (createdAtMs <= 0) {
+        return oldest;
+      }
+      return typeof oldest === "number"
+        ? Math.min(oldest, createdAtMs)
+        : createdAtMs;
+    },
+    undefined
+  );
+
+  return { messages, history, oldestLoadedAt };
+}
+
 function toStoredMessages(messages: LinkedInConversationMessage[]) {
   return messages.map((message) => ({
     messageId: message.id,
@@ -1623,21 +1682,118 @@ function toCachedMessages(snapshot: any): LinkedInConversationMessage[] {
   }));
 }
 
-function getWebhookParticipantName(payload: any): string | undefined {
-  const senderName = getWebhookString(payload?.sender, "name", "attendee_name");
-  if (senderName) {
-    return senderName;
+function getWebhookParticipantName(
+  payload: unknown,
+  participantProviderId?: string
+): string | undefined {
+  const sender = getNestedRecord(payload, "sender");
+  const senderProviderId = getWebhookString(
+    sender,
+    "attendee_provider_id",
+    "provider_id",
+    "id"
+  );
+  if (!participantProviderId || senderProviderId === participantProviderId) {
+    const senderName = getWebhookString(sender, "name", "attendee_name");
+    if (senderName) {
+      return senderName;
+    }
   }
 
   const attendees = getWebhookArray(payload, "attendees");
   for (const attendee of attendees) {
+    const attendeeProviderId = getWebhookString(
+      attendee,
+      "attendee_provider_id",
+      "provider_id",
+      "id"
+    );
+    if (participantProviderId && attendeeProviderId !== participantProviderId) {
+      continue;
+    }
     const name = getWebhookString(attendee, "name", "attendee_name");
     if (name) {
       return name;
     }
   }
 
-  return getWebhookString(payload, "attendee_name");
+  return participantProviderId
+    ? undefined
+    : getWebhookString(payload, "attendee_name");
+}
+
+function getWebhookParticipantAvatarUrl(
+  payload: unknown,
+  participantProviderId?: string
+): string | undefined {
+  const sender = getNestedRecord(payload, "sender");
+  const senderProviderId = getWebhookString(
+    sender,
+    "attendee_provider_id",
+    "provider_id",
+    "id"
+  );
+  if (!participantProviderId || senderProviderId === participantProviderId) {
+    const senderAvatar = getWebhookString(sender, "picture_url");
+    if (senderAvatar) {
+      return senderAvatar;
+    }
+  }
+
+  for (const attendee of getWebhookArray(payload, "attendees")) {
+    const attendeeProviderId = getWebhookString(
+      attendee,
+      "attendee_provider_id",
+      "provider_id",
+      "id"
+    );
+    if (participantProviderId && attendeeProviderId !== participantProviderId) {
+      continue;
+    }
+    const avatar = getWebhookString(attendee, "picture_url");
+    if (avatar) {
+      return avatar;
+    }
+  }
+
+  return undefined;
+}
+
+function getWebhookParticipantProfileUrl(
+  payload: unknown,
+  participantProviderId?: string
+): string | undefined {
+  const sender = getNestedRecord(payload, "sender");
+  const senderProviderId = getWebhookString(
+    sender,
+    "attendee_provider_id",
+    "provider_id",
+    "id"
+  );
+  if (!participantProviderId || senderProviderId === participantProviderId) {
+    const senderProfileUrl = getWebhookString(sender, "profile_url");
+    if (senderProfileUrl) {
+      return senderProfileUrl;
+    }
+  }
+
+  for (const attendee of getWebhookArray(payload, "attendees")) {
+    const attendeeProviderId = getWebhookString(
+      attendee,
+      "attendee_provider_id",
+      "provider_id",
+      "id"
+    );
+    if (participantProviderId && attendeeProviderId !== participantProviderId) {
+      continue;
+    }
+    const profileUrl = getWebhookString(attendee, "profile_url");
+    if (profileUrl) {
+      return profileUrl;
+    }
+  }
+
+  return undefined;
 }
 
 function normalizeWebhookAttachments(
@@ -1667,6 +1823,8 @@ async function persistConversationSnapshot(
     messages: LinkedInConversationMessage[];
     warningCode?: LinkedInPanelWarningCode;
     warningMessage?: string;
+    history?: ConversationHistoryPageMetadata;
+    historyOldestLoadedAt?: number;
   }
 ) {
   const chat = args.chat;
@@ -1702,11 +1860,15 @@ async function persistConversationSnapshot(
       readOnly:
         typeof chat?.read_only === "number" ? chat.read_only !== 0 : undefined,
       contentType: chat?.content_type,
-      lastSyncedAt: Date.now(),
-      lastSyncAttemptAt: Date.now(),
-      lastSyncSuccessAt: Date.now(),
+      lastSyncedAt: getCurrentUTCTimestamp(),
+      lastSyncAttemptAt: getCurrentUTCTimestamp(),
+      lastSyncSuccessAt: getCurrentUTCTimestamp(),
       lastSyncErrorCode: args.warningCode,
       lastSyncErrorMessage: args.warningMessage,
+      historyNextCursor: args.history?.nextCursor,
+      historyHasMore: args.history?.hasMore,
+      historyBoundary: args.history?.boundary,
+      historyOldestLoadedAt: args.historyOldestLoadedAt,
       messages: toStoredMessages(args.messages),
     }
   );
@@ -1802,6 +1964,14 @@ function buildBasePanelContext(args: {
             conversationId: args.cachedSnapshot?.conversation?.conversationId,
           }),
     messages: toCachedMessages(args.cachedSnapshot),
+    history: {
+      nextCursor:
+        args.cachedSnapshot?.conversation?.historyHasMore === true
+          ? args.cachedSnapshot?.conversation?.historyNextCursor
+          : undefined,
+      hasMore: args.cachedSnapshot?.conversation?.historyHasMore === true,
+      boundary: args.cachedSnapshot?.conversation?.historyBoundary,
+    },
     draftText: args.draftText,
     draftAttachments: args.draftAttachments,
     actionRequestId: args.actionRequestId,
@@ -1860,6 +2030,8 @@ export const ensureUnipileWebhooksInternal = internalAction({
       {
         source: "messaging",
         events: [
+          // Unipile v1 emits both inbound and outbound messages as
+          // `message_received`; direction comes from account_info/sender.
           "message_received",
           "message_read",
           "message_reaction",
@@ -1914,7 +2086,7 @@ export const ensureUnipileWebhooksInternal = internalAction({
           requestUrl,
           enabled: true,
           events: config.events as any,
-          updatedAt: Date.now(),
+          updatedAt: getCurrentUTCTimestamp(),
         }
       );
     }
@@ -2581,9 +2753,12 @@ async function resolveProspectLinkedInPanelContext(
     const chats = await listLinkedInChatsForAttendeeOrEmpty({
       attendeeId: prospectIdentity.providerId,
       accountId: storedAccount.accountId,
-      limit: 10,
+      limit: 25,
     });
-    const chat = chats[0] ?? null;
+    const chat = selectDeterministicLinkedInChat(
+      chats,
+      prospectIdentity.providerId
+    );
     if (!chat) {
       return {
         ...baseContext,
@@ -2595,14 +2770,9 @@ async function resolveProspectLinkedInPanelContext(
       };
     }
 
-    const messages = (
-      await listLinkedInChatMessages({
-        chatId: chat.id,
-        limit: 100,
-      })
-    )
-      .map(normalizeMessage)
-      .sort((left, right) => toMs(left.createdAt) - toMs(right.createdAt));
+    const page = await loadLinkedInConversationHistoryPage({
+      chatId: chat.id,
+    });
 
     const eligibility = buildEligibility({
       status: connectionStatus,
@@ -2617,7 +2787,9 @@ async function resolveProspectLinkedInPanelContext(
       chat,
       prospectIdentity,
       eligibility,
-      messages,
+      messages: page.messages,
+      history: page.history,
+      historyOldestLoadedAt: page.oldestLoadedAt,
     });
 
     return {
@@ -2628,7 +2800,8 @@ async function resolveProspectLinkedInPanelContext(
         chat.attendee_provider_id ?? prospectIdentity.providerId,
       participantHeadline: prospectIdentity.title,
       eligibility,
-      messages,
+      messages: page.messages,
+      history: page.history,
     };
   } catch (error) {
     const failure = getLinkedInFailure(error);
@@ -2653,6 +2826,95 @@ async function resolveProspectLinkedInPanelContext(
           : undefined,
     };
   }
+}
+
+/**
+ * Fetch one bounded LinkedIn provider page for an already-resolved prospect
+ * conversation. The page action intentionally does not rediscover chats: the
+ * cached conversation id scopes the opaque provider cursor and keeps one
+ * provider message request per page.
+ */
+async function getProspectLinkedInHistoryPageForUser(
+  ctx: any,
+  userId: Id<"users">,
+  prospectId: Id<"prospects">,
+  args: { cursor?: string; limit?: number; sinceMs?: number }
+): Promise<{
+  conversationId: string;
+  messages: LinkedInConversationMessage[];
+  history: ConversationHistoryPageMetadata;
+} | null> {
+  const prospect = await getOwnedLinkedInProspectForUser(
+    ctx,
+    userId,
+    prospectId
+  );
+  if (!prospect) {
+    return null;
+  }
+
+  const storedAccount = await ctx.runQuery(
+    internalLinkedInStore.getLinkedInAccountForUserInternal,
+    { userId }
+  );
+  const connectionStatus = toConnectionStatus(storedAccount);
+  if (!connectionStatus.isConnected || !storedAccount?.accountId) {
+    return null;
+  }
+
+  const cachedSnapshot: {
+    conversation?: {
+      conversationId?: string;
+      sourceId?: string;
+      participantProviderId?: string;
+    } | null;
+  } | null = await ctx.runQuery(
+    internal.platformConversations.getConversationSnapshotInternal,
+    { userId, platform: "linkedin", prospectId }
+  );
+  const conversation = cachedSnapshot?.conversation;
+  if (!conversation?.conversationId) {
+    return null;
+  }
+
+  const prospectIdentity = getProspectLinkedInIdentity(prospect);
+  const page = await loadLinkedInConversationHistoryPage({
+    chatId: conversation.conversationId,
+    cursor: args.cursor,
+    limit: args.limit,
+    sinceMs: args.sinceMs,
+  });
+  const eligibility = buildEligibility({
+    status: connectionStatus,
+    providerId: prospectIdentity.providerId,
+    conversationId: conversation.conversationId,
+  });
+  if (shouldPersistRecentConversationHistoryPage(args)) {
+    await persistConversationSnapshot(ctx, {
+      userId,
+      prospect,
+      accountId: storedAccount.accountId,
+      chat: {
+        id: conversation.conversationId,
+        account_id: storedAccount.accountId,
+        account_type: "LINKEDIN",
+        provider_id: conversation.sourceId,
+        attendee_provider_id:
+          conversation.participantProviderId ?? prospectIdentity.providerId,
+      },
+      prospectIdentity,
+      eligibility,
+      messages: page.messages,
+      history: page.history,
+      historyOldestLoadedAt: page.oldestLoadedAt,
+    });
+  }
+
+  return {
+    conversationId: conversation.conversationId,
+    messages: page.messages,
+    history: page.history,
+  };
 }
 
 export const getLinkedInConnectionStatus = action({
@@ -2858,6 +3120,55 @@ export const getLinkedInConversationPanelContext = action({
         draftText,
         draftAttachments,
         actionRequestId,
+      }
+    );
+  },
+});
+
+/**
+ * Return one bounded older LinkedIn provider page. `cursor` is opaque and may
+ * only continue the cached conversation for this owned prospect.
+ */
+export const getLinkedInConversationHistoryPage = action({
+  args: {
+    prospectId: v.id("prospects"),
+    cursor: v.optional(v.string()),
+    limit: v.optional(v.number()),
+    sinceMs: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getCurrentUserId(ctx);
+    return await getProspectLinkedInHistoryPageForUser(
+      ctx,
+      userId,
+      args.prospectId,
+      {
+        cursor: args.cursor,
+        limit: args.limit,
+        sinceMs: args.sinceMs,
+      }
+    );
+  },
+});
+
+/** Same page contract for trusted agent/workflow callers. */
+export const getLinkedInConversationHistoryPageInternal = internalAction({
+  args: {
+    userId: v.id("users"),
+    prospectId: v.id("prospects"),
+    cursor: v.optional(v.string()),
+    limit: v.optional(v.number()),
+    sinceMs: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    return await getProspectLinkedInHistoryPageForUser(
+      ctx,
+      args.userId,
+      args.prospectId,
+      {
+        cursor: args.cursor,
+        limit: args.limit,
+        sinceMs: args.sinceMs,
       }
     );
   },
@@ -5117,25 +5428,22 @@ export const handleUnipileWebhookPayloadInternal = internalAction({
       return { processed: true as const };
     }
 
+    const webhookChat = getNestedRecord(payload, "chat");
     const conversationId =
-      typeof payload?.chat_id === "string"
-        ? payload.chat_id
-        : getWebhookString(payload, "conversation_id");
+      getWebhookString(payload, "chat_id", "conversation_id") ??
+      getWebhookString(webhookChat, "id", "chat_id");
     if (!conversationId) {
       return { processed: false as const };
     }
 
     if (event === "message_read") {
-      const readAtMs = toMs(
-        getWebhookString(payload, "timestamp", "read_at") ??
-          new Date().toISOString()
-      );
+      const readAtMs = toMs(getWebhookString(payload, "timestamp", "read_at"));
       await ctx.runMutation(
         internal.platformConversations.markConversationMessagesReadInternal,
         {
           userId: linkedAccount.userId,
           conversationId,
-          readAt: readAtMs || Date.now(),
+          readAt: readAtMs || getCurrentUTCTimestamp(),
         }
       );
       return { processed: true as const };
@@ -5143,6 +5451,7 @@ export const handleUnipileWebhookPayloadInternal = internalAction({
 
     if (
       event !== "message_received" &&
+      event !== "message_sent" &&
       event !== "message_reaction" &&
       event !== "message_edited" &&
       event !== "message_deleted" &&
@@ -5175,13 +5484,21 @@ export const handleUnipileWebhookPayloadInternal = internalAction({
             }
           );
 
+    const webhookMessage = getNestedRecord(payload, "message");
     const messageId =
-      typeof payload?.message_id === "string"
-        ? payload.message_id
-        : (existingSnapshot?.conversation?.latestMessageId ??
-          `${conversationId}:${event}:${getWebhookString(payload, "timestamp") ?? Date.now()}`);
+      getWebhookString(payload, "message_id", "messageId") ??
+      getWebhookString(webhookMessage, "message_id", "messageId", "id");
+    if (!messageId) {
+      console.warn("[LinkedIn] Messaging webhook missing stable message id", {
+        accountId,
+        event,
+        conversationId,
+      });
+      return { processed: false as const };
+    }
     const timestamp =
-      getWebhookString(payload, "timestamp") ?? new Date().toISOString();
+      getWebhookString(payload, "timestamp") ??
+      getWebhookString(webhookMessage, "timestamp", "created_at");
     const attachments = normalizeWebhookAttachments(payload);
     const providerMessageId = getWebhookString(payload, "provider_id");
     const knownMessage = existingSnapshot?.messages?.find(
@@ -5195,7 +5512,8 @@ export const handleUnipileWebhookPayloadInternal = internalAction({
         ? knownMessage.direction
         : undefined;
     const senderProviderId = getWebhookString(
-      payload?.sender,
+      getNestedRecord(payload, "sender"),
+      "attendee_provider_id",
       "provider_id",
       "id"
     );
@@ -5228,15 +5546,15 @@ export const handleUnipileWebhookPayloadInternal = internalAction({
         participantUsername:
           existingSnapshot?.conversation?.participantUsername,
         participantName:
-          getWebhookParticipantName(payload) ??
+          getWebhookParticipantName(payload, participantProviderId) ??
           existingSnapshot?.conversation?.participantName,
         participantHeadline:
           existingSnapshot?.conversation?.participantHeadline,
         participantAvatarUrl:
-          getWebhookString(payload?.sender, "picture_url") ??
+          getWebhookParticipantAvatarUrl(payload, participantProviderId) ??
           existingSnapshot?.conversation?.participantAvatarUrl,
         participantProfileUrl:
-          getWebhookString(payload?.sender, "profile_url") ??
+          getWebhookParticipantProfileUrl(payload, participantProviderId) ??
           existingSnapshot?.conversation?.participantProfileUrl,
         participantVerified:
           existingSnapshot?.conversation?.participantVerified,
@@ -5252,9 +5570,9 @@ export const handleUnipileWebhookPayloadInternal = internalAction({
         contentType:
           existingSnapshot?.conversation?.contentType ??
           getWebhookString(payload, "content_type"),
-        lastSyncedAt: Date.now(),
+        lastSyncedAt: getCurrentUTCTimestamp(),
         lastSyncAttemptAt: existingSnapshot?.conversation?.lastSyncAttemptAt,
-        lastSyncSuccessAt: Date.now(),
+        lastSyncSuccessAt: getCurrentUTCTimestamp(),
         lastSyncErrorCode: existingSnapshot?.conversation?.lastSyncErrorCode,
         lastSyncErrorMessage:
           existingSnapshot?.conversation?.lastSyncErrorMessage,
@@ -5271,27 +5589,28 @@ export const handleUnipileWebhookPayloadInternal = internalAction({
             ),
             text:
               getWebhookString(payload, "message", "text") ??
+              getWebhookString(webhookMessage, "text", "message") ??
               (event === "message_deleted"
                 ? "Message deleted"
                 : existingSnapshot?.messages?.find(
                     (message: any) => message.messageId === messageId
                   )?.text),
             createdAt: timestamp,
-            createdAtMs: toMs(timestamp) || Date.now(),
+            createdAtMs: toMs(timestamp) || getCurrentUTCTimestamp(),
             attachments,
             deliveredAt:
               event === "message_delivered"
-                ? toMs(timestamp) || Date.now()
+                ? toMs(timestamp) || getCurrentUTCTimestamp()
                 : undefined,
             readAt:
               event === "message_read"
-                ? toMs(timestamp) || Date.now()
+                ? toMs(timestamp) || getCurrentUTCTimestamp()
                 : undefined,
             messageType: existingSnapshot?.messages?.find(
               (message: any) => message.messageId === messageId
             )?.messageType,
             isEvent:
-              event !== "message_received" ||
+              (event !== "message_received" && event !== "message_sent") ||
               Boolean(
                 existingSnapshot?.messages?.find(
                   (message: any) => message.messageId === messageId
@@ -5304,7 +5623,7 @@ export const handleUnipileWebhookPayloadInternal = internalAction({
     );
 
     if (
-      event === "message_received" &&
+      (event === "message_received" || event === "message_sent") &&
       direction === "received" &&
       prospect?._id
     ) {
@@ -5312,7 +5631,10 @@ export const handleUnipileWebhookPayloadInternal = internalAction({
         prospectId: prospect._id,
         responseType: "dm",
         responseMessageId: messageId,
-        responseText: getWebhookString(payload, "message", "text") ?? undefined,
+        responseText:
+          getWebhookString(payload, "message", "text") ??
+          getWebhookString(webhookMessage, "text", "message") ??
+          undefined,
         responseData: payload,
         conversationId,
       });

--- a/convex/platformConversations.ts
+++ b/convex/platformConversations.ts
@@ -4,6 +4,7 @@ import { buildChangedPatchWithUpdatedAt } from "./lib/patchHelpers";
 import { mergeConversationAttachments } from "./lib/xDm";
 import {
   platformConversationAttachmentValidator,
+  conversationHistoryBoundaryValidator,
   platformConversationDirectionValidator,
   platformConversationEventTypeValidator,
   platformConversationMessageTypeValidator,
@@ -13,6 +14,9 @@ import {
   xDmPanelWarningCodeValidator,
 } from "./validators";
 import { getCurrentUTCTimestamp } from "../shared/lib/utils/time/timeUtils";
+import { normalizeConversationHistoryPageLimit } from "./lib/conversationHistoryPaginationCore";
+
+const DEFAULT_CONVERSATION_SNAPSHOT_MESSAGE_LIMIT = 25;
 
 function sortMessagesByTime<T extends { createdAtMs: number }>(
   messages: T[]
@@ -36,6 +40,7 @@ export const getConversationSnapshotInternal = internalQuery({
     platform: platformConversationPlatformValidator,
     conversationId: v.optional(v.string()),
     prospectId: v.optional(v.id("prospects")),
+    messageLimit: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     const conversation = args.conversationId
@@ -49,16 +54,21 @@ export const getConversationSnapshotInternal = internalQuery({
           .first()
       : await ctx.db
           .query("platformConversations")
-          .withIndex("by_prospect_platform", (q) =>
-            q.eq("prospectId", args.prospectId!).eq("platform", args.platform)
+          .withIndex("by_user_prospect_platform", (q) =>
+            q
+              .eq("userId", args.userId)
+              .eq("prospectId", args.prospectId!)
+              .eq("platform", args.platform)
           )
-          .filter((q) => q.eq(q.field("userId"), args.userId))
           .first();
 
     if (!conversation) {
       return null;
     }
 
+    const messageLimit = normalizeConversationHistoryPageLimit(
+      args.messageLimit ?? DEFAULT_CONVERSATION_SNAPSHOT_MESSAGE_LIMIT
+    );
     const messages = await ctx.db
       .query("platformConversationMessages")
       .withIndex("by_user_conversation_created_at", (q) =>
@@ -66,7 +76,8 @@ export const getConversationSnapshotInternal = internalQuery({
           .eq("userId", args.userId)
           .eq("conversationId", conversation.conversationId)
       )
-      .collect();
+      .order("desc")
+      .take(messageLimit);
 
     return {
       conversation,
@@ -139,6 +150,10 @@ export const upsertConversationSnapshotInternal = internalMutation({
     nextSyncAllowedAt: v.optional(v.number()),
     lastSyncErrorCode: v.optional(xDmPanelWarningCodeValidator),
     lastSyncErrorMessage: v.optional(v.string()),
+    historyNextCursor: v.optional(v.string()),
+    historyHasMore: v.optional(v.boolean()),
+    historyBoundary: v.optional(conversationHistoryBoundaryValidator),
+    historyOldestLoadedAt: v.optional(v.number()),
     activitySubscribedAt: v.optional(v.number()),
     messages: v.array(
       v.object({
@@ -229,6 +244,28 @@ export const upsertConversationSnapshotInternal = internalMutation({
         "lastSyncErrorMessage",
         existingConversation?.lastSyncErrorMessage
       ),
+      historyNextCursor: pickOptionalPatchValue(
+        args,
+        "historyNextCursor",
+        existingConversation?.historyNextCursor
+      ),
+      historyHasMore: pickOptionalPatchValue(
+        args,
+        "historyHasMore",
+        existingConversation?.historyHasMore
+      ),
+      historyBoundary: pickOptionalPatchValue(
+        args,
+        "historyBoundary",
+        existingConversation?.historyBoundary
+      ),
+      historyOldestLoadedAt:
+        typeof args.historyOldestLoadedAt === "number"
+          ? Math.min(
+              args.historyOldestLoadedAt,
+              existingConversation?.historyOldestLoadedAt ?? Infinity
+            )
+          : existingConversation?.historyOldestLoadedAt,
       activitySubscribedAt:
         args.activitySubscribedAt ?? existingConversation?.activitySubscribedAt,
       updatedAt: now,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -131,6 +131,7 @@ import {
   xActivitySubscriptionStatusValidator,
   xDmEligibilityReasonCodeValidator,
   xDmPanelWarningCodeValidator,
+  conversationHistoryBoundaryValidator,
   xSubscriptionTypeValidator,
   socialQueryMonitorPurposeValidator,
   styleBackfillStatusValidator,
@@ -1043,11 +1044,16 @@ export default defineSchema({
     nextSyncAllowedAt: v.optional(v.number()),
     lastSyncErrorCode: v.optional(xDmPanelWarningCodeValidator),
     lastSyncErrorMessage: v.optional(v.string()),
+    historyNextCursor: v.optional(v.string()),
+    historyHasMore: v.optional(v.boolean()),
+    historyBoundary: v.optional(conversationHistoryBoundaryValidator),
+    historyOldestLoadedAt: v.optional(v.number()),
     activitySubscribedAt: v.optional(v.number()),
     updatedAt: v.number(),
   })
     .index("by_user_platform", ["userId", "platform"])
     .index("by_user_conversation", ["userId", "conversationId"])
+    .index("by_user_prospect_platform", ["userId", "prospectId", "platform"])
     .index("by_workspace", ["workspaceId"])
     .index("by_prospect_platform", ["prospectId", "platform"]),
 

--- a/convex/validators.ts
+++ b/convex/validators.ts
@@ -565,6 +565,11 @@ export const xDmPanelWarningCodeValidator = v.union(
   v.literal("feature_not_subscribed")
 );
 
+export const conversationHistoryBoundaryValidator = v.union(
+  v.literal("complete"),
+  v.literal("x_30_day_limit")
+);
+
 export const platformConversationAttachmentValidator = v.object({
   mediaKey: v.optional(v.string()),
   type: v.string(),
@@ -593,6 +598,7 @@ export const platformConversationEventTypeValidator = v.union(
   v.literal("chat.received"),
   v.literal("chat.conversation_join"),
   v.literal("message_received"),
+  v.literal("message_sent"),
   v.literal("message_read"),
   v.literal("message_reaction"),
   v.literal("message_edited"),

--- a/convex/x.ts
+++ b/convex/x.ts
@@ -29,6 +29,14 @@ import {
   getHydratedTimelinePage,
   getXExecutionFailure,
 } from "./lib/xdkTwitterProvider";
+import {
+  applyConversationHistorySince,
+  buildConversationHistoryPageMetadata,
+  getProviderPageCursor,
+  normalizeConversationHistoryPageLimit,
+  shouldPersistRecentConversationHistoryPage,
+  type ConversationHistoryPageMetadata,
+} from "./lib/conversationHistoryPaginationCore";
 import { getTwitterActionCatalogEntry } from "./lib/twitterActionCatalog";
 import { getTwitterViewerStatesForUser } from "./lib/twitterViewerStateService";
 import { userTimelineModeValidator } from "./validators";
@@ -49,7 +57,10 @@ import {
 } from "../shared/lib/twitter/hydration";
 import { applyViewerStateToTweet } from "../shared/lib/twitter/ui";
 import { logger } from "../shared/lib/logger";
-import { getCurrentUTCTimestamp } from "../shared/lib/utils/time/timeUtils";
+import {
+  getCurrentUTCTimestamp,
+  parseIsoToTimestamp,
+} from "../shared/lib/utils/time/timeUtils";
 import {
   assertPostTextWithinLimit,
   getDmTextLimitError,
@@ -296,11 +307,54 @@ function isMissingConversationError(error: unknown): boolean {
 }
 
 function toCreatedAtMs(createdAt?: string): number {
-  if (!createdAt) {
-    return 0;
-  }
-  const parsed = Date.parse(createdAt);
-  return Number.isFinite(parsed) ? parsed : 0;
+  return createdAt ? (parseIsoToTimestamp(createdAt) ?? 0) : 0;
+}
+
+type XDmConversationHistoryPage = {
+  messages: XDmMessage[];
+  history: ConversationHistoryPageMetadata;
+  oldestLoadedAt?: number;
+};
+
+async function loadXDmConversationHistoryPage(args: {
+  provider: Awaited<ReturnType<typeof getXProviderContextForUser>>;
+  conversationId: string;
+  cursor?: string;
+  limit?: number;
+  sinceMs?: number;
+}): Promise<XDmConversationHistoryPage> {
+  const response = await getDmEventsByConversationId(
+    args.provider,
+    args.conversationId,
+    {
+      maxResults: normalizeConversationHistoryPageLimit(args.limit),
+      paginationToken: args.cursor,
+    }
+  );
+  const normalized = normalizeDmMessages(response, args.provider.xUserId);
+  const { items: messages, reachedSince } = applyConversationHistorySince(
+    normalized,
+    args.sinceMs
+  );
+  const history = buildConversationHistoryPageMetadata({
+    providerCursor: getProviderPageCursor(response),
+    reachedSince,
+    platform: "twitter",
+  });
+  const oldestLoadedAt = messages.reduce<number | undefined>(
+    (oldest, message) => {
+      const createdAtMs = toCreatedAtMs(message.createdAt);
+      if (createdAtMs <= 0) {
+        return oldest;
+      }
+      return typeof oldest === "number"
+        ? Math.min(oldest, createdAtMs)
+        : createdAtMs;
+    },
+    undefined
+  );
+
+  return { messages, history, oldestLoadedAt };
 }
 
 function toStoredConversationMessages(messages: XDmMessage[]) {
@@ -312,7 +366,7 @@ function toStoredConversationMessages(messages: XDmMessage[]) {
     createdAt: message.createdAt,
     createdAtMs: toCreatedAtMs(message.createdAt),
     attachments: message.attachments,
-    readAt: message.readAt ? Date.parse(message.readAt) : undefined,
+    readAt: message.readAt ? parseIsoToTimestamp(message.readAt) : undefined,
   }));
 }
 
@@ -354,6 +408,8 @@ async function persistDmConversationSnapshot(
     nextSyncAllowedAt?: number;
     lastSyncErrorCode?: "rate_limited" | "activity_degraded";
     lastSyncErrorMessage?: string;
+    history?: ConversationHistoryPageMetadata;
+    historyOldestLoadedAt?: number;
   }
 ) {
   await ctx.runMutation(
@@ -378,6 +434,10 @@ async function persistDmConversationSnapshot(
       nextSyncAllowedAt: args.nextSyncAllowedAt,
       lastSyncErrorCode: args.lastSyncErrorCode,
       lastSyncErrorMessage: args.lastSyncErrorMessage,
+      historyNextCursor: args.history?.nextCursor,
+      historyHasMore: args.history?.hasMore,
+      historyBoundary: args.history?.boundary,
+      historyOldestLoadedAt: args.historyOldestLoadedAt,
       messages: toStoredConversationMessages(args.messages),
     }
   );
@@ -474,6 +534,14 @@ function buildBaseDmPanelContext(args: {
             conversationId: args.cachedSnapshot?.conversation?.conversationId,
           }),
     messages: toCachedDmMessages(args.cachedSnapshot),
+    history: {
+      nextCursor:
+        args.cachedSnapshot?.conversation?.historyHasMore === true
+          ? args.cachedSnapshot?.conversation?.historyNextCursor
+          : undefined,
+      hasMore: args.cachedSnapshot?.conversation?.historyHasMore === true,
+      boundary: args.cachedSnapshot?.conversation?.historyBoundary,
+    },
     draftText: args.draftText,
     draftAttachments: args.draftAttachments,
     actionRequestId: args.actionRequestId,
@@ -512,6 +580,11 @@ function shouldPerformLiveDmSync(snapshot: any): boolean {
     return false;
   }
   if (typeof conversation.lastSyncSuccessAt !== "number") {
+    return true;
+  }
+  // Snapshots created before bounded provider pagination must be refreshed once
+  // so the panel receives an honest continuation contract.
+  if (typeof conversation.historyHasMore !== "boolean") {
     return true;
   }
   return (
@@ -636,6 +709,9 @@ async function syncProspectDmConversationForUser(
     prospectIdentity: ReturnType<typeof resolveProspectTwitterIdentity>;
     connectionStatus: XConnectionStatus;
     baseContext: XDmPanelContext;
+    historyCursor?: string;
+    historySinceMs?: number;
+    historyLimit?: number;
   }
 ): Promise<XDmPanelContext> {
   const syncAttemptAt = getCurrentUTCTimestamp();
@@ -659,37 +735,32 @@ async function syncProspectDmConversationForUser(
     conversationId,
   });
 
-  let messages = args.baseContext.messages;
+  let persistedMessages = args.baseContext.messages;
+  let panelMessages = args.baseContext.messages;
+  let history: ConversationHistoryPageMetadata = args.baseContext.history ?? {
+    hasMore: false,
+  };
 
   try {
-    const threadResponse = await getDmEventsByConversationId(
+    const page = await loadXDmConversationHistoryPage({
       provider,
       conversationId,
-      { maxResults: 100 }
-    );
-    messages = mergeDmMessages(
-      normalizeDmMessages(threadResponse, args.connectionStatus.xUserId),
+      cursor: args.historyCursor,
+      limit: args.historyLimit,
+      sinceMs: args.historySinceMs,
+    });
+    persistedMessages = mergeDmMessages(
+      page.messages,
       args.baseContext.messages
     );
-    await persistDmConversationSnapshot(ctx, {
-      userId: args.userId,
-      prospect: args.prospect,
-      conversationId,
-      participantUserId: profileUserId,
-      participantUsername: profile.username ?? profile.screen_name,
-      participantName: profile.name,
-      participantAvatarUrl: profile.profile_image_url_https,
-      participantVerified: profile.verified,
-      eligibility,
-      messages,
-      lastSyncAttemptAt: syncAttemptAt,
-      lastSyncSuccessAt: getCurrentUTCTimestamp(),
-      nextSyncAllowedAt: undefined,
-      lastSyncErrorCode: undefined,
-      lastSyncErrorMessage: undefined,
-    });
-  } catch (error) {
-    if (isMissingConversationError(error)) {
+    panelMessages = page.messages;
+    history = page.history;
+    if (
+      shouldPersistRecentConversationHistoryPage({
+        cursor: args.historyCursor,
+        sinceMs: args.historySinceMs,
+      })
+    ) {
       await persistDmConversationSnapshot(ctx, {
         userId: args.userId,
         prospect: args.prospect,
@@ -700,12 +771,34 @@ async function syncProspectDmConversationForUser(
         participantAvatarUrl: profile.profile_image_url_https,
         participantVerified: profile.verified,
         eligibility,
-        messages,
+        messages: persistedMessages,
         lastSyncAttemptAt: syncAttemptAt,
         lastSyncSuccessAt: getCurrentUTCTimestamp(),
         nextSyncAllowedAt: undefined,
         lastSyncErrorCode: undefined,
         lastSyncErrorMessage: undefined,
+        history: page.history,
+        historyOldestLoadedAt: page.oldestLoadedAt,
+      });
+    }
+  } catch (error) {
+    if (isMissingConversationError(error)) {
+      history = { hasMore: false, boundary: "x_30_day_limit" };
+      await persistDmConversationSnapshot(ctx, {
+        userId: args.userId,
+        prospect: args.prospect,
+        conversationId,
+        participantUserId: profileUserId,
+        participantUsername: profile.username ?? profile.screen_name,
+        participantName: profile.name,
+        participantAvatarUrl: profile.profile_image_url_https,
+        participantVerified: profile.verified,
+        eligibility,
+        messages: persistedMessages,
+        lastSyncAttemptAt: syncAttemptAt,
+        // A 404 means the provider has no legacy DM history for this
+        // conversation. Do not advance the successful-sync timestamp.
+        history,
       });
     } else {
       const failure = getXExecutionFailure(error);
@@ -722,7 +815,7 @@ async function syncProspectDmConversationForUser(
           participantAvatarUrl: profile.profile_image_url_https,
           participantVerified: profile.verified,
           eligibility,
-          messages,
+          messages: persistedMessages,
           lastSyncAttemptAt: syncAttemptAt,
           nextSyncAllowedAt,
           lastSyncErrorCode: "rate_limited",
@@ -765,7 +858,8 @@ async function syncProspectDmConversationForUser(
       profile.screen_name ??
       args.baseContext.participantUsername,
     eligibility,
-    messages,
+    messages: panelMessages,
+    history,
     warning: ensured.ensured ? undefined : args.baseContext.warning,
   };
 }
@@ -778,6 +872,9 @@ async function resolveProspectDmPanelContext(
     draftText?: string;
     draftAttachments?: XDmAttachmentSummary[];
     actionRequestId?: string;
+    historyCursor?: string;
+    historySinceMs?: number;
+    historyLimit?: number;
   }
 ): Promise<XDmPanelContext | null> {
   const prospect = await getOwnedTwitterProspectForUser(
@@ -834,7 +931,10 @@ async function resolveProspectDmPanelContext(
   ) {
     return baseContext;
   }
-  if (!shouldPerformLiveDmSync(cachedSnapshot)) {
+  const isExplicitHistoryPage =
+    typeof options?.historyCursor === "string" ||
+    typeof options?.historySinceMs === "number";
+  if (!isExplicitHistoryPage && !shouldPerformLiveDmSync(cachedSnapshot)) {
     return baseContext;
   }
 
@@ -845,6 +945,9 @@ async function resolveProspectDmPanelContext(
       prospectIdentity,
       connectionStatus,
       baseContext,
+      historyCursor: options?.historyCursor,
+      historySinceMs: options?.historySinceMs,
+      historyLimit: options?.historyLimit,
     });
   } catch (error) {
     logger.warn("Unable to refresh X/Twitter DM panel context", {
@@ -854,6 +957,98 @@ async function resolveProspectDmPanelContext(
     });
     return baseContext;
   }
+}
+
+/**
+ * Fetch exactly one bounded X/Twitter provider page for an owned prospect.
+ * The opaque cursor is scoped to the resolved one-to-one conversation; callers
+ * never supply a conversation id directly.
+ */
+async function getProspectXDmHistoryPageForUser(
+  ctx: any,
+  userId: Id<"users">,
+  prospectId: Id<"prospects">,
+  args: {
+    cursor?: string;
+    limit?: number;
+    sinceMs?: number;
+  }
+) {
+  const prospect = await getOwnedTwitterProspectForUser(
+    ctx,
+    userId,
+    prospectId
+  );
+  if (!prospect) {
+    return null;
+  }
+
+  const prospectIdentity = resolveProspectTwitterIdentity(
+    prospect as Record<string, unknown>
+  );
+  const connectionStatus = await getXConnectionStatusForUser(
+    ctx,
+    getXStoreRefs(),
+    userId
+  );
+  if (
+    !prospectIdentity.username ||
+    !connectionStatus.xUserId ||
+    !connectionStatus.isConnected ||
+    (connectionStatus.missingScopes ?? []).some((scope) => scope === "dm.read")
+  ) {
+    return null;
+  }
+
+  const provider = await getXProviderContextForUser(ctx, getXStoreRefs(), {
+    userId,
+    requiredScopes: ["tweet.read", "users.read", "dm.read"],
+  });
+  const { profileUserId, profile } = await getHydratedProfileByUsername(
+    provider,
+    prospectIdentity.username
+  );
+  const conversationId = computeOneToOneDmConversationId(
+    connectionStatus.xUserId,
+    profileUserId
+  );
+  const page = await loadXDmConversationHistoryPage({
+    provider,
+    conversationId,
+    cursor: args.cursor,
+    limit: args.limit,
+    sinceMs: args.sinceMs,
+  });
+  const eligibility = buildDmEligibility({
+    isConnected: connectionStatus.isConnected,
+    missingScopes: connectionStatus.missingScopes,
+    receivesYourDm: profile.can_dm,
+    conversationId,
+  });
+  if (shouldPersistRecentConversationHistoryPage(args)) {
+    await persistDmConversationSnapshot(ctx, {
+      userId,
+      prospect,
+      conversationId,
+      participantUserId: profileUserId,
+      participantUsername: profile.username ?? profile.screen_name,
+      participantName: profile.name,
+      participantAvatarUrl: profile.profile_image_url_https,
+      participantVerified: profile.verified,
+      eligibility,
+      messages: page.messages,
+      lastSyncAttemptAt: getCurrentUTCTimestamp(),
+      lastSyncSuccessAt: getCurrentUTCTimestamp(),
+      history: page.history,
+      historyOldestLoadedAt: page.oldestLoadedAt,
+    });
+  }
+
+  return {
+    conversationId,
+    messages: page.messages,
+    history: page.history,
+  };
 }
 
 async function hydrateViewerStatesForPosts(
@@ -1689,10 +1884,11 @@ async function syncDmConversationForUser(
     userId,
     requiredScopes: ["tweet.read", "users.read", "dm.read"],
   });
-  const response = await getDmEventsByConversationId(provider, conversationId, {
-    maxResults: 100,
+  const page = await loadXDmConversationHistoryPage({
+    provider,
+    conversationId,
   });
-  const messages = normalizeDmMessages(response, provider.xUserId);
+  const messages = page.messages;
   if (existingConversation?.prospectId) {
     const prospect = await getOwnedTwitterProspectForUser(
       ctx,
@@ -1720,12 +1916,15 @@ async function syncDmConversationForUser(
           conversationId,
         },
         messages,
+        history: page.history,
+        historyOldestLoadedAt: page.oldestLoadedAt,
       });
     }
   }
   return {
     conversationId,
     messages,
+    history: page.history,
   };
 }
 
@@ -1765,6 +1964,55 @@ export const getDmPanelContext = action({
       draftAttachments,
       actionRequestId,
     });
+  },
+});
+
+/**
+ * Return one bounded X/Twitter provider page. `cursor` is the opaque value
+ * returned by the prior panel/page response; messages are chronological.
+ */
+export const getDmConversationHistoryPage = action({
+  args: {
+    prospectId: v.id("prospects"),
+    cursor: v.optional(v.string()),
+    limit: v.optional(v.number()),
+    sinceMs: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getCurrentUserId(ctx);
+    return await getProspectXDmHistoryPageForUser(
+      ctx,
+      userId,
+      args.prospectId,
+      {
+        cursor: args.cursor,
+        limit: args.limit,
+        sinceMs: args.sinceMs,
+      }
+    );
+  },
+});
+
+/** Same page contract for trusted agent/workflow callers. */
+export const getDmConversationHistoryPageInternal = internalAction({
+  args: {
+    userId: v.id("users"),
+    prospectId: v.id("prospects"),
+    cursor: v.optional(v.string()),
+    limit: v.optional(v.number()),
+    sinceMs: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    return await getProspectXDmHistoryPageForUser(
+      ctx,
+      args.userId,
+      args.prospectId,
+      {
+        cursor: args.cursor,
+        limit: args.limit,
+        sinceMs: args.sinceMs,
+      }
+    );
   },
 });
 

--- a/convex/xActivity.ts
+++ b/convex/xActivity.ts
@@ -13,10 +13,15 @@ import {
   getXWebhookCallbackUrl,
   listXActivitySubscriptions,
   listXWebhooks,
+  updateXActivitySubscription,
   type XActivityEventType,
   type XDmActivityEventType,
   validateXWebhook,
 } from "./lib/xActivity";
+import {
+  findMatchingXActivitySubscription,
+  isDuplicateXActivitySubscriptionError,
+} from "./lib/xActivityReconciliationCore";
 import {
   extractActivityCreatedPost,
   matchesTwitterManualReplyRecovery,
@@ -25,42 +30,14 @@ import { normalizeDmMessages } from "./lib/xDm";
 import { decryptXSecret } from "./lib/xdkCrypto";
 import { getXProviderContextForUser } from "./lib/xdkAuth";
 import { getDmEventsByConversationId } from "./lib/xdkTwitterProvider";
-import { getCurrentUTCTimestamp } from "../shared/lib/utils/time/timeUtils";
+import {
+  getCurrentUTCTimestamp,
+  parseIsoToTimestamp,
+} from "../shared/lib/utils/time/timeUtils";
 
 const ACTIVITY_ENSURE_SUCCESS_TTL_MS = 6 * 60 * 60 * 1000;
 const ACTIVITY_ENSURE_RETRY_MS = 15 * 60 * 1000;
 const ACTIVITY_ENSURE_RATE_LIMIT_RETRY_MS = 5 * 60 * 1000;
-
-function isDuplicateSubscriptionError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  const normalized = message.toLowerCase();
-  return (
-    normalized.includes("duplicatesubscription") &&
-    normalized.includes("subscription already exists")
-  );
-}
-
-function findMatchingRemoteSubscription(
-  subscriptions: Array<{
-    eventType: XActivityEventType;
-    filterUserId?: string;
-    webhookId?: string;
-    subscriptionId: string;
-    tag?: string;
-  }>,
-  args: {
-    eventType: XActivityEventType;
-    xUserId: string;
-    webhookId: string;
-  }
-) {
-  return subscriptions.find(
-    (candidate) =>
-      candidate.eventType === args.eventType &&
-      candidate.filterUserId === args.xUserId &&
-      candidate.webhookId === args.webhookId
-  );
-}
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   return typeof value === "object" && value !== null
@@ -87,13 +64,21 @@ function extractConversationId(
   payload: Record<string, unknown>
 ): string | undefined {
   const message = asRecord(payload.message);
+  const conversation = asRecord(payload.conversation);
   return (
     asString(payload.dm_conversation_id) ??
     asString(payload.dmConversationId) ??
     asString(message?.dm_conversation_id) ??
     asString(message?.dmConversationId) ??
     asString(payload.conversation_id) ??
-    asString(payload.conversationId)
+    asString(payload.conversationId) ??
+    asString(payload.chat_id) ??
+    asString(payload.chatId) ??
+    asString(message?.conversation_id) ??
+    asString(message?.conversationId) ??
+    asString(message?.chat_id) ??
+    asString(message?.chatId) ??
+    asString(conversation?.id)
   );
 }
 
@@ -103,9 +88,13 @@ function extractMessageId(
   const message = asRecord(payload.message);
   return (
     asString(payload.id) ??
+    asString(payload.message_id) ??
+    asString(payload.messageId) ??
     asString(payload.event_id) ??
     asString(payload.eventId) ??
-    asString(message?.id)
+    asString(message?.id) ??
+    asString(message?.message_id) ??
+    asString(message?.messageId)
   );
 }
 
@@ -116,6 +105,36 @@ function extractMessageText(
   return asString(payload.text) ?? asString(message?.text);
 }
 
+function extractMessageCreatedAt(
+  payload: Record<string, unknown>
+): string | undefined {
+  const message = asRecord(payload.message);
+  return (
+    asString(payload.created_at) ??
+    asString(payload.createdAt) ??
+    asString(payload.timestamp) ??
+    asString(message?.created_at) ??
+    asString(message?.createdAt) ??
+    asString(message?.timestamp)
+  );
+}
+
+function extractSenderUserId(
+  payload: Record<string, unknown>
+): string | undefined {
+  const message = asRecord(payload.message);
+  const sender = asRecord(payload.sender);
+  return (
+    asString(payload.sender_id) ??
+    asString(payload.senderId) ??
+    asString(message?.sender_id) ??
+    asString(message?.senderId) ??
+    asString(sender?.id) ??
+    asString(sender?.user_id) ??
+    asString(sender?.userId)
+  );
+}
+
 type NormalizedDmActivityEvent = {
   kind: "dm";
   eventType: XDmActivityEventType;
@@ -124,6 +143,8 @@ type NormalizedDmActivityEvent = {
   conversationId?: string;
   messageId?: string;
   text?: string;
+  createdAt?: string;
+  senderUserId?: string;
 };
 
 type NormalizedPostActivityEvent = {
@@ -187,6 +208,8 @@ function normalizeWebhookEvents(
       conversationId: extractConversationId(normalizedPayload),
       messageId: extractMessageId(normalizedPayload),
       text: extractMessageText(normalizedPayload),
+      createdAt: extractMessageCreatedAt(normalizedPayload),
+      senderUserId: extractSenderUserId(normalizedPayload),
     });
   }
 
@@ -250,7 +273,7 @@ async function syncConversationSnapshot(
     provider,
     args.conversationId,
     {
-      maxResults: 100,
+      maxResults: 25,
     }
   );
   const messages = normalizeDmMessages(response, provider.xUserId);
@@ -288,9 +311,13 @@ async function syncConversationSnapshot(
         senderUserId: message.senderUserId,
         text: message.text,
         createdAt: message.createdAt,
-        createdAtMs: message.createdAt ? Date.parse(message.createdAt) : 0,
+        createdAtMs: message.createdAt
+          ? (parseIsoToTimestamp(message.createdAt) ?? 0)
+          : 0,
         attachments: message.attachments,
-        readAt: message.readAt ? Date.parse(message.readAt) : undefined,
+        readAt: message.readAt
+          ? parseIsoToTimestamp(message.readAt)
+          : undefined,
         sourceEventType: args.sourceEventType,
       })),
     }
@@ -307,6 +334,86 @@ async function syncConversationSnapshot(
     ),
     messages,
   };
+}
+
+/**
+ * Chat Activity events are encrypted and cannot be backfilled through the
+ * legacy DM lookup endpoint. Persist their normalized payload directly. The
+ * same fallback protects a just-delivered dm.* event from a provider read race.
+ */
+async function persistNormalizedDmActivityEvent(
+  ctx: ActionCtx,
+  args: {
+    userId: Id<"users">;
+    event: NormalizedDmActivityEvent;
+  }
+) {
+  if (!args.event.conversationId) {
+    return null;
+  }
+
+  const existingConversation = await ctx.runQuery(
+    internal.platformConversations
+      .getConversationByUserAndConversationIdInternal,
+    {
+      userId: args.userId,
+      conversationId: args.event.conversationId,
+    }
+  );
+  const now = getCurrentUTCTimestamp();
+  const direction = args.event.eventType.endsWith(".sent")
+    ? ("sent" as const)
+    : ("received" as const);
+  // X does not guarantee a timestamp on every Activity event. Preserve that
+  // absence instead of manufacturing an ISO value; the numeric ingestion time
+  // keeps the event chronologically addressable in the local cache.
+  const createdAt = args.event.createdAt;
+  const createdAtMs =
+    (createdAt ? parseIsoToTimestamp(createdAt) : undefined) ?? now;
+  const messages = args.event.messageId
+    ? [
+        {
+          messageId: args.event.messageId,
+          direction,
+          senderUserId: args.event.senderUserId,
+          text: args.event.text,
+          createdAt,
+          createdAtMs,
+          sourceEventType: args.event.eventType,
+        },
+      ]
+    : [];
+
+  await ctx.runMutation(
+    internal.platformConversations.upsertConversationSnapshotInternal,
+    {
+      userId: args.userId,
+      workspaceId: existingConversation?.workspaceId,
+      prospectId: existingConversation?.prospectId,
+      platform: "twitter",
+      conversationId: args.event.conversationId,
+      participantUserId:
+        existingConversation?.participantUserId ??
+        (direction === "received" ? args.event.senderUserId : undefined),
+      participantUsername: existingConversation?.participantUsername,
+      participantName: existingConversation?.participantName,
+      participantAvatarUrl: existingConversation?.participantAvatarUrl,
+      participantVerified: existingConversation?.participantVerified,
+      eligibilityEnabled: existingConversation?.eligibilityEnabled,
+      eligibilityReasonCode: existingConversation?.eligibilityReasonCode,
+      eligibilityReasonLabel: existingConversation?.eligibilityReasonLabel,
+      messages,
+    }
+  );
+
+  return await ctx.runQuery(
+    internal.platformConversations
+      .getConversationByUserAndConversationIdInternal,
+    {
+      userId: args.userId,
+      conversationId: args.event.conversationId,
+    }
+  );
 }
 
 async function ensureWebhookAndSubscriptions(args: {
@@ -368,10 +475,12 @@ async function ensureWebhookAndSubscriptions(args: {
   let remoteSubscriptions = await listXActivitySubscriptions();
   let authMode: "app" | "user" = "app";
   for (const eventType of args.eventTypes) {
-    let subscription = findMatchingRemoteSubscription(remoteSubscriptions, {
+    const expectedTag = `reacherx:${args.userId}:${eventType}`;
+    let subscription = findMatchingXActivitySubscription(remoteSubscriptions, {
       eventType,
       xUserId: args.xUserId,
       webhookId: webhook.id,
+      expectedTag,
     });
 
     if (!subscription) {
@@ -380,28 +489,48 @@ async function ensureWebhookAndSubscriptions(args: {
           eventType,
           xUserId: args.xUserId,
           webhookId: webhook.id,
-          tag: `reacherx:${args.userId}:${eventType}`,
+          tag: expectedTag,
           userOAuthAccessToken: args.userOAuthAccessToken,
         });
         subscription = created.subscription;
         authMode = created.authMode;
         remoteSubscriptions = [...remoteSubscriptions, subscription];
       } catch (error) {
-        if (!isDuplicateSubscriptionError(error)) {
+        if (!isDuplicateXActivitySubscriptionError(error)) {
           throw error;
         }
 
         remoteSubscriptions = await listXActivitySubscriptions();
-        subscription = findMatchingRemoteSubscription(remoteSubscriptions, {
+        subscription = findMatchingXActivitySubscription(remoteSubscriptions, {
           eventType,
           xUserId: args.xUserId,
           webhookId: webhook.id,
+          expectedTag,
         });
 
         if (!subscription) {
           throw error;
         }
       }
+    }
+
+    // The documented list response may omit webhook_id. Reconcile the
+    // delivery target/tag with PUT instead of creating a duplicate.
+    if (
+      subscription.webhookId !== webhook.id ||
+      subscription.tag !== expectedTag
+    ) {
+      const updated = await updateXActivitySubscription({
+        subscriptionId: subscription.subscriptionId,
+        webhookId: webhook.id,
+        tag: expectedTag,
+      });
+      subscription = updated;
+      remoteSubscriptions = remoteSubscriptions.map((candidate) =>
+        candidate.subscriptionId === updated.subscriptionId
+          ? updated
+          : candidate
+      );
     }
 
     await args.ctx.runMutation(
@@ -411,7 +540,7 @@ async function ensureWebhookAndSubscriptions(args: {
         xUserId: args.xUserId,
         eventType,
         subscriptionId: subscription.subscriptionId,
-        webhookId: subscription.webhookId,
+        webhookId: subscription.webhookId ?? webhook.id,
         tag: subscription.tag,
       }
     );
@@ -499,7 +628,9 @@ export const ensureDmActivitySubscriptionsForUserInternal = internalAction({
       account.activitySubscriptionsNextRetryAt > now;
     const shouldAttemptDuplicateReconciliation =
       isPendingRetryWindow &&
-      isDuplicateSubscriptionError(account.activitySubscriptionsLastError);
+      isDuplicateXActivitySubscriptionError(
+        account.activitySubscriptionsLastError
+      );
 
     if (isPendingRetryWindow && !shouldAttemptDuplicateReconciliation) {
       return { ensured: false };
@@ -889,8 +1020,9 @@ export const handleWebhookPayloadInternal = internalAction({
           continue;
         }
 
+        const isIncomingMessage = event.eventType.endsWith("received");
         const existingMessage =
-          event.messageId && event.eventType.endsWith("received")
+          event.messageId && isIncomingMessage
             ? await ctx.runQuery(
                 internal.platformConversations.getConversationMessageInternal,
                 {
@@ -900,27 +1032,46 @@ export const handleWebhookPayloadInternal = internalAction({
                 }
               )
             : null;
+        const isEncryptedChatEvent = event.eventType.startsWith("chat.");
 
-        const synced = await syncConversationSnapshot(ctx, {
+        const synced = isEncryptedChatEvent
+          ? null
+          : await syncConversationSnapshot(ctx, {
+              userId,
+              conversationId: event.conversationId,
+              sourceEventType: event.eventType,
+            });
+        // Always consume the normalized webhook payload. For chat.* it is the
+        // only readable message source; for dm.* it fills a race where lookup
+        // has not yet indexed the just-delivered event.
+        const conversation = await persistNormalizedDmActivityEvent(ctx, {
           userId,
-          conversationId: event.conversationId,
-          sourceEventType: event.eventType,
+          event,
         });
 
-        if (event.eventType.endsWith("received") && !existingMessage) {
-          const conversation = synced.conversation;
-          if (conversation?.prospectId) {
-            const latestInbound = [...synced.messages]
-              .reverse()
-              .find((message) => message.direction === "received");
-            if (latestInbound) {
-              await ctx.runMutation(internal.outreach.onProspectDmResponse, {
-                prospectId: conversation.prospectId,
-                responseMessageId: latestInbound.id,
-                responseText: latestInbound.text,
-                conversationId: event.conversationId,
-              });
-            }
+        if (isIncomingMessage && !existingMessage && conversation?.prospectId) {
+          const inboundMessage = event.messageId
+            ? await ctx.runQuery(
+                internal.platformConversations.getConversationMessageInternal,
+                {
+                  userId,
+                  conversationId: event.conversationId,
+                  messageId: event.messageId,
+                }
+              )
+            : [...(synced?.messages ?? [])]
+                .reverse()
+                .find((message) => message.direction === "received");
+          if (inboundMessage) {
+            await ctx.runMutation(internal.outreach.onProspectDmResponse, {
+              prospectId: conversation.prospectId,
+              responseMessageId:
+                "messageId" in inboundMessage
+                  ? inboundMessage.messageId
+                  : inboundMessage.id,
+              responseText: inboundMessage.text ?? "",
+              conversationId: event.conversationId,
+            });
           }
         }
 

--- a/features/agent/ui/AgentChat.tsx
+++ b/features/agent/ui/AgentChat.tsx
@@ -149,6 +149,7 @@ import {
   useRef,
   startTransition,
   type ClipboardEvent,
+  type UIEvent,
 } from "react";
 import { useStore } from "@nanostores/react";
 import { getProspectDisplayData } from "@/features/prospects/lib/getProspectDisplayData";
@@ -169,7 +170,6 @@ import {
   AddIcon,
   SearchActivityIcon,
   ArrowBackIcon,
-  RefreshIcon,
   MoreHorizIcon,
   MailIcon,
   PersonIcon,
@@ -363,6 +363,7 @@ const TOOL_LABELS: Record<string, string> = {
 const AGENT_DISPLAY_NAME = "Agent";
 const AGENT_AVATAR_FALLBACK = "△";
 const AGENT_CHAT_CONTENT_COLUMN_CLASS_NAME = "mx-auto w-full max-w-[48rem]";
+const AGENT_HISTORY_PRELOAD_DISTANCE = 160;
 
 export interface AgentChatProps {
   /** Prospect ID for context (from URL) */
@@ -1883,6 +1884,23 @@ function ChatMessage({
 // Chat Header Component
 // ============================================================================
 
+function AgentHistoryLoadingIndicator({ isLoading }: { isLoading: boolean }) {
+  if (!isLoading) {
+    return null;
+  }
+
+  return (
+    <div
+      className="pointer-events-none absolute inset-x-0 top-2 z-20 flex justify-center"
+      role="status"
+      aria-live="polite"
+      aria-label="Loading earlier messages"
+    >
+      <Spinner variant="circle" className="size-5" />
+    </div>
+  );
+}
+
 interface ChatHeaderProps {
   onBack?: () => void;
   onHistoryClick?: () => void;
@@ -2257,6 +2275,21 @@ export function AgentChat({
     newThreadSignal,
     deferSetupHandoff,
   });
+
+  const handleMessageScroll = useCallback(
+    (event: UIEvent<HTMLDivElement>) => {
+      if (
+        !hasMore ||
+        messageStatus === "LoadingMore" ||
+        event.currentTarget.scrollTop > AGENT_HISTORY_PRELOAD_DISTANCE
+      ) {
+        return;
+      }
+
+      loadMore();
+    },
+    [hasMore, loadMore, messageStatus]
+  );
 
   const rawDisplayMessages = useMemo(
     () => messages.filter((m) => m.key !== "welcome-message"),
@@ -3356,7 +3389,7 @@ export function AgentChat({
           role="status"
           aria-label="Loading setup conversation"
         >
-          <Spinner variant="circle" className="text-muted-foreground size-5" />
+          <Spinner variant="circle" className="size-5" />
         </div>
       </div>
     );
@@ -3612,7 +3645,10 @@ export function AgentChat({
         <div className="relative min-h-0 flex-1">
           <MessageScrollerProvider autoScroll defaultScrollPosition="end">
             <MessageScroller className="relative h-full min-h-0">
-              <MessageScrollerViewport>
+              <AgentHistoryLoadingIndicator
+                isLoading={messageStatus === "LoadingMore"}
+              />
+              <MessageScrollerViewport onScroll={handleMessageScroll}>
                 <MessageScrollerContent
                   className={cn(
                     AGENT_CHAT_CONTENT_COLUMN_CLASS_NAME,
@@ -3629,16 +3665,6 @@ export function AgentChat({
                       <WorkspacePlanLimitAlert />
                     </MessageScrollerItem>
                   ) : null}
-
-                  {hasMore && (
-                    <MessageScrollerItem messageId="load-more" className="mb-4">
-                      <div className="text-center">
-                        <Button size="xsIcon" onClick={loadMore}>
-                          <RefreshIcon className="fill-current" />
-                        </Button>
-                      </div>
-                    </MessageScrollerItem>
-                  )}
 
                   {visibleSetupDisplayMessages.map((message) => (
                     <MessageScrollerItem

--- a/features/agent/ui/components/AgentOnboardingPanelSpinner.tsx
+++ b/features/agent/ui/components/AgentOnboardingPanelSpinner.tsx
@@ -23,7 +23,7 @@ export function AgentOnboardingPanelSpinner({
       <div className="flex h-full min-h-0 w-full items-center justify-center">
         <Spinner
           variant="circle"
-          className="text-muted-foreground size-5"
+          className="size-5"
           aria-label="Loading onboarding draft"
         />
       </div>

--- a/features/prospects/hooks/useProspectDmPanel.ts
+++ b/features/prospects/hooks/useProspectDmPanel.ts
@@ -14,6 +14,7 @@ import type {
   XDmAttachmentSummary,
   XDmPanelContext,
 } from "@/shared/lib/twitter/dm";
+import { mergeConversationHistoryMessages } from "../lib/conversationHistoryHelpers";
 
 const dmPanelCache = new Map<string, XDmPanelContext | null>();
 const dmPanelInflight = new Map<string, Promise<XDmPanelContext | null>>();
@@ -32,6 +33,9 @@ export function useProspectDmPanel(args: {
 }) {
   const { prospectId, actionRequestId, enabled = true } = args;
   const getDmPanelContext = useAction(api.x.getDmPanelContext);
+  const getDmConversationHistoryPage = useAction(
+    api.x.getDmConversationHistoryPage
+  );
   const sendDmMessage = useAction(api.x.sendDmMessage);
   const cancelActionRequest = useMutation(
     api.socialActions.cancelActionRequest
@@ -44,6 +48,7 @@ export function useProspectDmPanel(args: {
   );
   const getDmPanelContextRef = useRef(getDmPanelContext);
   const dataRef = useRef<XDmPanelContext | null>(null);
+  const activeCacheKeyRef = useRef("");
 
   useEffect(() => {
     getDmPanelContextRef.current = getDmPanelContext;
@@ -52,9 +57,15 @@ export function useProspectDmPanel(args: {
   const [data, setData] = useState<XDmPanelContext | null>(null);
   const [loading, setLoading] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const [isLoadingOlder, setIsLoadingOlder] = useState(false);
+  const [loadOlderError, setLoadOlderError] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [statusOverride, setStatusOverride] = useState<string | null>(null);
   const cacheKey = `${prospectId ?? ""}:${actionRequestId ?? ""}`;
+
+  useEffect(() => {
+    activeCacheKeyRef.current = cacheKey;
+  }, [cacheKey]);
 
   useEffect(() => {
     dataRef.current = data;
@@ -65,6 +76,8 @@ export function useProspectDmPanel(args: {
   }, [prospectId, actionRequestId]);
 
   const refetch = useCallback(async () => {
+    setIsLoadingOlder(false);
+    setLoadOlderError(false);
     if (!enabled || !prospectId) {
       setData(null);
       setError(null);
@@ -84,14 +97,17 @@ export function useProspectDmPanel(args: {
     if (existingRequest) {
       setLoading(!hasVisibleData);
       setIsRefreshing(hasVisibleData);
-      const result = await existingRequest;
-      startTransition(() => {
-        setData(result);
-        setError(null);
-      });
-      setLoading(false);
-      setIsRefreshing(false);
-      return result;
+      try {
+        const result = await existingRequest;
+        startTransition(() => {
+          setData(result);
+          setError(null);
+        });
+        return result;
+      } finally {
+        setLoading(false);
+        setIsRefreshing(false);
+      }
     }
 
     try {
@@ -144,6 +160,59 @@ export function useProspectDmPanel(args: {
   useEffect(() => {
     void refetch();
   }, [refetch]);
+
+  const loadOlder = useCallback(async () => {
+    const requestCacheKey = cacheKey;
+    const currentData = dataRef.current;
+    const cursor = currentData?.history?.nextCursor;
+    if (
+      !prospectId ||
+      !currentData?.history?.hasMore ||
+      !cursor ||
+      isLoadingOlder
+    ) {
+      return null;
+    }
+
+    setIsLoadingOlder(true);
+    setLoadOlderError(false);
+    try {
+      const page = await getDmConversationHistoryPage({
+        prospectId: prospectId as Id<"prospects">,
+        cursor,
+        limit: 25,
+      });
+      if (!page) {
+        throw new Error("Conversation history is unavailable.");
+      }
+      if (activeCacheKeyRef.current !== requestCacheKey) return page;
+
+      const latestData = dataRef.current;
+      if (!latestData) return page;
+      const nextData: XDmPanelContext = {
+        ...latestData,
+        conversationId: page.conversationId ?? latestData.conversationId,
+        messages: mergeConversationHistoryMessages(
+          latestData.messages,
+          page.messages
+        ),
+        history: page.history,
+      };
+      dataRef.current = nextData;
+      dmPanelCache.set(cacheKey, nextData);
+      startTransition(() => setData(nextData));
+      return page;
+    } catch {
+      if (activeCacheKeyRef.current === requestCacheKey) {
+        setLoadOlderError(true);
+      }
+      return null;
+    } finally {
+      if (activeCacheKeyRef.current === requestCacheKey) {
+        setIsLoadingOlder(false);
+      }
+    }
+  }, [cacheKey, getDmConversationHistoryPage, isLoadingOlder, prospectId]);
 
   const actionRequestStatus = statusOverride ?? liveDraft?.status ?? null;
   const isPendingApproval = actionRequestStatus === "pending_approval";
@@ -258,8 +327,11 @@ export function useProspectDmPanel(args: {
     data: mergedData,
     loading,
     isRefreshing,
+    isLoadingOlder,
+    loadOlderError,
     error,
     refetch,
+    loadOlder,
     send,
     cancel,
     actionRequestStatus,

--- a/features/prospects/hooks/useProspectLinkedInPanel.ts
+++ b/features/prospects/hooks/useProspectLinkedInPanel.ts
@@ -15,6 +15,7 @@ import type {
   LinkedInConversationPanelContext,
 } from "@/shared/lib/linkedin/conversation";
 import { toast } from "sonner";
+import { mergeConversationHistoryMessages } from "../lib/conversationHistoryHelpers";
 
 const panelCache = new Map<string, LinkedInConversationPanelContext | null>();
 const panelInflight = new Map<
@@ -39,6 +40,9 @@ export function useProspectLinkedInPanel(args: {
   const getPanelContext = useAction(
     linkedinApi.getLinkedInConversationPanelContext
   );
+  const getLinkedInConversationHistoryPage = useAction(
+    linkedinApi.getLinkedInConversationHistoryPage
+  );
   const sendLinkedInMessage = useAction(linkedinApi.sendLinkedInMessage);
   const cancelActionRequest = useMutation(
     api.socialActions.cancelActionRequest
@@ -51,6 +55,7 @@ export function useProspectLinkedInPanel(args: {
   );
   const getPanelContextRef = useRef(getPanelContext);
   const dataRef = useRef<LinkedInConversationPanelContext | null>(null);
+  const activeCacheKeyRef = useRef("");
 
   useEffect(() => {
     getPanelContextRef.current = getPanelContext;
@@ -61,10 +66,16 @@ export function useProspectLinkedInPanel(args: {
   );
   const [loading, setLoading] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const [isLoadingOlder, setIsLoadingOlder] = useState(false);
+  const [loadOlderError, setLoadOlderError] = useState(false);
   const [isSendingMessage, setIsSendingMessage] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [statusOverride, setStatusOverride] = useState<string | null>(null);
   const cacheKey = `${prospectId ?? ""}:${actionRequestId ?? ""}`;
+
+  useEffect(() => {
+    activeCacheKeyRef.current = cacheKey;
+  }, [cacheKey]);
 
   useEffect(() => {
     dataRef.current = data;
@@ -75,6 +86,8 @@ export function useProspectLinkedInPanel(args: {
   }, [prospectId, actionRequestId]);
 
   const refetch = useCallback(async () => {
+    setIsLoadingOlder(false);
+    setLoadOlderError(false);
     if (!enabled || !prospectId) {
       setData(null);
       setError(null);
@@ -96,14 +109,17 @@ export function useProspectLinkedInPanel(args: {
     if (existingRequest) {
       setLoading(!hasVisibleData);
       setIsRefreshing(hasVisibleData);
-      const result = await existingRequest;
-      startTransition(() => {
-        setData(result);
-        setError(null);
-      });
-      setLoading(false);
-      setIsRefreshing(false);
-      return result;
+      try {
+        const result = await existingRequest;
+        startTransition(() => {
+          setData(result);
+          setError(null);
+        });
+        return result;
+      } finally {
+        setLoading(false);
+        setIsRefreshing(false);
+      }
     }
 
     try {
@@ -160,6 +176,64 @@ export function useProspectLinkedInPanel(args: {
   useEffect(() => {
     void refetch();
   }, [refetch]);
+
+  const loadOlder = useCallback(async () => {
+    const requestCacheKey = cacheKey;
+    const currentData = dataRef.current;
+    const cursor = currentData?.history?.nextCursor;
+    if (
+      !prospectId ||
+      !currentData?.history?.hasMore ||
+      !cursor ||
+      isLoadingOlder
+    ) {
+      return null;
+    }
+
+    setIsLoadingOlder(true);
+    setLoadOlderError(false);
+    try {
+      const page = await getLinkedInConversationHistoryPage({
+        prospectId: prospectId as Id<"prospects">,
+        cursor,
+        limit: 25,
+      });
+      if (!page) {
+        throw new Error("Conversation history is unavailable.");
+      }
+      if (activeCacheKeyRef.current !== requestCacheKey) return page;
+
+      const latestData = dataRef.current;
+      if (!latestData) return page;
+      const nextData: LinkedInConversationPanelContext = {
+        ...latestData,
+        conversationId: page.conversationId ?? latestData.conversationId,
+        messages: mergeConversationHistoryMessages(
+          latestData.messages,
+          page.messages
+        ),
+        history: page.history,
+      };
+      dataRef.current = nextData;
+      panelCache.set(cacheKey, nextData);
+      startTransition(() => setData(nextData));
+      return page;
+    } catch {
+      if (activeCacheKeyRef.current === requestCacheKey) {
+        setLoadOlderError(true);
+      }
+      return null;
+    } finally {
+      if (activeCacheKeyRef.current === requestCacheKey) {
+        setIsLoadingOlder(false);
+      }
+    }
+  }, [
+    cacheKey,
+    getLinkedInConversationHistoryPage,
+    isLoadingOlder,
+    prospectId,
+  ]);
 
   const actionRequestStatus = statusOverride ?? liveDraft?.status ?? null;
   const isPendingApproval = actionRequestStatus === "pending_approval";
@@ -387,8 +461,11 @@ export function useProspectLinkedInPanel(args: {
     data: mergedData,
     loading,
     isRefreshing,
+    isLoadingOlder,
+    loadOlderError,
     error,
     refetch,
+    loadOlder,
     send,
     cancel,
     actionRequestStatus,

--- a/features/prospects/lib/conversationHistoryHelpers.ts
+++ b/features/prospects/lib/conversationHistoryHelpers.ts
@@ -1,0 +1,30 @@
+type ConversationMessageLike = {
+  id: string;
+  createdAt?: string;
+};
+
+function toConversationMessageTimestamp(createdAt?: string): number {
+  return createdAt ? (parseIsoToTimestamp(createdAt) ?? 0) : 0;
+}
+
+/** Merge overlapping provider pages while preserving chronological rendering. */
+export function mergeConversationHistoryMessages<
+  T extends ConversationMessageLike,
+>(current: T[], incoming: T[]): T[] {
+  const messagesById = new Map<string, T>();
+
+  for (const message of incoming) {
+    messagesById.set(message.id, message);
+  }
+  for (const message of current) {
+    messagesById.set(message.id, message);
+  }
+
+  return [...messagesById.values()].sort((left, right) => {
+    const timestampDifference =
+      toConversationMessageTimestamp(left.createdAt) -
+      toConversationMessageTimestamp(right.createdAt);
+    return timestampDifference || left.id.localeCompare(right.id);
+  });
+}
+import { parseIsoToTimestamp } from "@/shared/lib/utils/time/timeUtils";

--- a/features/prospects/ui/components/ConversationHistoryPagination.tsx
+++ b/features/prospects/ui/components/ConversationHistoryPagination.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import * as React from "react";
+import { InfiniteScrollTrigger } from "@/shared/ui/components/InfiniteScrollTrigger";
+import { useScrollAreaViewportRef } from "@/shared/ui/components/ScrollArea";
+
+type ConversationHistoryPaginationProps = {
+  conversationKey: string;
+  messageCount: number;
+  hasMore: boolean;
+  isLoading: boolean;
+  loadMoreError?: boolean;
+  onLoadMore: () => void;
+};
+
+type PendingScrollAnchor = {
+  scrollHeight: number;
+  scrollTop: number;
+};
+
+/**
+ * Keeps a chat on its latest messages while preserving the visible message
+ * when an older provider page is prepended.
+ */
+function ConversationHistoryPagination({
+  conversationKey,
+  messageCount,
+  hasMore,
+  isLoading,
+  loadMoreError = false,
+  onLoadMore,
+}: ConversationHistoryPaginationProps) {
+  const viewportRef = useScrollAreaViewportRef();
+  const initializedConversationRef = React.useRef<string | null>(null);
+  const pendingAnchorRef = React.useRef<PendingScrollAnchor | null>(null);
+
+  React.useLayoutEffect(() => {
+    const viewport = viewportRef?.current;
+    if (!viewport) return;
+
+    if (initializedConversationRef.current !== conversationKey) {
+      initializedConversationRef.current = conversationKey;
+      pendingAnchorRef.current = null;
+
+      if (messageCount > 0) {
+        viewport.scrollTop = viewport.scrollHeight;
+      }
+    } else if (pendingAnchorRef.current && !isLoading) {
+      const pendingAnchor = pendingAnchorRef.current;
+      viewport.scrollTop =
+        pendingAnchor.scrollTop +
+        (viewport.scrollHeight - pendingAnchor.scrollHeight);
+      pendingAnchorRef.current = null;
+    }
+  }, [conversationKey, isLoading, messageCount, viewportRef]);
+
+  const handleLoadMore = React.useCallback(() => {
+    const viewport = viewportRef?.current;
+    if (viewport) {
+      pendingAnchorRef.current = {
+        scrollHeight: viewport.scrollHeight,
+        scrollTop: viewport.scrollTop,
+      };
+    }
+    onLoadMore();
+  }, [onLoadMore, viewportRef]);
+
+  if (!hasMore && !isLoading && !loadMoreError) return null;
+
+  return (
+    <InfiniteScrollTrigger
+      direction="start"
+      preloadDistance={160}
+      hasMore={hasMore}
+      isLoading={isLoading}
+      loadMoreError={loadMoreError}
+      onLoadMore={handleLoadMore}
+      resultCount={messageCount}
+      showKeyboardFallback={false}
+      loadingLabel="Loading earlier messages"
+      loadMoreLabel="Load earlier messages"
+      retryLabel="Retry loading earlier messages"
+    />
+  );
+}
+
+export { ConversationHistoryPagination };

--- a/features/prospects/ui/components/LinkedInConversationPanel.tsx
+++ b/features/prospects/ui/components/LinkedInConversationPanel.tsx
@@ -16,6 +16,7 @@ import {
   DM_COMPOSER_PLACEHOLDER_CLASS,
 } from "@/features/composer/ui/dmComposerClasses";
 import { useProspectLinkedInPanel } from "../../hooks/useProspectLinkedInPanel";
+import { ConversationHistoryPagination } from "./ConversationHistoryPagination";
 import { Button } from "@/shared/ui/components/Button";
 import {
   Alert,
@@ -23,7 +24,7 @@ import {
   AlertTitle,
 } from "@/shared/ui/components/Alert";
 import { ScrollArea } from "@/shared/ui/components/ScrollArea";
-import { Skeleton } from "@/shared/ui/components/Skeleton";
+import { Spinner } from "@/shared/ui/components/Spinner";
 import {
   Avatar,
   AvatarFallback,
@@ -130,7 +131,10 @@ export function LinkedInConversationPanel({
     data,
     loading,
     isRefreshing,
+    isLoadingOlder,
+    loadOlderError,
     error,
+    loadOlder,
     send,
     cancel,
     actionRequestStatus,
@@ -474,25 +478,12 @@ export function LinkedInConversationPanel({
           <ScrollArea className="min-h-0 flex-1" viewportClassName="pb-4">
             <PageContent className="space-y-4 px-4 py-4">
               {resolvedLoading ? (
-                <div className="space-y-4">
-                  <div className="flex flex-col gap-1">
-                    <Skeleton className="h-10 w-3/5 self-start rounded-[20px]" />
-                    <Skeleton className="h-6 w-2/5 self-start rounded-[20px]" />
-                  </div>
-                  <div className="flex flex-col gap-1">
-                    <Skeleton className="bg-foreground/10 h-10 w-1/2 self-end rounded-[20px]" />
-                  </div>
-                  <div className="flex flex-col gap-1">
-                    <Skeleton className="h-10 w-4/5 self-start rounded-[20px]" />
-                    <Skeleton className="h-6 w-2/5 self-start rounded-[20px]" />
-                  </div>
-                  <div className="flex flex-col gap-1">
-                    <Skeleton className="bg-foreground/10 h-10 w-3/5 self-end rounded-[20px]" />
-                    <Skeleton className="bg-foreground/10 h-6 w-1/3 self-end rounded-[20px]" />
-                  </div>
-                  <div className="flex flex-col gap-1">
-                    <Skeleton className="h-10 w-1/2 self-start rounded-[20px]" />
-                  </div>
+                <div
+                  role="status"
+                  aria-label="Loading LinkedIn conversation"
+                  className="flex min-h-48 items-center justify-center"
+                >
+                  <Spinner variant="circle" className="size-5" />
                 </div>
               ) : resolvedError ? (
                 <Alert>
@@ -532,6 +523,24 @@ export function LinkedInConversationPanel({
                     <span className="sr-only" aria-live="polite">
                       Refreshing conversation
                     </span>
+                  ) : null}
+                  {!isPreview && loadOlderError ? (
+                    <p
+                      role="alert"
+                      className="text-muted-foreground text-center text-xs"
+                    >
+                      Could not load earlier messages. Try again.
+                    </p>
+                  ) : null}
+                  {!isPreview ? (
+                    <ConversationHistoryPagination
+                      conversationKey={`${prospectId}:${resolvedData.conversationId ?? "pending"}`}
+                      messageCount={resolvedData.messages.length}
+                      hasMore={resolvedData.history?.hasMore === true}
+                      isLoading={isLoadingOlder}
+                      loadMoreError={loadOlderError}
+                      onLoadMore={() => void loadOlder()}
+                    />
                   ) : null}
                   {resolvedData.messages.length === 0 ? (
                     <div className="mx-auto flex w-full max-w-sm flex-col items-center px-4 pt-6 text-center">

--- a/features/prospects/ui/components/XConversationPanel.tsx
+++ b/features/prospects/ui/components/XConversationPanel.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/features/composer/ui/dmComposerClasses";
 import { formatDmMessageTime } from "../../lib/formatDmMessageTime";
 import { useProspectDmPanel } from "../../hooks/useProspectDmPanel";
+import { ConversationHistoryPagination } from "./ConversationHistoryPagination";
 import { XDmConversationMenu } from "./XDmConversationMenu";
 import { Button } from "@/shared/ui/components/Button";
 import {
@@ -25,7 +26,7 @@ import {
   AlertTitle,
 } from "@/shared/ui/components/Alert";
 import { ScrollArea } from "@/shared/ui/components/ScrollArea";
-import { Skeleton } from "@/shared/ui/components/Skeleton";
+import { Spinner } from "@/shared/ui/components/Spinner";
 import {
   Avatar,
   AvatarFallback,
@@ -100,7 +101,10 @@ export function XConversationPanel({
     data,
     loading,
     isRefreshing,
+    isLoadingOlder,
+    loadOlderError,
     error,
+    loadOlder,
     send,
     cancel,
     actionRequestStatus,
@@ -328,7 +332,7 @@ export function XConversationPanel({
             mediaKinds: resolvedMediaKinds,
           });
           toast.success("DM approved.", {
-            description: "Queued. We'll notify you if X blocks it.",
+            description: "Queued. We'll notify you if X/Twitter blocks it.",
           });
           return;
         }
@@ -406,7 +410,7 @@ export function XConversationPanel({
     >
       <PageLayout className="flex h-full max-w-[520px] flex-col md:w-full md:max-w-[520px]">
         <PageHeader
-          title={data?.prospect.displayName ?? "X DM"}
+          title={data?.prospect.displayName ?? "X/Twitter DM"}
           titleLeading={
             data ? (
               <ProspectPlatformAvatar platform="twitter" badgeSize="sm">
@@ -437,29 +441,18 @@ export function XConversationPanel({
           <ScrollArea className="min-h-0 flex-1" viewportClassName="pb-4">
             <PageContent className="space-y-4 px-4 py-4">
               {loading ? (
-                <div className="space-y-4">
-                  <div className="flex flex-col gap-1">
-                    <Skeleton className="h-10 w-3/5 self-start rounded-[20px]" />
-                    <Skeleton className="h-6 w-2/5 self-start rounded-[20px]" />
-                  </div>
-                  <div className="flex flex-col gap-1">
-                    <Skeleton className="bg-foreground/10 h-10 w-1/2 self-end rounded-[20px]" />
-                  </div>
-                  <div className="flex flex-col gap-1">
-                    <Skeleton className="h-10 w-4/5 self-start rounded-[20px]" />
-                    <Skeleton className="h-6 w-2/5 self-start rounded-[20px]" />
-                  </div>
-                  <div className="flex flex-col gap-1">
-                    <Skeleton className="bg-foreground/10 h-10 w-3/5 self-end rounded-[20px]" />
-                    <Skeleton className="bg-foreground/10 h-6 w-1/3 self-end rounded-[20px]" />
-                  </div>
-                  <div className="flex flex-col gap-1">
-                    <Skeleton className="h-10 w-1/2 self-start rounded-[20px]" />
-                  </div>
+                <div
+                  role="status"
+                  aria-label="Loading X/Twitter conversation"
+                  className="flex min-h-48 items-center justify-center"
+                >
+                  <Spinner variant="circle" className="size-5" />
                 </div>
               ) : error ? (
                 <div className="rounded-[20px] border px-4 py-3 text-sm">
-                  <p className="font-medium">Could not load X conversation</p>
+                  <p className="font-medium">
+                    Could not load X/Twitter conversation
+                  </p>
                   <p className="text-muted-foreground mt-1">{error}</p>
                 </div>
               ) : data ? (
@@ -477,6 +470,29 @@ export function XConversationPanel({
                       Refreshing conversation
                     </span>
                   ) : null}
+                  {data.history?.boundary === "x_30_day_limit" &&
+                  !data.history.hasMore ? (
+                    <p className="text-muted-foreground text-center text-xs">
+                      X/Twitter provides conversation history from the past 30
+                      days.
+                    </p>
+                  ) : null}
+                  {loadOlderError ? (
+                    <p
+                      role="alert"
+                      className="text-muted-foreground text-center text-xs"
+                    >
+                      Could not load earlier messages. Try again.
+                    </p>
+                  ) : null}
+                  <ConversationHistoryPagination
+                    conversationKey={`${prospectId}:${data.conversationId ?? "pending"}`}
+                    messageCount={data.messages.length}
+                    hasMore={data.history?.hasMore === true}
+                    isLoading={isLoadingOlder}
+                    loadMoreError={loadOlderError}
+                    onLoadMore={() => void loadOlder()}
+                  />
                   {renderedMessages.length === 0 ? (
                     <div className="mx-auto flex w-full max-w-sm flex-col items-center px-4 pt-6 text-center">
                       <ProspectPlatformAvatar platform="twitter" badgeSize="lg">

--- a/shared/lib/linkedin/conversation.ts
+++ b/shared/lib/linkedin/conversation.ts
@@ -68,6 +68,13 @@ export interface LinkedInConversationPanelWarning {
   retryAfterMs?: number;
 }
 
+/** Opaque provider pagination state for older conversation messages. */
+export interface LinkedInConversationHistoryPageState {
+  nextCursor?: string;
+  hasMore: boolean;
+  boundary?: "complete" | "x_30_day_limit";
+}
+
 export interface LinkedInConversationPanelContext {
   platform: "linkedin";
   conversationId?: string;
@@ -80,6 +87,8 @@ export interface LinkedInConversationPanelContext {
   prospect: LinkedInConversationProspectSummary;
   eligibility: LinkedInConversationEligibility;
   messages: LinkedInConversationMessage[];
+  /** Provider page metadata; messages are always returned ascending for rendering. */
+  history?: LinkedInConversationHistoryPageState;
   draftText?: string;
   draftAttachments?: LinkedInConversationAttachmentSummary[];
   actionRequestId?: string;

--- a/shared/lib/twitter/dm.ts
+++ b/shared/lib/twitter/dm.ts
@@ -59,6 +59,14 @@ export interface XDmPanelWarning {
   retryAfterMs?: number;
 }
 
+/** Opaque provider pagination state for older conversation messages. */
+export interface ConversationHistoryPageState {
+  nextCursor?: string;
+  hasMore: boolean;
+  /** X's DM lookup API cannot return events older than 30 days. */
+  boundary?: "complete" | "x_30_day_limit";
+}
+
 export interface XDmPanelContext {
   platform: "twitter";
   conversationId?: string;
@@ -68,6 +76,8 @@ export interface XDmPanelContext {
   prospect: XDmProspectSummary;
   eligibility: XDmEligibility;
   messages: XDmMessage[];
+  /** The current provider page is newest-first from the API, normalized ascending for rendering. */
+  history?: ConversationHistoryPageState;
   draftText?: string;
   draftAttachments?: XDmAttachmentSummary[];
   actionRequestId?: string;

--- a/shared/ui/components/InfiniteScrollTrigger.tsx
+++ b/shared/ui/components/InfiniteScrollTrigger.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Button } from "@/shared/ui/components/Button";
 import { useScrollAreaViewportRef } from "@/shared/ui/components/ScrollArea";
+import { Spinner } from "@/shared/ui/components/Spinner";
 import { cn } from "@/shared/lib/utils";
 
 const DEFAULT_PRELOAD_DISTANCE = 600;
@@ -15,6 +16,12 @@ type InfiniteScrollTriggerProps = {
   resultCount: number;
   className?: string;
   preloadDistance?: number;
+  direction?: "start" | "end";
+  loadingLabel?: string;
+  loadMoreLabel?: string;
+  retryLabel?: string;
+  /** Keep the normal path fully automatic; errors still expose retry UI. */
+  showKeyboardFallback?: boolean;
 };
 
 /**
@@ -29,6 +36,11 @@ function InfiniteScrollTrigger({
   resultCount,
   className,
   preloadDistance = DEFAULT_PRELOAD_DISTANCE,
+  direction = "end",
+  loadingLabel = "Loading more results",
+  loadMoreLabel = "Load more results",
+  retryLabel = "Retry loading more",
+  showKeyboardFallback = true,
 }: InfiniteScrollTriggerProps) {
   const sentinelRef = useRef<HTMLDivElement>(null);
   const scrollAreaViewportRef = useScrollAreaViewportRef();
@@ -63,7 +75,10 @@ function InfiniteScrollTrigger({
       },
       {
         root,
-        rootMargin: `0px 0px ${preloadDistance}px 0px`,
+        rootMargin:
+          direction === "start"
+            ? `${preloadDistance}px 0px 0px 0px`
+            : `0px 0px ${preloadDistance}px 0px`,
         threshold: 0,
       }
     );
@@ -73,11 +88,16 @@ function InfiniteScrollTrigger({
 
       animationFrame = window.requestAnimationFrame(() => {
         animationFrame = null;
-        const remainingDistance = root
-          ? root.scrollHeight - root.scrollTop - root.clientHeight
-          : document.documentElement.scrollHeight -
-            window.scrollY -
-            window.innerHeight;
+        const remainingDistance =
+          direction === "start"
+            ? root
+              ? root.scrollTop
+              : window.scrollY
+            : root
+              ? root.scrollHeight - root.scrollTop - root.clientHeight
+              : document.documentElement.scrollHeight -
+                window.scrollY -
+                window.innerHeight;
 
         if (remainingDistance <= preloadDistance) {
           requestMore();
@@ -103,6 +123,7 @@ function InfiniteScrollTrigger({
     hasMore,
     isLoading,
     loadMoreError,
+    direction,
     preloadDistance,
     resultCount,
     scrollAreaViewportRef,
@@ -125,14 +146,19 @@ function InfiniteScrollTrigger({
       }
       className={cn(
         "relative h-px w-full",
-        showVisibleFallback && "h-auto pt-2",
+        (isLoading || showVisibleFallback) && "h-auto pt-2",
         className
       )}
     >
       {isLoading ? (
-        <span role="status" aria-live="polite" className="sr-only">
-          Loading more results
-        </span>
+        <div
+          role="status"
+          aria-live="polite"
+          aria-label={loadingLabel}
+          className="flex justify-center py-2"
+        >
+          <Spinner variant="circle" className="size-5" />
+        </div>
       ) : showVisibleFallback ? (
         <Button
           type="button"
@@ -141,9 +167,9 @@ function InfiniteScrollTrigger({
           className="w-full"
           onClick={onLoadMore}
         >
-          {loadMoreError ? "Retry loading more" : "Load more"}
+          {loadMoreError ? retryLabel : loadMoreLabel}
         </Button>
-      ) : hasMore ? (
+      ) : hasMore && showKeyboardFallback ? (
         <Button
           type="button"
           size="xs"
@@ -151,7 +177,7 @@ function InfiniteScrollTrigger({
           className="sr-only focus:not-sr-only focus:absolute focus:inset-x-0 focus:top-2 focus:z-20 focus:w-full"
           onClick={onLoadMore}
         >
-          Load more results
+          {loadMoreLabel}
         </Button>
       ) : null}
     </div>

--- a/shared/ui/components/Spinner.tsx
+++ b/shared/ui/components/Spinner.tsx
@@ -13,7 +13,10 @@ const Default = ({ className, ...props }: SpinnerVariantProps) => (
 );
 
 const Circle = ({ className, ...props }: SpinnerVariantProps) => (
-  <LoaderCircleIcon className={cn("animate-spin", className)} {...props} />
+  <LoaderCircleIcon
+    className={cn(className, "text-primary animate-spin")}
+    {...props}
+  />
 );
 
 const Pinwheel = ({ className, ...props }: SpinnerVariantProps) => (

--- a/tests/conversation-history-pagination.test.ts
+++ b/tests/conversation-history-pagination.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { mergeConversationHistoryMessages } from "../features/prospects/lib/conversationHistoryHelpers";
+
+test("conversation pages merge without duplicates in chronological order", () => {
+  const current = [
+    { id: "3", createdAt: "2026-08-10T12:00:00.000Z", text: "latest" },
+    { id: "2", createdAt: "2026-08-10T11:00:00.000Z", text: "current" },
+  ];
+  const olderPage = [
+    { id: "1", createdAt: "2026-08-10T10:00:00.000Z", text: "older" },
+    {
+      id: "2",
+      createdAt: "2026-08-10T11:00:00.000Z",
+      text: "provider overlap",
+    },
+  ];
+
+  const merged = mergeConversationHistoryMessages(current, olderPage);
+
+  assert.deepEqual(
+    merged.map((message) => message.id),
+    ["1", "2", "3"]
+  );
+  assert.equal(merged[1]?.text, "current");
+});
+
+test("both conversation hooks request exactly one bounded older page", () => {
+  for (const file of [
+    "features/prospects/hooks/useProspectDmPanel.ts",
+    "features/prospects/hooks/useProspectLinkedInPanel.ts",
+  ]) {
+    const source = readFileSync(file, "utf8");
+
+    assert.match(source, /ConversationHistoryPage/);
+    assert.match(source, /cursor,/);
+    assert.match(source, /limit: 25/);
+    assert.match(source, /mergeConversationHistoryMessages/);
+    assert.doesNotMatch(source, /while\s*\(/);
+  }
+});
+
+test("conversation panels expose upward history loading and recovery copy", () => {
+  for (const file of [
+    "features/prospects/ui/components/XConversationPanel.tsx",
+    "features/prospects/ui/components/LinkedInConversationPanel.tsx",
+  ]) {
+    const source = readFileSync(file, "utf8");
+
+    assert.match(source, /<ConversationHistoryPagination/);
+    assert.match(source, /Could not load earlier messages\. Try again\./);
+  }
+
+  const paginationSource = readFileSync(
+    "features/prospects/ui/components/ConversationHistoryPagination.tsx",
+    "utf8"
+  );
+  assert.match(paginationSource, /<InfiniteScrollTrigger/);
+  assert.match(paginationSource, /hasMore=\{hasMore\}/);
+  assert.match(paginationSource, /showKeyboardFallback=\{false\}/);
+  assert.doesNotMatch(paginationSource, /<Button/);
+  assert.doesNotMatch(paginationSource, /userScrolledUp|canScroll/);
+
+  const xSource = readFileSync(
+    "features/prospects/ui/components/XConversationPanel.tsx",
+    "utf8"
+  );
+  assert.match(
+    xSource,
+    /X\/Twitter provides conversation history from the past 30/
+  );
+});

--- a/tests/dm-history-core.test.ts
+++ b/tests/dm-history-core.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  applyConversationHistorySince,
+  buildConversationHistoryPageMetadata,
+  getProviderPageCursor,
+  normalizeConversationHistoryPageLimit,
+  selectDeterministicLinkedInChat,
+  shouldPersistRecentConversationHistoryPage,
+} from "../convex/lib/conversationHistoryPaginationCore";
+import {
+  findMatchingXActivitySubscription,
+  isDuplicateXActivitySubscriptionError,
+} from "../convex/lib/xActivityReconciliationCore";
+import {
+  getWebhookMessageDirection,
+  getWebhookParticipantProviderId,
+} from "../convex/lib/linkedinWebhookCore";
+import { parseIsoToTimestamp } from "../shared/lib/utils/time/timeUtils";
+
+test("conversation history limits are bounded and provider cursors remain opaque", () => {
+  assert.equal(normalizeConversationHistoryPageLimit(), 25);
+  assert.equal(normalizeConversationHistoryPageLimit(0), 1);
+  assert.equal(normalizeConversationHistoryPageLimit(500), 50);
+  assert.equal(
+    getProviderPageCursor({ meta: { next_token: "opaque/x-token" } }),
+    "opaque/x-token"
+  );
+  assert.equal(
+    getProviderPageCursor({ cursor: "opaque-linkedin-token" }),
+    "opaque-linkedin-token"
+  );
+});
+
+test("date boundaries stop pagination without returning older messages", () => {
+  const sinceMs = parseIsoToTimestamp("2026-08-10T11:00:00.000Z");
+  if (typeof sinceMs !== "number") {
+    throw new Error("Expected a valid ISO timestamp fixture.");
+  }
+  const result = applyConversationHistorySince(
+    [
+      { id: "1", createdAt: "2026-08-10T10:00:00.000Z" },
+      { id: "2", createdAt: "2026-08-10T11:00:00.000Z" },
+      { id: "3", createdAt: "2026-08-10T12:00:00.000Z" },
+    ],
+    sinceMs
+  );
+
+  assert.deepEqual(
+    result.items.map((item) => item.id),
+    ["2", "3"]
+  );
+  assert.equal(result.reachedSince, true);
+  assert.deepEqual(
+    buildConversationHistoryPageMetadata({
+      providerCursor: "unused-after-boundary",
+      reachedSince: result.reachedSince,
+      platform: "twitter",
+    }),
+    {
+      nextCursor: undefined,
+      hasMore: false,
+      boundary: "x_30_day_limit",
+    }
+  );
+});
+
+test("older provider pages are not added to the recent conversation cache", () => {
+  assert.equal(shouldPersistRecentConversationHistoryPage({}), true);
+  assert.equal(
+    shouldPersistRecentConversationHistoryPage({ cursor: "older-page" }),
+    false
+  );
+  assert.equal(
+    shouldPersistRecentConversationHistoryPage({ sinceMs: 123 }),
+    false
+  );
+});
+
+test("LinkedIn chat selection is deterministic for the requested attendee", () => {
+  const selected = selectDeterministicLinkedInChat(
+    [
+      {
+        id: "wrong-attendee",
+        attendee_provider_id: "other",
+        timestamp: "2026-08-10T13:00:00.000Z",
+      },
+      {
+        id: "older-match",
+        attendee_provider_id: "target",
+        timestamp: "2026-08-10T11:00:00.000Z",
+      },
+      {
+        id: "newer-match",
+        attendee_provider_id: "target",
+        timestamp: "2026-08-10T12:00:00.000Z",
+      },
+    ],
+    "target"
+  );
+
+  assert.equal(selected?.id, "newer-match");
+});
+
+test("X/Twitter subscription reconciliation handles paginated-list omissions", () => {
+  const subscription = findMatchingXActivitySubscription(
+    [
+      {
+        subscriptionId: "subscription-1",
+        eventType: "chat.received",
+        filterUserId: "viewer-1",
+        tag: "reacherx:user-1:chat.received",
+      },
+    ],
+    {
+      eventType: "chat.received",
+      xUserId: "viewer-1",
+      webhookId: "webhook-1",
+      expectedTag: "reacherx:user-1:chat.received",
+    }
+  );
+
+  assert.equal(subscription?.subscriptionId, "subscription-1");
+  assert.equal(
+    isDuplicateXActivitySubscriptionError(
+      new Error("DuplicateSubscription: subscription already exists")
+    ),
+    true
+  );
+});
+
+test("Unipile message_received direction uses account and sender provider ids", () => {
+  const sentPayload = {
+    event: "message_received",
+    account_info: { user_id: "self" },
+    sender: { attendee_provider_id: "self" },
+  };
+  const receivedPayload = {
+    event: "message_received",
+    account_info: { user_id: "self" },
+    sender: { attendee_provider_id: "prospect" },
+  };
+
+  assert.equal(getWebhookMessageDirection(sentPayload, {}), "sent");
+  assert.equal(getWebhookMessageDirection(receivedPayload, {}), "received");
+  assert.equal(
+    getWebhookParticipantProviderId(receivedPayload, {}),
+    "prospect"
+  );
+});

--- a/tests/e2e/dm-conversation-history.md
+++ b/tests/e2e/dm-conversation-history.md
@@ -1,0 +1,33 @@
+# DM conversation history verification
+
+Date: 2026-08-10
+
+Branch: `codex/fix-dm-conversation-history`
+
+## Automated coverage
+
+- X/Twitter and LinkedIn provider-page normalization, cursor handling, ascending order, deduplication, and history boundaries.
+- X/Twitter Activity subscription pagination and duplicate reconciliation.
+- LinkedIn webhook direction detection for sent and received messages.
+- Agent date-range and continuation behavior, including the bounded provider-page budget.
+- Conversation-panel prepend behavior, scroll anchoring, circular loading state, retry copy, and history-boundary copy.
+- Shared infinite-scroll loading spinner used by the `/` prospects page.
+
+## Browser verification
+
+Environment: local Next.js app and development Convex deployment.
+
+- Confirmed the signed-in connected-accounts page shows the expected Google, X/Twitter, and LinkedIn connections.
+- On `/`, confirmed the initial result set rendered 10 prospect cards.
+- Scrolled to the infinite-load boundary and observed the circular spinner with the accessible label `Loading more results`.
+- Confirmed the next page appended successfully, increasing the visible result count from 10 to 14.
+- Confirmed there were no browser console errors or warnings after the flow.
+
+The development workspace has no eligible contacted prospect with an enabled DM action, so a live provider-backed conversation-history continuation could not be exercised without seeding data or changing production state. That path is covered by the automated provider, hook, and UI regression tests. Production was inspected read-only and was not deployed or mutated.
+
+## Deployment and migration check
+
+- The new conversation-history fields are optional.
+- The new `platformConversations.by_user_prospect_platform` index is created by the normal Convex deployment.
+- Development and production webhook configuration rows were inspected read-only; neither contains the unsupported `message_sent` event.
+- No data migration or backfill is required.

--- a/tests/infinite-scroll.test.ts
+++ b/tests/infinite-scroll.test.ts
@@ -60,7 +60,20 @@ test("normal loading and exhaustion keep a stable footer height", () => {
   assert.match(source, /"relative h-px w-full"/);
   assert.match(source, /data-state=/);
   assert.match(source, /Loading more results/);
+  assert.match(source, /<Spinner/);
+  assert.match(source, /variant="circle"/);
   assert.doesNotMatch(source, /AsciiSpinnerText/);
+});
+
+test("infinite scroll supports loading earlier results from the top", () => {
+  const source = readFileSync(INFINITE_SCROLL_FILE, "utf8");
+
+  assert.match(source, /direction\?: "start" \| "end"/);
+  assert.match(source, /direction === "start"/);
+  assert.match(source, /root\.scrollTop/);
+  assert.match(source, /loadingLabel/);
+  assert.match(source, /loadMoreLabel/);
+  assert.match(source, /retryLabel/);
 });
 
 test("overlapping reactive pages do not render duplicate prospects", () => {

--- a/tests/prospect-interaction-history-core.test.ts
+++ b/tests/prospect-interaction-history-core.test.ts
@@ -5,15 +5,18 @@ import {
   normalizeConversationMessage,
   normalizePublicInteraction,
 } from "../convex/lib/prospectInteractionHistoryCore";
+import type { Id } from "../convex/_generated/dataModel";
 
 test("normalizes DMs and public interactions into one agent-safe shape", () => {
   const dm = normalizeConversationMessage({
     platform: "twitter",
+    messageId: "dm-1",
     direction: "received",
     createdAtMs: 300,
     text: "  Interested—send me the details.  ",
   });
   const comment = normalizePublicInteraction({
+    _id: "interaction-1" as Id<"prospectInteractions">,
     platform: "linkedin",
     interactionType: "comment_reply_posted",
     direction: "outgoing",
@@ -23,6 +26,7 @@ test("normalizes DMs and public interactions into one agent-safe shape", () => {
   });
 
   assert.deepEqual(dm, {
+    id: "dm-1",
     kind: "dm",
     platform: "twitter",
     direction: "received",
@@ -32,6 +36,7 @@ test("normalizes DMs and public interactions into one agent-safe shape", () => {
     attachmentCount: 0,
   });
   assert.deepEqual(comment, {
+    id: "interaction-1",
     kind: "comment",
     platform: "linkedin",
     direction: "sent",
@@ -48,6 +53,7 @@ test("filters interaction history dynamically and keeps newest items first", () 
   const result = filterProspectInteractionHistory({
     items: [
       {
+        id: "reply-1",
         kind: "reply",
         platform: "twitter",
         direction: "sent",
@@ -56,6 +62,7 @@ test("filters interaction history dynamically and keeps newest items first", () 
         attachmentCount: 0,
       },
       {
+        id: "dm-1",
         kind: "dm",
         platform: "twitter",
         direction: "received",
@@ -64,6 +71,7 @@ test("filters interaction history dynamically and keeps newest items first", () 
         attachmentCount: 0,
       },
       {
+        id: "comment-1",
         kind: "comment",
         platform: "linkedin",
         direction: "received",

--- a/tests/ui-consistency-regressions.test.ts
+++ b/tests/ui-consistency-regressions.test.ts
@@ -71,6 +71,83 @@ test("LinkedIn unavailable states use shared actionable alerts", () => {
   assert.match(conversationSource, /messagingRecoveryAction\.label/);
 });
 
+test("DM panels use circular loading and X/Twitter product copy", () => {
+  const xConversationSource = readSource(
+    "features/prospects/ui/components/XConversationPanel.tsx"
+  );
+  const linkedInConversationSource = readSource(
+    "features/prospects/ui/components/LinkedInConversationPanel.tsx"
+  );
+
+  for (const source of [xConversationSource, linkedInConversationSource]) {
+    assert.match(source, /<Spinner/);
+    assert.match(source, /variant="circle"/);
+    assert.doesNotMatch(source, /<Skeleton/);
+  }
+
+  assert.match(xConversationSource, /Loading X\/Twitter conversation/);
+  assert.match(xConversationSource, /Could not load X\/Twitter conversation/);
+  assert.doesNotMatch(xConversationSource, /Could not load X conversation/);
+});
+
+test("circular spinners use the primary color without local overrides", () => {
+  const spinnerSource = readSource("shared/ui/components/Spinner.tsx");
+  assert.match(spinnerSource, /text-primary animate-spin/);
+
+  for (const file of [
+    "shared/ui/components/InfiniteScrollTrigger.tsx",
+    "features/agent/ui/AgentChat.tsx",
+    "features/agent/ui/components/AgentOnboardingPanelSpinner.tsx",
+    "features/prospects/ui/components/XConversationPanel.tsx",
+    "features/prospects/ui/components/LinkedInConversationPanel.tsx",
+    "features/composer/ui/components/MediaUploadSection.tsx",
+  ]) {
+    const source = readSource(file);
+    for (const match of source.matchAll(/<Spinner\b[\s\S]*?\/>/g)) {
+      if (match[0].includes('variant="circle"')) {
+        assert.doesNotMatch(
+          match[0],
+          /text-(?:muted-foreground|foreground|primary-foreground)/,
+          `${file} must not override the shared circle-spinner color`
+        );
+      }
+    }
+  }
+});
+
+test("conversation history opens at the latest page and preserves scroll position", () => {
+  const historyPaginationSource = readSource(
+    "features/prospects/ui/components/ConversationHistoryPagination.tsx"
+  );
+
+  assert.match(
+    historyPaginationSource,
+    /viewport\.scrollTop = viewport\.scrollHeight/
+  );
+  assert.match(
+    historyPaginationSource,
+    /viewport\.scrollHeight - pendingAnchor\.scrollHeight/
+  );
+  assert.match(historyPaginationSource, /direction="start"/);
+  assert.match(historyPaginationSource, /Loading earlier messages/);
+  assert.doesNotMatch(historyPaginationSource, /<Button/);
+  assert.doesNotMatch(historyPaginationSource, /userScrolledUp|canScroll/);
+});
+
+test("Agent history loads at the start edge with a circular spinner", () => {
+  const agentChatSource = readSource("features/agent/ui/AgentChat.tsx");
+
+  assert.match(agentChatSource, /function AgentHistoryLoadingIndicator/);
+  assert.match(agentChatSource, /onScroll=\{handleMessageScroll\}/);
+  assert.match(agentChatSource, /scrollTop > AGENT_HISTORY_PRELOAD_DISTANCE/);
+  assert.match(agentChatSource, /messageStatus === "LoadingMore"/);
+  assert.match(agentChatSource, /Loading earlier messages/);
+  assert.match(agentChatSource, /<Spinner/);
+  assert.match(agentChatSource, /variant="circle"/);
+  assert.doesNotMatch(agentChatSource, /messageId="load-more"/);
+  assert.doesNotMatch(agentChatSource, /RefreshIcon/);
+});
+
 test("desktop side panels own a left divider and mobile panels have no side borders", () => {
   const pageLayoutSource = readSource(
     "features/webapp/ui/components/page/PageLayout.tsx"


### PR DESCRIPTION
## What changed
- Add bounded, paginated X/Twitter and LinkedIn DM history with provider cursor and boundary handling.
- Load older conversation pages automatically in the panels with circular primary-color loading states.
- Prevent invalid or stale opaque cursors from reaching providers.
- Recover stalled assistant generations when an AI SDK error chunk cannot be replayed, and clean up aborted streams.
- Add provider, UI, integration, and end-to-end evidence tests.

## Verification
- Convex tests: 33 files, 180 passed.
- Additional DM tests: 11 passed.
- TypeScript, strict Oxlint, Prettier, and Convex deployment typecheck passed.
- Exact development thread smoke-tested after deployment: failed response rendered, no Stop generating state, no aborted streams for the failed order, and no new browser console errors or warnings.

No schema migration or data backfill is required.