### PR TITLE
Fix live DM history and X subscription recovery

### DIFF
--- a/convex/agents/outreach/tools/getProspectInteractionHistory.test.ts
+++ b/convex/agents/outreach/tools/getProspectInteractionHistory.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+import { getProspectInteractionHistoryInputSchema } from "./getProspectInteractionHistory";
+
+describe("getProspectInteractionHistory input", () => {
+  test("rejects invented provider cursors from Agent input", () => {
+    expect(
+      getProspectInteractionHistoryInputSchema.safeParse({
+        cursor: "hallucinated-provider-cursor",
+      }).success
+    ).toBe(false);
+  });
+
+  test("accepts a bounded latest or since request without provider state", () => {
+    expect(
+      getProspectInteractionHistoryInputSchema.parse({
+        platform: "twitter",
+        limit: 25,
+      })
+    ).toMatchObject({
+      platform: "twitter",
+      limit: 25,
+      kinds: ["dm", "comment", "reply"],
+    });
+    expect(
+      getProspectInteractionHistoryInputSchema.parse({
+        platform: "linkedin",
+        since: "2026-08-01T00:00:00.000Z",
+      })
+    ).toMatchObject({
+      platform: "linkedin",
+      since: "2026-08-01T00:00:00.000Z",
+    });
+  });
+});

--- a/convex/agents/outreach/tools/getProspectInteractionHistory.ts
+++ b/convex/agents/outreach/tools/getProspectInteractionHistory.ts
@@ -1,15 +1,24 @@
 "use node";
 
-// Shared agent tool: reads the real platform interaction history for the
-// selected prospect. Thin Layer 1 wrapper over platform sync actions and the
-// normalized Layer 3 interaction read model.
+// Shared Agent tool: reads the real platform interaction history for the
+// selected prospect. Provider cursors remain backend-owned; the Agent receives
+// evidence about freshness and coverage, not pagination implementation details.
 
 import { createTool } from "@convex-dev/agent";
 import { z } from "zod";
 import { internal } from "../../../_generated/api";
 import type { Id } from "../../../_generated/dataModel";
-import type { ProspectInteractionHistoryItem } from "../../../lib/prospectInteractionHistoryCore";
-import { isCurrentConversationHistoryCursor } from "../../../lib/conversationHistoryPaginationCore";
+import {
+  AGENT_PROVIDER_HISTORY_PAGE_SIZE,
+  getAgentProviderHistoryPageBudget,
+  getInteractionHistoryEvidenceSource,
+  normalizeInteractionHistoryConnectionState,
+  shouldContinueAgentProviderHistoryRead,
+  type InteractionHistoryConnectionState,
+  type InteractionHistoryEvidenceSource,
+  type InteractionHistoryProviderEvidence,
+  type ProspectInteractionHistoryItem,
+} from "../../../lib/prospectInteractionHistoryCore";
 import { parseIsoToTimestamp } from "../../../../shared/lib/utils/time/timeUtils";
 import {
   AMBIGUOUS_PROSPECT_SELECTION_MESSAGE,
@@ -25,8 +34,42 @@ import {
 const platformSchema = z.enum(["all", "twitter", "linkedin"]);
 const kindSchema = z.enum(["dm", "comment", "reply"]);
 const directionSchema = z.enum(["all", "sent", "received"]);
-const MAX_AGENT_PROVIDER_HISTORY_PAGES = 4;
-const AGENT_PROVIDER_HISTORY_PAGE_SIZE = 25;
+
+export const getProspectInteractionHistoryInputSchema = z
+  .object({
+    platform: platformSchema
+      .optional()
+      .default("all")
+      .describe("Read X, LinkedIn, or both platforms."),
+    kinds: z
+      .array(kindSchema)
+      .min(1)
+      .optional()
+      .default(["dm", "comment", "reply"])
+      .describe("Interaction types to include."),
+    direction: directionSchema
+      .optional()
+      .default("all")
+      .describe("Read sent interactions, received interactions, or both."),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(50)
+      .optional()
+      .default(20)
+      .describe("Maximum number of interactions to return."),
+    since: z
+      .string()
+      .datetime({ offset: true })
+      .optional()
+      .describe(
+        "Optional ISO-8601 lower time boundary. The backend may read up to four bounded provider pages to cover it."
+      ),
+  })
+  .strict();
+
+type Platform = "twitter" | "linkedin";
 
 type ProviderDmMessage = {
   id: string;
@@ -37,6 +80,7 @@ type ProviderDmMessage = {
 };
 
 type ProviderHistoryPage = {
+  conversationId: string;
   messages: ProviderDmMessage[];
   history: {
     nextCursor?: string;
@@ -46,17 +90,14 @@ type ProviderHistoryPage = {
 } | null;
 
 type InteractionHistoryCoverage = {
-  platform: "twitter" | "linkedin";
+  platform: Platform;
   hasConversation: boolean;
   lastSyncSuccessAt?: number;
   lastSyncAttemptAt?: number;
   syncError?: string;
-  historyNextCursor?: string;
   historyHasMore: boolean;
   historyBoundary?: "complete" | "x_30_day_limit";
   historyOldestLoadedAt?: number;
-  providerPagesFetched?: number;
-  providerPageLimitReached?: boolean;
 };
 
 type ProspectInteractionHistoryResult = {
@@ -67,6 +108,7 @@ type ProspectInteractionHistoryResult = {
   items: ProspectInteractionHistoryItem[];
   truncated: boolean;
   coverage: InteractionHistoryCoverage[];
+  evidence: InteractionHistoryProviderEvidence[];
   queriedAt: number;
 };
 
@@ -74,7 +116,6 @@ type GetProspectInteractionHistoryResult =
   | {
       success: true;
       history: ProspectInteractionHistoryResult;
-      refreshWarnings: string[];
     }
   | {
       success: false;
@@ -82,8 +123,27 @@ type GetProspectInteractionHistoryResult =
       error: string;
     };
 
+type ProviderRead = {
+  platform: Platform;
+  items: ProspectInteractionHistoryItem[];
+  source: InteractionHistoryEvidenceSource;
+  connection: InteractionHistoryConnectionState;
+  refreshAttempted: boolean;
+  refreshSucceeded: boolean;
+  conversationFound: boolean;
+  pagesFetched: number;
+  pageLimitReached: boolean;
+  historyHasMore: boolean;
+  boundary?: "complete" | "x_30_day_limit";
+  error?: string;
+};
+
+function getPlatforms(platform: "all" | Platform): Platform[] {
+  return platform === "all" ? ["twitter", "linkedin"] : [platform];
+}
+
 function normalizeProviderMessage(
-  platform: "twitter" | "linkedin",
+  platform: Platform,
   message: ProviderDmMessage
 ): ProspectInteractionHistoryItem {
   return {
@@ -128,159 +188,197 @@ function mergeHistoryItems(args: {
   };
 }
 
-async function readProviderDmPages(args: {
+function getProviderErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim()) {
+    return error.message;
+  }
+  return "The provider could not refresh this conversation.";
+}
+
+function getUnavailableConnectionMessage(
+  platform: Platform,
+  connection: InteractionHistoryConnectionState
+): string | undefined {
+  if (connection === "connected" || connection === "unknown") {
+    return undefined;
+  }
+  const label = platform === "twitter" ? "X/Twitter" : "LinkedIn";
+  return connection === "reconnect_required"
+    ? `${label} needs to be reconnected before this conversation can be verified.`
+    : `${label} is ${connection}, so this conversation cannot be verified live.`;
+}
+
+async function getConnectionState(args: {
+  ctx: ToolContext;
+  userId: Id<"users">;
+  platform: Platform;
+}): Promise<InteractionHistoryConnectionState> {
+  try {
+    const account =
+      args.platform === "twitter"
+        ? await args.ctx.runQuery(internal.xStore.getXAccountForUserInternal, {
+            userId: args.userId,
+          })
+        : await args.ctx.runQuery(
+            internal.linkedinStore.getLinkedInAccountForUserInternal,
+            { userId: args.userId }
+          );
+    return account
+      ? normalizeInteractionHistoryConnectionState(account.status)
+      : "disconnected";
+  } catch {
+    return "unknown";
+  }
+}
+
+async function getProviderHistoryPage(args: {
   ctx: ToolContext;
   userId: Id<"users">;
   prospectId: Id<"prospects">;
-  platform: "all" | "twitter" | "linkedin";
+  platform: Platform;
   cursor?: string;
   sinceMs?: number;
-  cachedCoverage: InteractionHistoryCoverage[];
-}) {
-  const platforms =
-    args.platform === "all"
-      ? (["twitter", "linkedin"] as const)
-      : ([args.platform] as const);
-  const providerItems: ProspectInteractionHistoryItem[] = [];
-  const pagination = new Map<
-    "twitter" | "linkedin",
-    Pick<
-      InteractionHistoryCoverage,
-      | "historyNextCursor"
-      | "historyHasMore"
-      | "historyBoundary"
-      | "providerPagesFetched"
-      | "providerPageLimitReached"
-    >
-  >();
+}): Promise<ProviderHistoryPage> {
+  const pageArgs = {
+    userId: args.userId,
+    prospectId: args.prospectId,
+    limit: AGENT_PROVIDER_HISTORY_PAGE_SIZE,
+    ...(args.cursor ? { cursor: args.cursor } : {}),
+    ...(typeof args.sinceMs === "number" ? { sinceMs: args.sinceMs } : {}),
+  };
+  return args.platform === "twitter"
+    ? await args.ctx.runAction(
+        internal.x.getDmConversationHistoryPageInternal,
+        pageArgs
+      )
+    : await args.ctx.runAction(
+        internal.linkedin.getLinkedInConversationHistoryPageInternal,
+        pageArgs
+      );
+}
 
-  for (const platform of platforms) {
-    const cached = args.cachedCoverage.find(
-      (coverage) => coverage.platform === platform
-    );
-    let cursor = args.cursor ?? cached?.historyNextCursor;
-    let pagesFetched = 0;
-    let page: ProviderHistoryPage = null;
-    const pageBudget =
-      typeof args.sinceMs === "number" ? MAX_AGENT_PROVIDER_HISTORY_PAGES : 1;
+async function readLiveProviderHistory(args: {
+  ctx: ToolContext;
+  userId: Id<"users">;
+  prospectId: Id<"prospects">;
+  platform: Platform;
+  sinceMs?: number;
+  hasCachedConversation: boolean;
+}): Promise<ProviderRead> {
+  const connectionPromise = getConnectionState(args);
+  const pageBudget = getAgentProviderHistoryPageBudget(args.sinceMs);
+  const items: ProspectInteractionHistoryItem[] = [];
+  let cursor: string | undefined;
+  let lastPage: ProviderHistoryPage = null;
+  let pagesFetched = 0;
 
-    // A recent cached page already satisfies an ordinary read. We only issue
-    // provider requests for an explicit continuation or date-range request.
-    if (!args.cursor && typeof args.sinceMs !== "number") {
-      continue;
-    }
-    if (!cursor) {
-      pagination.set(platform, {
-        historyNextCursor: undefined,
-        historyHasMore: false,
-        historyBoundary: cached?.historyBoundary,
-        providerPagesFetched: 0,
+  try {
+    do {
+      const page = await getProviderHistoryPage({
+        ...args,
+        cursor,
       });
-      continue;
-    }
-
-    while (cursor && pagesFetched < pageBudget) {
-      page =
-        platform === "twitter"
-          ? await args.ctx.runAction(
-              internal.x.getDmConversationHistoryPageInternal,
-              {
-                userId: args.userId,
-                prospectId: args.prospectId,
-                cursor,
-                limit: AGENT_PROVIDER_HISTORY_PAGE_SIZE,
-                ...(typeof args.sinceMs === "number"
-                  ? { sinceMs: args.sinceMs }
-                  : {}),
-              }
-            )
-          : await args.ctx.runAction(
-              internal.linkedin.getLinkedInConversationHistoryPageInternal,
-              {
-                userId: args.userId,
-                prospectId: args.prospectId,
-                cursor,
-                limit: AGENT_PROVIDER_HISTORY_PAGE_SIZE,
-                ...(typeof args.sinceMs === "number"
-                  ? { sinceMs: args.sinceMs }
-                  : {}),
-              }
-            );
       pagesFetched += 1;
       if (!page) {
-        break;
+        const connection = await connectionPromise;
+        const error = getUnavailableConnectionMessage(
+          args.platform,
+          connection
+        );
+        const refreshSucceeded = !error;
+        return {
+          platform: args.platform,
+          items,
+          source: getInteractionHistoryEvidenceSource({
+            liveSucceeded: refreshSucceeded,
+            hasCachedConversation: args.hasCachedConversation,
+          }),
+          connection,
+          refreshAttempted: true,
+          refreshSucceeded,
+          conversationFound: items.length > 0,
+          pagesFetched,
+          pageLimitReached: false,
+          historyHasMore: false,
+          error,
+        };
       }
-      providerItems.push(
+
+      lastPage = page;
+      items.push(
         ...page.messages.map((message) =>
-          normalizeProviderMessage(platform, message)
+          normalizeProviderMessage(args.platform, message)
         )
       );
       cursor = page.history.nextCursor;
-      if (typeof args.sinceMs !== "number" || !page.history.hasMore) {
-        break;
-      }
-    }
+    } while (
+      shouldContinueAgentProviderHistoryRead({
+        sinceMs: args.sinceMs,
+        pagesFetched,
+        nextCursor: cursor,
+        hasMore: lastPage?.history.hasMore ?? false,
+      })
+    );
 
-    pagination.set(platform, {
-      historyNextCursor: page?.history.nextCursor,
-      historyHasMore: page?.history.hasMore ?? false,
-      historyBoundary: page?.history.boundary ?? cached?.historyBoundary,
-      providerPagesFetched: pagesFetched,
-      providerPageLimitReached: Boolean(cursor) && pagesFetched >= pageBudget,
-    });
+    const connection = await connectionPromise;
+    return {
+      platform: args.platform,
+      items,
+      source: "live",
+      connection,
+      refreshAttempted: true,
+      refreshSucceeded: true,
+      conversationFound: Boolean(lastPage),
+      pagesFetched,
+      pageLimitReached:
+        pagesFetched >= pageBudget && lastPage?.history.hasMore === true,
+      historyHasMore: lastPage?.history.hasMore ?? false,
+      boundary: lastPage?.history.boundary,
+    };
+  } catch (error) {
+    const connection = await connectionPromise;
+    return {
+      platform: args.platform,
+      items,
+      source: getInteractionHistoryEvidenceSource({
+        liveSucceeded: false,
+        hasCachedConversation: args.hasCachedConversation,
+      }),
+      connection,
+      refreshAttempted: true,
+      refreshSucceeded: false,
+      conversationFound: items.length > 0,
+      pagesFetched,
+      pageLimitReached: false,
+      historyHasMore: false,
+      error: getProviderErrorMessage(error),
+    };
   }
+}
 
-  return { providerItems, pagination };
+function readCachedProviderHistory(args: {
+  platform: Platform;
+  hasCachedConversation: boolean;
+  connection: InteractionHistoryConnectionState;
+}): ProviderRead {
+  return {
+    platform: args.platform,
+    items: [],
+    source: "cached",
+    connection: args.connection,
+    refreshAttempted: false,
+    refreshSucceeded: false,
+    conversationFound: args.hasCachedConversation,
+    pagesFetched: 0,
+    pageLimitReached: false,
+    historyHasMore: false,
+  };
 }
 
 export const getProspectInteractionHistory = createTool({
   description:
-    "Read the actual interaction history between the workspace user and the selected prospect: X/Twitter or LinkedIn DMs, comments, and replies, including direction and timestamps. Use this before answering what was said, what happened, who replied, or how the relationship has progressed. For older DMs, pass the opaque cursor returned in coverage with exactly one platform; for a date range, pass since and inspect coverage for provider limits. You must disclose x_30_day_limit when X/Twitter coverage reports it. The selected prospect is resolved from the current prospect thread or an explicit tag in the main workspace thread.",
-  inputSchema: z.object({
-    platform: platformSchema
-      .optional()
-      .default("all")
-      .describe("Read X, LinkedIn, or both platforms."),
-    kinds: z
-      .array(kindSchema)
-      .min(1)
-      .optional()
-      .default(["dm", "comment", "reply"])
-      .describe("Interaction types to include."),
-    direction: directionSchema
-      .optional()
-      .default("all")
-      .describe("Read sent interactions, received interactions, or both."),
-    limit: z
-      .number()
-      .int()
-      .min(1)
-      .max(50)
-      .optional()
-      .default(20)
-      .describe("Maximum number of interactions to return."),
-    since: z
-      .string()
-      .datetime({ offset: true })
-      .optional()
-      .describe(
-        "Optional ISO-8601 lower time boundary. The tool deliberately reads up to four bounded older DM pages to reach it."
-      ),
-    cursor: z
-      .string()
-      .min(1)
-      .optional()
-      .describe(
-        "Opaque older-DM cursor returned in coverage. Only valid with one platform and when DMs are included."
-      ),
-    refresh: z
-      .boolean()
-      .optional()
-      .default(true)
-      .describe(
-        "Refresh connected-platform DM snapshots before reading when possible."
-      ),
-  }),
+    "Read the actual interaction history between the workspace user and the selected prospect: X/Twitter or LinkedIn DMs, comments, and replies, including direction and timestamps. Use this before answering what was said, what happened, who replied, or how the relationship has progressed. The backend owns provider pagination: a normal read fetches the latest bounded DM page, and a since read may fetch up to four bounded pages. Never ask for or provide provider cursors. Inspect history.evidence before drawing conclusions: live means the provider read succeeded now; cached means a live read could not be verified and the items are previously synced; failed means no trustworthy DM evidence was available. Disclose an X/Twitter x_30_day_limit boundary when present. The selected prospect is resolved from the current prospect thread or an explicit tag in the main workspace thread.",
+  inputSchema: getProspectInteractionHistoryInputSchema,
   execute: async (ctx, args): Promise<GetProspectInteractionHistoryResult> => {
     try {
       const selected = await resolveSelectedThreadContext(
@@ -307,21 +405,6 @@ export const getProspectInteractionHistory = createTool({
 
       const userId = ctx.userId as Id<"users">;
       const prospectId = selected.prospectId;
-      if (args.cursor && args.platform === "all") {
-        return {
-          success: false as const,
-          history: null,
-          error:
-            "An older-DM cursor is scoped to one platform. Choose X/Twitter or LinkedIn.",
-        };
-      }
-      if (args.cursor && !args.kinds.includes("dm")) {
-        return {
-          success: false as const,
-          history: null,
-          error: "An older-DM cursor can only be used when DMs are included.",
-        };
-      }
       const sinceMs = args.since ? parseIsoToTimestamp(args.since) : undefined;
       if (args.since && typeof sinceMs !== "number") {
         return {
@@ -330,39 +413,67 @@ export const getProspectInteractionHistory = createTool({
           error: "The since value must be a valid ISO-8601 timestamp.",
         };
       }
-      const refreshWarnings: string[] = [];
-      if (args.refresh && !args.cursor && args.kinds.includes("dm")) {
-        const refreshes: Array<Promise<unknown>> = [];
-        if (args.platform === "all" || args.platform === "twitter") {
-          refreshes.push(
-            ctx.runAction(internal.x.refreshProspectDmConversationInternal, {
-              userId,
-              prospectId,
-            })
-          );
-        }
-        if (args.platform === "all" || args.platform === "linkedin") {
-          refreshes.push(
-            ctx.runAction(
-              internal.linkedin.getProspectLinkedInMessageStateInternal,
-              { userId, prospectId }
-            )
-          );
-        }
 
-        const refreshResults = await Promise.allSettled(refreshes);
-        for (const result of refreshResults) {
-          if (result.status === "rejected") {
-            refreshWarnings.push(
-              result.reason instanceof Error
-                ? result.reason.message
-                : "A platform conversation refresh failed."
-            );
-          }
+      const cachedHistory: Omit<
+        ProspectInteractionHistoryResult,
+        "evidence"
+      > | null = await ctx.runQuery(
+        internal.interactions.getProspectInteractionHistoryInternal,
+        {
+          userId,
+          prospectId,
+          platform: args.platform,
+          kinds: args.kinds,
+          direction: args.direction,
+          limit: args.limit,
+          sinceMs,
         }
+      );
+      if (!cachedHistory) {
+        return {
+          success: false as const,
+          history: null,
+          error: "Prospect not found or unavailable to the current user.",
+        };
       }
 
-      const history: ProspectInteractionHistoryResult | null =
+      const platforms = getPlatforms(args.platform);
+      const providerReads = args.kinds.includes("dm")
+        ? await Promise.all(
+            platforms.map((platform) =>
+              readLiveProviderHistory({
+                ctx,
+                userId,
+                prospectId,
+                platform,
+                sinceMs,
+                hasCachedConversation: Boolean(
+                  cachedHistory.coverage.find(
+                    (coverage) => coverage.platform === platform
+                  )?.hasConversation
+                ),
+              })
+            )
+          )
+        : await Promise.all(
+            platforms.map(async (platform) =>
+              readCachedProviderHistory({
+                platform,
+                hasCachedConversation: Boolean(
+                  cachedHistory.coverage.find(
+                    (coverage) => coverage.platform === platform
+                  )?.hasConversation
+                ),
+                connection: await getConnectionState({
+                  ctx,
+                  userId,
+                  platform,
+                }),
+              })
+            )
+          );
+
+      const history: Omit<ProspectInteractionHistoryResult, "evidence"> | null =
         await ctx.runQuery(
           internal.interactions.getProspectInteractionHistoryInternal,
           {
@@ -383,46 +494,47 @@ export const getProspectInteractionHistory = createTool({
         };
       }
 
-      if (args.cursor) {
-        if (
-          args.platform === "all" ||
-          !isCurrentConversationHistoryCursor({
-            cursor: args.cursor,
-            platform: args.platform,
-            coverage: history.coverage,
-          })
-        ) {
-          return {
-            success: false as const,
-            history: null,
-            error:
-              "That older-DM cursor is no longer valid. Start a fresh history read.",
-          };
-        }
-      }
-
-      const providerRead = await readProviderDmPages({
-        ctx,
-        userId,
-        prospectId,
-        platform: args.platform,
-        cursor: args.cursor,
-        sinceMs,
-        cachedCoverage: history.coverage,
-      });
+      const readsByPlatform = new Map(
+        providerReads.map((read) => [read.platform, read] as const)
+      );
       const merged = mergeHistoryItems({
         cached: history.items,
-        provider: providerRead.providerItems,
+        provider: providerReads.flatMap((read) => read.items),
         direction: args.direction,
         limit: args.limit,
       });
       const coverage = history.coverage.map((coverageItem) => {
-        const providerPagination = providerRead.pagination.get(
-          coverageItem.platform
-        );
-        return providerPagination
-          ? { ...coverageItem, ...providerPagination }
-          : coverageItem;
+        const read = readsByPlatform.get(coverageItem.platform);
+        return {
+          ...coverageItem,
+          historyHasMore: read?.historyHasMore ?? coverageItem.historyHasMore,
+          historyBoundary: read?.boundary ?? coverageItem.historyBoundary,
+          providerPagesFetched: read?.pagesFetched ?? 0,
+          providerPageLimitReached: read?.pageLimitReached ?? false,
+        };
+      });
+      const evidence = coverage.map((coverageItem) => {
+        const read = readsByPlatform.get(coverageItem.platform);
+        const lastSuccessfulSyncAt = coverageItem.lastSyncSuccessAt;
+        return {
+          platform: coverageItem.platform,
+          source: read?.source ?? "cached",
+          connection: read?.connection ?? "unknown",
+          refreshAttempted: read?.refreshAttempted ?? false,
+          refreshSucceeded: read?.refreshSucceeded ?? false,
+          conversationFound:
+            read?.conversationFound ?? coverageItem.hasConversation,
+          pagesFetched: read?.pagesFetched ?? 0,
+          pageLimitReached: read?.pageLimitReached ?? false,
+          lastSuccessfulSyncAt,
+          lastSyncAttemptAt: coverageItem.lastSyncAttemptAt,
+          staleForMs:
+            typeof lastSuccessfulSyncAt === "number"
+              ? Math.max(0, history.queriedAt - lastSuccessfulSyncAt)
+              : undefined,
+          boundary: read?.boundary ?? coverageItem.historyBoundary,
+          error: read?.error ?? coverageItem.syncError,
+        } satisfies InteractionHistoryProviderEvidence;
       });
 
       return {
@@ -433,10 +545,14 @@ export const getProspectInteractionHistory = createTool({
           truncated:
             history.truncated ||
             merged.truncated ||
-            coverage.some((coverageItem) => coverageItem.historyHasMore),
+            coverage.some(
+              (coverageItem) =>
+                coverageItem.historyHasMore ||
+                coverageItem.providerPageLimitReached
+            ),
           coverage,
+          evidence,
         },
-        refreshWarnings,
       };
     } catch (error) {
       return {

--- a/convex/agents/prompts.ts
+++ b/convex/agents/prompts.ts
@@ -264,7 +264,7 @@ ${buildUseCaseContextBlock(useCase)}
 - For create-plan or revise-plan requests from this workspace thread, call \`managePlanBatch\` even when exactly one ${entitySingularLower} is selected. Use scope.kind=\`tagged\`; a single selected prospect is a batch of one.
 - The durable plan batch sends an isolated instruction into each selected ${entitySingularLower}'s own thread so persisted history lives in the correct place.
 - Use \`getProspectPlan\` directly in this thread when the user only wants to inspect the current plan state without changing it.
-- When exactly one ${entitySingularLower} is selected and the user asks what was said or what happened across DMs, comments, or replies, call \`getProspectInteractionHistory\` before answering. Do not substitute public timeline posts or agent-chat history for the real interaction record.
+- When exactly one ${entitySingularLower} is selected and the user asks what was said or what happened across DMs, comments, or replies, call \`getProspectInteractionHistory\` before answering. Do not substitute public timeline posts or agent-chat history for the real interaction record. Read its per-platform \`evidence\`: live data supports current factual claims; cached or failed data requires you to explain that current conversation state could not be verified, rather than inferring a reply or no reply.
 
 ## Visual Rendering Rules
 - For any request to show a profile, post, post list, or thread, ALWAYS call \`displayEntity\`.
@@ -534,7 +534,7 @@ When you are in a record-specific conversation, context is automatically injecte
 - When helpful and safe, use your available app-owned social action tools to directly take actions on X or LinkedIn for the user, such as liking posts, replying, reposting, following, messaging, inviting, reacting, or commenting.
 
 ## Tool Routing Rules (CRITICAL)
-- When the user asks what was said or what happened between them and this ${entitySingularLower} across DMs, comments, or replies, call \`getProspectInteractionHistory\` before answering. Do not treat public timeline posts, a plan, or this agent chat as the interaction record.
+- When the user asks what was said or what happened between them and this ${entitySingularLower} across DMs, comments, or replies, call \`getProspectInteractionHistory\` before answering. Do not treat public timeline posts, a plan, or this agent chat as the interaction record. Reason naturally from its evidence and freshness metadata; never turn a stale, unavailable, or bounded history read into an unqualified claim about what the person did or did not say.
 - If the user asks for a direct X or LinkedIn action on a specific post already shown in chat, prefer the direct action path over plan generation.
 - When the user asks to change the current plan, call \`refinePlan\` directly. It resolves the active plan from thread context, so do not call \`getProspectPlan\` immediately before it unless the user also explicitly asked to inspect the plan.
 - When hidden context lists application-issued attachment references, pass the exact reference names into the matching task or action's \`attachmentRefs\`. Never invent, expose, or copy storage URLs/upload IDs. Use \`mediaUrls\` only to preserve exact verified URLs already present in the current plan context, or when a delegated system instruction explicitly provides them. Keep the user's instruction natural-language and apply it only to the tasks they described; never invent a fixed purpose/category field.
@@ -581,7 +581,7 @@ When you are in a record-specific conversation, context is automatically injecte
 
 **Context Tools:**
 - getSocialContext: Fetch normalized profile, posts, threads, and activity data. Use exact retrieval intent first: latest, oldest, time range, or best_for_reply only when explicitly requested.
-- getProspectInteractionHistory: Read the real X/LinkedIn DM, comment, and reply history between the workspace user and this ${entitySingularLower}. Use it for conversation-history and relationship-progress questions.
+- getProspectInteractionHistory: Read the real X/LinkedIn DM, comment, and reply history between the workspace user and this ${entitySingularLower}. Use it for conversation-history and relationship-progress questions. It returns live/cached/failed evidence, connection state, freshness, coverage boundary, and bounded-page metadata for your reasoning.
 - getProspectPlan: Get an existing plan for the internal prospect record
 - inspectWorkspace: Get the workspace's offering description, ideal customer profiles, connected accounts, and autonomy settings. Use this to ground strategy in the user's real goals before generating or refining plans.
 - researchProspect: Deep web research on the prospect and their company (recent news, launches, funding, hiring, public opinions). Use BEFORE generating a plan when prospect context is thin, and whenever the user asks for deeper research. Cite what you learned when proposing angles.

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -45,4 +45,11 @@ crons.interval(
   internal.memory.retryFailedCanonicalWorkspaceMemoryIndexesCron
 );
 
+crons.interval(
+  "reconcile X/Twitter DM activity subscriptions",
+  { minutes: 15 },
+  internal.xActivity.retryDmActivitySubscriptionsCron,
+  {}
+);
+
 export default crons;

--- a/convex/lib/conversationHistoryPaginationCore.test.ts
+++ b/convex/lib/conversationHistoryPaginationCore.test.ts
@@ -61,6 +61,13 @@ describe("conversation history pagination", () => {
         platform: "twitter",
       })
     ).toEqual({ hasMore: false, boundary: "x_30_day_limit" });
+    expect(
+      buildConversationHistoryPageMetadata({
+        providerCursor: "older-page-not-needed",
+        reachedSince: true,
+        platform: "twitter",
+      })
+    ).toEqual({ hasMore: false, boundary: "complete" });
   });
 
   test("selects the exact LinkedIn attendee chat deterministically", () => {

--- a/convex/lib/conversationHistoryPaginationCore.ts
+++ b/convex/lib/conversationHistoryPaginationCore.ts
@@ -120,14 +120,20 @@ export function buildConversationHistoryPageMetadata(args: {
   platform: "twitter" | "linkedin";
 }): ConversationHistoryPageMetadata {
   const hasMore = Boolean(args.providerCursor) && !args.reachedSince;
+  // Reaching the caller's requested lower bound is complete coverage for that
+  // request. X's 30-day boundary is only meaningful when the provider itself
+  // has no older page left before that requested boundary was reached.
+  const boundary = args.reachedSince
+    ? "complete"
+    : hasMore
+      ? undefined
+      : args.platform === "twitter"
+        ? "x_30_day_limit"
+        : "complete";
   return {
     nextCursor: hasMore ? args.providerCursor : undefined,
     hasMore,
-    ...(hasMore
-      ? {}
-      : {
-          boundary: args.platform === "twitter" ? "x_30_day_limit" : "complete",
-        }),
+    ...(boundary ? { boundary } : {}),
   };
 }
 

--- a/convex/lib/prospectInteractionHistoryCore.test.ts
+++ b/convex/lib/prospectInteractionHistoryCore.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "vitest";
+import {
+  AGENT_PROVIDER_HISTORY_PAGE_SIZE,
+  MAX_AGENT_PROVIDER_HISTORY_PAGES,
+  getAgentProviderHistoryPageBudget,
+  getInteractionHistoryEvidenceSource,
+  normalizeInteractionHistoryConnectionState,
+  shouldContinueAgentProviderHistoryRead,
+} from "./prospectInteractionHistoryCore";
+
+describe("Agent interaction-history evidence", () => {
+  test("keeps ordinary live reads to one bounded page and bounds since reads", () => {
+    expect(AGENT_PROVIDER_HISTORY_PAGE_SIZE).toBe(25);
+    expect(getAgentProviderHistoryPageBudget()).toBe(1);
+    expect(getAgentProviderHistoryPageBudget(1)).toBe(
+      MAX_AGENT_PROVIDER_HISTORY_PAGES
+    );
+    expect(
+      shouldContinueAgentProviderHistoryRead({
+        pagesFetched: 1,
+        nextCursor: "provider-owned-cursor",
+        hasMore: true,
+      })
+    ).toBe(false);
+    expect(
+      shouldContinueAgentProviderHistoryRead({
+        sinceMs: 1,
+        pagesFetched: MAX_AGENT_PROVIDER_HISTORY_PAGES - 1,
+        nextCursor: "provider-owned-cursor",
+        hasMore: true,
+      })
+    ).toBe(true);
+    expect(
+      shouldContinueAgentProviderHistoryRead({
+        sinceMs: 1,
+        pagesFetched: MAX_AGENT_PROVIDER_HISTORY_PAGES,
+        nextCursor: "provider-owned-cursor",
+        hasMore: true,
+      })
+    ).toBe(false);
+  });
+
+  test("retains the distinction between live, cached, and failed evidence", () => {
+    expect(
+      getInteractionHistoryEvidenceSource({
+        liveSucceeded: true,
+        hasCachedConversation: true,
+      })
+    ).toBe("live");
+    expect(
+      getInteractionHistoryEvidenceSource({
+        liveSucceeded: false,
+        hasCachedConversation: true,
+      })
+    ).toBe("cached");
+    expect(
+      getInteractionHistoryEvidenceSource({
+        liveSucceeded: false,
+        hasCachedConversation: false,
+      })
+    ).toBe("failed");
+  });
+
+  test("normalizes reconnect and provider account states for Agent evidence", () => {
+    expect(normalizeInteractionHistoryConnectionState("connected")).toBe(
+      "connected"
+    );
+    expect(normalizeInteractionHistoryConnectionState("expired")).toBe(
+      "reconnect_required"
+    );
+    expect(normalizeInteractionHistoryConnectionState("action_required")).toBe(
+      "action_required"
+    );
+    expect(normalizeInteractionHistoryConnectionState(undefined)).toBe(
+      "unknown"
+    );
+  });
+});

--- a/convex/lib/prospectInteractionHistoryCore.ts
+++ b/convex/lib/prospectInteractionHistoryCore.ts
@@ -30,6 +30,88 @@ export type ProspectInteractionHistoryItem = {
   attachmentCount: number;
 };
 
+export const AGENT_PROVIDER_HISTORY_PAGE_SIZE = 25;
+export const MAX_AGENT_PROVIDER_HISTORY_PAGES = 4;
+
+export type InteractionHistoryEvidenceSource = "live" | "cached" | "failed";
+
+export type InteractionHistoryConnectionState =
+  | "connected"
+  | "disconnected"
+  | "reconnect_required"
+  | "action_required"
+  | "restricted"
+  | "unknown";
+
+export type InteractionHistoryProviderEvidence = {
+  platform: "twitter" | "linkedin";
+  source: InteractionHistoryEvidenceSource;
+  connection: InteractionHistoryConnectionState;
+  refreshAttempted: boolean;
+  refreshSucceeded: boolean;
+  conversationFound: boolean;
+  pagesFetched: number;
+  pageLimitReached: boolean;
+  lastSuccessfulSyncAt?: number;
+  lastSyncAttemptAt?: number;
+  staleForMs?: number;
+  boundary?: "complete" | "x_30_day_limit";
+  error?: string;
+};
+
+/** Normalize provider-specific account statuses for Agent-facing evidence. */
+export function normalizeInteractionHistoryConnectionState(
+  status?: string
+): InteractionHistoryConnectionState {
+  switch (status) {
+    case "connected":
+      return "connected";
+    case "reconnect_required":
+    case "expired":
+      return "reconnect_required";
+    case "action_required":
+      return "action_required";
+    case "restricted":
+      return "restricted";
+    case "disconnected":
+      return "disconnected";
+    default:
+      return "unknown";
+  }
+}
+
+/** Latest reads use one bounded page; date-range reads may walk a small budget. */
+export function getAgentProviderHistoryPageBudget(sinceMs?: number): number {
+  return typeof sinceMs === "number" ? MAX_AGENT_PROVIDER_HISTORY_PAGES : 1;
+}
+
+/** Provider cursors stay backend-owned for Agent reads. */
+export function shouldContinueAgentProviderHistoryRead(args: {
+  sinceMs?: number;
+  pagesFetched: number;
+  nextCursor?: string;
+  hasMore: boolean;
+}): boolean {
+  return (
+    typeof args.sinceMs === "number" &&
+    args.pagesFetched < MAX_AGENT_PROVIDER_HISTORY_PAGES &&
+    args.hasMore &&
+    typeof args.nextCursor === "string" &&
+    args.nextCursor.length > 0
+  );
+}
+
+/** Preserve whether the Agent is reasoning over live data or a fallback. */
+export function getInteractionHistoryEvidenceSource(args: {
+  liveSucceeded: boolean;
+  hasCachedConversation: boolean;
+}): InteractionHistoryEvidenceSource {
+  if (args.liveSucceeded) {
+    return "live";
+  }
+  return args.hasCachedConversation ? "cached" : "failed";
+}
+
 type ConversationMessage = Pick<
   Doc<"platformConversationMessages">,
   | "platform"

--- a/convex/lib/xActivity.test.ts
+++ b/convex/lib/xActivity.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "vitest";
+import { normalizeXActivityEventType } from "./xActivity";
+
+describe("X Activity provider normalization", () => {
+  test("accepts X's dotted encrypted-chat join alias", () => {
+    expect(normalizeXActivityEventType("chat.conversation.join")).toBe(
+      "chat.conversation_join"
+    );
+  });
+
+  test("preserves documented event types and rejects unknown values", () => {
+    expect(normalizeXActivityEventType("dm.received")).toBe("dm.received");
+    expect(normalizeXActivityEventType("unknown.event")).toBeUndefined();
+  });
+});

--- a/convex/lib/xActivity.ts
+++ b/convex/lib/xActivity.ts
@@ -22,6 +22,21 @@ export type XPostActivityEventType =
 export type XActivityEventType = (typeof X_ACTIVITY_EVENT_TYPES)[number];
 export type XActivityAuthMode = "app" | "user";
 
+/**
+ * X currently returns the encrypted-chat join event with dot separators even
+ * though the subscription catalog documents the final separator as an
+ * underscore. Keep one internal value while accepting the provider alias.
+ */
+export function normalizeXActivityEventType(
+  value: string
+): XActivityEventType | undefined {
+  const normalized =
+    value === "chat.conversation.join" ? "chat.conversation_join" : value;
+  return X_ACTIVITY_EVENT_TYPES.includes(normalized as XActivityEventType)
+    ? (normalized as XActivityEventType)
+    : undefined;
+}
+
 const textEncoder = new TextEncoder();
 
 function getRequiredEnv(name: "X_API_BEARER_TOKEN"): string {
@@ -138,24 +153,23 @@ function normalizeSubscription(
       : typeof input.subscriptionId === "string"
         ? input.subscriptionId
         : undefined;
-  const eventType =
+  const rawEventType =
     typeof input.event_type === "string"
       ? input.event_type
       : typeof input.eventType === "string"
         ? input.eventType
         : undefined;
-  if (
-    !subscriptionId ||
-    !eventType ||
-    !X_ACTIVITY_EVENT_TYPES.includes(eventType as XActivityEventType)
-  ) {
+  const eventType = rawEventType
+    ? normalizeXActivityEventType(rawEventType)
+    : undefined;
+  if (!subscriptionId || !eventType) {
     return null;
   }
 
   const filter = isRecord(input.filter) ? input.filter : undefined;
   return {
     subscriptionId,
-    eventType: eventType as XActivityEventType,
+    eventType,
     filterUserId:
       typeof filter?.user_id === "string"
         ? filter.user_id

--- a/convex/lib/xActivityReconciliationCore.test.ts
+++ b/convex/lib/xActivityReconciliationCore.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import {
   findMatchingXActivitySubscription,
+  getXActivitySubscriptionHealth,
   isDuplicateXActivitySubscriptionError,
 } from "./xActivityReconciliationCore";
 
@@ -60,5 +61,24 @@ describe("X Activity subscription reconciliation", () => {
     new Error("Subscription already exists"),
   ])("recognizes provider duplicate responses", (error) => {
     expect(isDuplicateXActivitySubscriptionError(error)).toBe(true);
+  });
+
+  test("keeps DM health independent from post subscription health", () => {
+    const account = {
+      dmActivitySubscriptionStatus: "pending_retry" as const,
+      dmActivitySubscriptionsLastError: "missing dm.received",
+      postActivitySubscriptionStatus: "healthy" as const,
+    };
+
+    expect(getXActivitySubscriptionHealth(account, "dm")).toEqual({
+      status: "pending_retry",
+      nextRetryAt: undefined,
+      lastError: "missing dm.received",
+    });
+    expect(getXActivitySubscriptionHealth(account, "post")).toEqual({
+      status: "healthy",
+      nextRetryAt: undefined,
+      lastError: undefined,
+    });
   });
 });

--- a/convex/lib/xActivityReconciliationCore.ts
+++ b/convex/lib/xActivityReconciliationCore.ts
@@ -6,6 +6,40 @@ export type XActivitySubscriptionCandidate<TEvent extends string = string> = {
   tag?: string;
 };
 
+export type XActivitySubscriptionCapability = "dm" | "post";
+export type XActivitySubscriptionHealthStatus =
+  | "unknown"
+  | "healthy"
+  | "degraded"
+  | "pending_retry";
+
+type XActivitySubscriptionHealthRecord = {
+  dmActivitySubscriptionStatus?: XActivitySubscriptionHealthStatus;
+  dmActivitySubscriptionsNextRetryAt?: number;
+  dmActivitySubscriptionsLastError?: string;
+  postActivitySubscriptionStatus?: XActivitySubscriptionHealthStatus;
+  postActivitySubscriptionsNextRetryAt?: number;
+  postActivitySubscriptionsLastError?: string;
+};
+
+/** Post monitoring health must never be treated as evidence that DMs are healthy. */
+export function getXActivitySubscriptionHealth(
+  account: XActivitySubscriptionHealthRecord,
+  capability: XActivitySubscriptionCapability
+) {
+  return capability === "dm"
+    ? {
+        status: account.dmActivitySubscriptionStatus,
+        nextRetryAt: account.dmActivitySubscriptionsNextRetryAt,
+        lastError: account.dmActivitySubscriptionsLastError,
+      }
+    : {
+        status: account.postActivitySubscriptionStatus,
+        nextRetryAt: account.postActivitySubscriptionsNextRetryAt,
+        lastError: account.postActivitySubscriptionsLastError,
+      };
+}
+
 /**
  * Select an X Activity subscription by its immutable identity first. X's list
  * response may omit `webhook_id`, so webhook equality cannot be a requirement

--- a/convex/linkedin.ts
+++ b/convex/linkedin.ts
@@ -2829,10 +2829,9 @@ async function resolveProspectLinkedInPanelContext(
 }
 
 /**
- * Fetch one bounded LinkedIn provider page for an already-resolved prospect
- * conversation. The page action intentionally does not rediscover chats: the
- * cached conversation id scopes the opaque provider cursor and keeps one
- * provider message request per page.
+ * Fetch one bounded LinkedIn provider page. A latest read may discover the
+ * prospect chat when no snapshot exists; continuation cursors remain scoped to
+ * an already-resolved cached conversation.
  */
 async function getProspectLinkedInHistoryPageForUser(
   ctx: any,
@@ -2872,14 +2871,44 @@ async function getProspectLinkedInHistoryPageForUser(
     internal.platformConversations.getConversationSnapshotInternal,
     { userId, platform: "linkedin", prospectId }
   );
-  const conversation = cachedSnapshot?.conversation;
-  if (!conversation?.conversationId) {
+  const prospectIdentity = getProspectLinkedInIdentity(prospect);
+  if (!prospectIdentity.providerId) {
     return null;
   }
+  let conversation = cachedSnapshot?.conversation;
+  let resolvedChat: UnipileChat | null = null;
+  if (!conversation?.conversationId) {
+    // Provider cursors are only safe for an already-resolved panel snapshot.
+    // A fresh backend-owned Agent read may discover the latest matching chat.
+    if (args.cursor) {
+      return null;
+    }
+    const chats = await listLinkedInChatsForAttendeeOrEmpty({
+      attendeeId: prospectIdentity.providerId,
+      accountId: storedAccount.accountId,
+      limit: 25,
+    });
+    resolvedChat = selectDeterministicLinkedInChat(
+      chats,
+      prospectIdentity.providerId ?? ""
+    );
+    if (!resolvedChat) {
+      return null;
+    }
+    conversation = {
+      conversationId: resolvedChat.id,
+      sourceId: resolvedChat.provider_id,
+      participantProviderId:
+        resolvedChat.attendee_provider_id ?? prospectIdentity.providerId,
+    };
+  }
 
-  const prospectIdentity = getProspectLinkedInIdentity(prospect);
+  const conversationId = conversation.conversationId;
+  if (!conversationId) {
+    return null;
+  }
   const page = await loadLinkedInConversationHistoryPage({
-    chatId: conversation.conversationId,
+    chatId: conversationId,
     cursor: args.cursor,
     limit: args.limit,
     sinceMs: args.sinceMs,
@@ -2887,21 +2916,23 @@ async function getProspectLinkedInHistoryPageForUser(
   const eligibility = buildEligibility({
     status: connectionStatus,
     providerId: prospectIdentity.providerId,
-    conversationId: conversation.conversationId,
+    conversationId,
   });
   if (shouldPersistRecentConversationHistoryPage(args)) {
     await persistConversationSnapshot(ctx, {
       userId,
       prospect,
       accountId: storedAccount.accountId,
-      chat: {
-        id: conversation.conversationId,
-        account_id: storedAccount.accountId,
-        account_type: "LINKEDIN",
-        provider_id: conversation.sourceId,
-        attendee_provider_id:
-          conversation.participantProviderId ?? prospectIdentity.providerId,
-      },
+      chat:
+        resolvedChat ??
+        ({
+          id: conversationId,
+          account_id: storedAccount.accountId,
+          account_type: "LINKEDIN",
+          provider_id: conversation.sourceId,
+          attendee_provider_id:
+            conversation.participantProviderId ?? prospectIdentity.providerId,
+        } as UnipileChat),
       prospectIdentity,
       eligibility,
       messages: page.messages,
@@ -2911,7 +2942,7 @@ async function getProspectLinkedInHistoryPageForUser(
   }
 
   return {
-    conversationId: conversation.conversationId,
+    conversationId,
     messages: page.messages,
     history: page.history,
   };

--- a/convex/outreachRecovery.ts
+++ b/convex/outreachRecovery.ts
@@ -1839,9 +1839,9 @@ export const ensureTwitterManualReplyRecoveryForUserInternal = internalAction({
 
     const now = getCurrentUTCTimestamp();
     const isPendingRetryWindow =
-      account.activitySubscriptionStatus === "pending_retry" &&
-      typeof account.activitySubscriptionsNextRetryAt === "number" &&
-      account.activitySubscriptionsNextRetryAt > now;
+      account.postActivitySubscriptionStatus === "pending_retry" &&
+      typeof account.postActivitySubscriptionsNextRetryAt === "number" &&
+      account.postActivitySubscriptionsNextRetryAt > now;
     if (isPendingRetryWindow) {
       await ctx.runMutation(
         internalRecovery.syncTwitterManualReplyRecoveryStatusForUserInternal,
@@ -1854,7 +1854,8 @@ export const ensureTwitterManualReplyRecoveryForUserInternal = internalAction({
       await ctx.scheduler.runAfter(
         Math.max(
           0,
-          account.activitySubscriptionsNextRetryAt! - getCurrentUTCTimestamp()
+          account.postActivitySubscriptionsNextRetryAt! -
+            getCurrentUTCTimestamp()
         ),
         internalRecovery.ensureTwitterManualReplyRecoveryForUserInternal,
         { userId: args.userId }
@@ -1902,8 +1903,8 @@ export const ensureTwitterManualReplyRecoveryForUserInternal = internalAction({
         { userId: args.userId }
       );
       const retryAt =
-        typeof latestAccount?.activitySubscriptionsNextRetryAt === "number"
-          ? latestAccount.activitySubscriptionsNextRetryAt
+        typeof latestAccount?.postActivitySubscriptionsNextRetryAt === "number"
+          ? latestAccount.postActivitySubscriptionsNextRetryAt
           : now + TWITTER_ACTIVITY_RETRY_DELAY_MS;
       await ctx.scheduler.runAfter(
         Math.max(0, retryAt - getCurrentUTCTimestamp()),

--- a/convex/platformConversations.ts
+++ b/convex/platformConversations.ts
@@ -179,6 +179,8 @@ export const upsertConversationSnapshotInternal = internalMutation({
   },
   handler: async (ctx, args) => {
     const now = getCurrentUTCTimestamp();
+    const didSyncSucceed = typeof args.lastSyncSuccessAt === "number";
+    const hasNewHistoryState = typeof args.historyHasMore === "boolean";
     const existingConversation = await ctx.db
       .query("platformConversations")
       .withIndex("by_user_conversation", (q) =>
@@ -229,36 +231,40 @@ export const upsertConversationSnapshotInternal = internalMutation({
         "lastSyncSuccessAt",
         existingConversation?.lastSyncSuccessAt
       ),
-      nextSyncAllowedAt: pickOptionalPatchValue(
-        args,
-        "nextSyncAllowedAt",
-        existingConversation?.nextSyncAllowedAt
-      ),
-      lastSyncErrorCode: pickOptionalPatchValue(
-        args,
-        "lastSyncErrorCode",
-        existingConversation?.lastSyncErrorCode
-      ),
-      lastSyncErrorMessage: pickOptionalPatchValue(
-        args,
-        "lastSyncErrorMessage",
-        existingConversation?.lastSyncErrorMessage
-      ),
-      historyNextCursor: pickOptionalPatchValue(
-        args,
-        "historyNextCursor",
-        existingConversation?.historyNextCursor
-      ),
+      nextSyncAllowedAt: didSyncSucceed
+        ? undefined
+        : pickOptionalPatchValue(
+            args,
+            "nextSyncAllowedAt",
+            existingConversation?.nextSyncAllowedAt
+          ),
+      lastSyncErrorCode: didSyncSucceed
+        ? undefined
+        : pickOptionalPatchValue(
+            args,
+            "lastSyncErrorCode",
+            existingConversation?.lastSyncErrorCode
+          ),
+      lastSyncErrorMessage: didSyncSucceed
+        ? undefined
+        : pickOptionalPatchValue(
+            args,
+            "lastSyncErrorMessage",
+            existingConversation?.lastSyncErrorMessage
+          ),
+      historyNextCursor: hasNewHistoryState
+        ? args.historyHasMore
+          ? args.historyNextCursor
+          : undefined
+        : existingConversation?.historyNextCursor,
       historyHasMore: pickOptionalPatchValue(
         args,
         "historyHasMore",
         existingConversation?.historyHasMore
       ),
-      historyBoundary: pickOptionalPatchValue(
-        args,
-        "historyBoundary",
-        existingConversation?.historyBoundary
-      ),
+      historyBoundary: hasNewHistoryState
+        ? args.historyBoundary
+        : existingConversation?.historyBoundary,
       historyOldestLoadedAt:
         typeof args.historyOldestLoadedAt === "number"
           ? Math.min(

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -209,9 +209,29 @@ export default defineSchema({
     activitySubscriptionsNextRetryAt: v.optional(v.number()),
     activitySubscriptionsLastError: v.optional(v.string()),
     activitySubscriptionsLastAuthMode: v.optional(xActivityAuthModeValidator),
+    /** X Activity health is tracked per capability so post delivery cannot mask broken DMs. */
+    dmActivitySubscriptionStatus: v.optional(
+      xActivitySubscriptionStatusValidator
+    ),
+    dmActivitySubscriptionsEnsuredAt: v.optional(v.number()),
+    dmActivitySubscriptionsLastAttemptAt: v.optional(v.number()),
+    dmActivitySubscriptionsNextRetryAt: v.optional(v.number()),
+    dmActivitySubscriptionsLastError: v.optional(v.string()),
+    dmActivitySubscriptionsLastAuthMode: v.optional(xActivityAuthModeValidator),
+    postActivitySubscriptionStatus: v.optional(
+      xActivitySubscriptionStatusValidator
+    ),
+    postActivitySubscriptionsEnsuredAt: v.optional(v.number()),
+    postActivitySubscriptionsLastAttemptAt: v.optional(v.number()),
+    postActivitySubscriptionsNextRetryAt: v.optional(v.number()),
+    postActivitySubscriptionsLastError: v.optional(v.string()),
+    postActivitySubscriptionsLastAuthMode: v.optional(
+      xActivityAuthModeValidator
+    ),
   })
     .index("by_user", ["userId"])
     .index("by_user_status", ["userId", "status"])
+    .index("by_status", ["status"])
     .index("by_x_user_id", ["xUserId"]),
 
   xAuthSessions: defineTable({

--- a/convex/x.ts
+++ b/convex/x.ts
@@ -37,6 +37,7 @@ import {
   shouldPersistRecentConversationHistoryPage,
   type ConversationHistoryPageMetadata,
 } from "./lib/conversationHistoryPaginationCore";
+import { getXActivitySubscriptionHealth } from "./lib/xActivityReconciliationCore";
 import { getTwitterActionCatalogEntry } from "./lib/twitterActionCatalog";
 import { getTwitterViewerStatesForUser } from "./lib/twitterViewerStateService";
 import { userTimelineModeValidator } from "./validators";
@@ -406,7 +407,7 @@ async function persistDmConversationSnapshot(
     lastSyncAttemptAt?: number;
     lastSyncSuccessAt?: number;
     nextSyncAllowedAt?: number;
-    lastSyncErrorCode?: "rate_limited" | "activity_degraded";
+    lastSyncErrorCode?: "rate_limited" | "activity_degraded" | "provider_error";
     lastSyncErrorMessage?: string;
     history?: ConversationHistoryPageMetadata;
     historyOldestLoadedAt?: number;
@@ -465,11 +466,11 @@ function buildCachedDmWarning(args: {
   }
 
   const account = args.account;
+  const dmHealth = getXActivitySubscriptionHealth(account ?? {}, "dm");
   if (
     args.connectionStatus.status === "connected" &&
     args.connectionStatus.isConnected &&
-    account?.activitySubscriptionStatus &&
-    account.activitySubscriptionStatus !== "healthy" &&
+    dmHealth.status !== "healthy" &&
     (typeof conversation?.lastSyncSuccessAt !== "number" ||
       getCurrentUTCTimestamp() - conversation.lastSyncSuccessAt >
         DM_PANEL_FRESH_MS)
@@ -479,12 +480,8 @@ function buildCachedDmWarning(args: {
       message:
         "Realtime DM activity is temporarily degraded. Messaging still works, but live updates may lag.",
       retryAfterMs:
-        typeof account.activitySubscriptionsNextRetryAt === "number"
-          ? Math.max(
-              0,
-              account.activitySubscriptionsNextRetryAt -
-                getCurrentUTCTimestamp()
-            )
+        typeof dmHealth.nextRetryAt === "number"
+          ? Math.max(0, dmHealth.nextRetryAt - getCurrentUTCTimestamp())
           : undefined,
     };
   }
@@ -502,6 +499,17 @@ function buildBaseDmPanelContext(args: {
   draftAttachments?: XDmAttachmentSummary[];
   actionRequestId?: string;
 }): XDmPanelContext {
+  const currentConnectionEligibility = buildDmEligibility({
+    isConnected: args.connectionStatus.isConnected,
+    missingScopes: args.connectionStatus.missingScopes,
+    receivesYourDm: args.prospectIdentity.canDm,
+    conversationId: args.cachedSnapshot?.conversation?.conversationId,
+  });
+  const canUseCachedEligibility =
+    args.connectionStatus.isConnected &&
+    !(args.connectionStatus.missingScopes ?? []).some(
+      (scope) => scope === "dm.read" || scope === "dm.write"
+    );
   return {
     platform: "twitter",
     conversationId: args.cachedSnapshot?.conversation?.conversationId,
@@ -517,6 +525,7 @@ function buildBaseDmPanelContext(args: {
       verified: args.prospectIdentity.verified,
     },
     eligibility:
+      canUseCachedEligibility &&
       args.cachedSnapshot?.conversation?.eligibilityReasonCode &&
       typeof args.cachedSnapshot?.conversation?.eligibilityEnabled === "boolean"
         ? {
@@ -527,12 +536,7 @@ function buildBaseDmPanelContext(args: {
               "DM eligibility unavailable right now.",
             conversationId: args.cachedSnapshot.conversation.conversationId,
           }
-        : buildDmEligibility({
-            isConnected: args.connectionStatus.isConnected,
-            missingScopes: args.connectionStatus.missingScopes,
-            receivesYourDm: args.prospectIdentity.canDm,
-            conversationId: args.cachedSnapshot?.conversation?.conversationId,
-          }),
+        : currentConnectionEligibility,
     messages: toCachedDmMessages(args.cachedSnapshot),
     history: {
       nextCursor:
@@ -712,6 +716,7 @@ async function syncProspectDmConversationForUser(
     historyCursor?: string;
     historySinceMs?: number;
     historyLimit?: number;
+    activitySubscriptionsEnsured: boolean;
   }
 ): Promise<XDmPanelContext> {
   const syncAttemptAt = getCurrentUTCTimestamp();
@@ -842,13 +847,6 @@ async function syncProspectDmConversationForUser(
     }
   }
 
-  const ensured = await ctx.runAction(
-    internal.xActivity.ensureDmActivitySubscriptionsForUserInternal,
-    {
-      userId: args.userId,
-    }
-  );
-
   return {
     ...args.baseContext,
     conversationId,
@@ -860,7 +858,13 @@ async function syncProspectDmConversationForUser(
     eligibility,
     messages: panelMessages,
     history,
-    warning: ensured.ensured ? undefined : args.baseContext.warning,
+    warning: args.activitySubscriptionsEnsured
+      ? undefined
+      : (args.baseContext.warning ?? {
+          code: "activity_degraded",
+          message:
+            "Realtime X/Twitter DM updates are temporarily degraded. Live history reads still work, but new messages may arrive late.",
+        }),
   };
 }
 
@@ -931,11 +935,27 @@ async function resolveProspectDmPanelContext(
   ) {
     return baseContext;
   }
+  const dmSubscriptions = await ctx.runAction(
+    internal.xActivity.ensureDmActivitySubscriptionsForUserInternal,
+    { userId }
+  );
+  const resolvedBaseContext = dmSubscriptions.ensured
+    ? baseContext.warning?.code === "activity_degraded"
+      ? { ...baseContext, warning: undefined }
+      : baseContext
+    : {
+        ...baseContext,
+        warning: baseContext.warning ?? {
+          code: "activity_degraded" as const,
+          message:
+            "Realtime X/Twitter DM updates are temporarily degraded. Live history reads still work, but new messages may arrive late.",
+        },
+      };
   const isExplicitHistoryPage =
     typeof options?.historyCursor === "string" ||
     typeof options?.historySinceMs === "number";
   if (!isExplicitHistoryPage && !shouldPerformLiveDmSync(cachedSnapshot)) {
-    return baseContext;
+    return resolvedBaseContext;
   }
 
   try {
@@ -944,18 +964,52 @@ async function resolveProspectDmPanelContext(
       prospect,
       prospectIdentity,
       connectionStatus,
-      baseContext,
+      baseContext: resolvedBaseContext,
       historyCursor: options?.historyCursor,
       historySinceMs: options?.historySinceMs,
       historyLimit: options?.historyLimit,
+      activitySubscriptionsEnsured: dmSubscriptions.ensured,
     });
   } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
     logger.warn("Unable to refresh X/Twitter DM panel context", {
-      error: error instanceof Error ? error.message : String(error),
+      error: message,
       userId,
       prospectId,
     });
-    return baseContext;
+    if (resolvedBaseContext.conversationId) {
+      try {
+        await persistDmConversationSnapshot(ctx, {
+          userId,
+          prospect,
+          conversationId: resolvedBaseContext.conversationId,
+          participantUserId: resolvedBaseContext.participantUserId,
+          participantUsername: resolvedBaseContext.participantUsername,
+          eligibility: resolvedBaseContext.eligibility,
+          messages: resolvedBaseContext.messages,
+          lastSyncAttemptAt: getCurrentUTCTimestamp(),
+          lastSyncErrorCode: "provider_error",
+          lastSyncErrorMessage: message,
+        });
+      } catch (persistError) {
+        logger.warn("Unable to persist X/Twitter DM refresh failure", {
+          error:
+            persistError instanceof Error
+              ? persistError.message
+              : String(persistError),
+          userId,
+          prospectId,
+        });
+      }
+    }
+    return {
+      ...resolvedBaseContext,
+      warning: {
+        code: "provider_error",
+        message:
+          "Live X/Twitter DM history could not be refreshed. Showing last synced messages.",
+      },
+    };
   }
 }
 
@@ -999,6 +1053,14 @@ async function getProspectXDmHistoryPageForUser(
   ) {
     return null;
   }
+
+  // Every DM read is also a recovery opportunity. The ensure action is
+  // idempotent and only performs a remote reconciliation after its bounded
+  // verification window expires.
+  await ctx.runAction(
+    internal.xActivity.ensureDmActivitySubscriptionsForUserInternal,
+    { userId }
+  );
 
   const provider = await getXProviderContextForUser(ctx, getXStoreRefs(), {
     userId,
@@ -1313,6 +1375,11 @@ export const completeTwitterConnection = action({
       await ctx.scheduler.runAfter(
         0,
         internal.styleMonitorActions.ensureStyleMonitor,
+        { userId }
+      );
+      await ctx.scheduler.runAfter(
+        0,
+        internal.xActivity.ensureDmActivitySubscriptionsForUserInternal,
         { userId }
       );
     }

--- a/convex/xActivity.ts
+++ b/convex/xActivity.ts
@@ -13,6 +13,7 @@ import {
   getXWebhookCallbackUrl,
   listXActivitySubscriptions,
   listXWebhooks,
+  normalizeXActivityEventType,
   updateXActivitySubscription,
   type XActivityEventType,
   type XDmActivityEventType,
@@ -20,6 +21,7 @@ import {
 } from "./lib/xActivity";
 import {
   findMatchingXActivitySubscription,
+  getXActivitySubscriptionHealth,
   isDuplicateXActivitySubscriptionError,
 } from "./lib/xActivityReconciliationCore";
 import {
@@ -174,8 +176,12 @@ function normalizeWebhookEvents(
     if (!envelope) {
       continue;
     }
-    const eventType =
+    const rawEventType =
       asString(envelope.event_type) ?? asString(envelope.eventType);
+    if (!rawEventType) {
+      continue;
+    }
+    const eventType = normalizeXActivityEventType(rawEventType);
     if (!eventType) {
       continue;
     }
@@ -608,29 +614,22 @@ export const ensureDmActivitySubscriptionsForUserInternal = internalAction({
         typeof subscription.webhookId === "string" &&
         validLocalWebhookIds.has(subscription.webhookId)
     )?.webhookId;
-    if (localWebhookId && hasAllLocalSubscriptions) {
-      await ctx.runMutation(internal.xStore.patchXAccountInternal, {
-        userId: args.userId,
-        patch: {
-          activitySubscriptionStatus: "healthy",
-          activitySubscriptionsEnsuredAt: now,
-          activitySubscriptionsLastAttemptAt: now,
-          activitySubscriptionsNextRetryAt: undefined,
-          activitySubscriptionsLastError: undefined,
-        },
-      });
+    const dmHealth = getXActivitySubscriptionHealth(account, "dm");
+    const isRecentlyVerified =
+      dmHealth.status === "healthy" &&
+      typeof dmHealth.nextRetryAt === "number" &&
+      dmHealth.nextRetryAt > now;
+    if (localWebhookId && hasAllLocalSubscriptions && isRecentlyVerified) {
       return { ensured: true, webhookId: localWebhookId };
     }
 
     const isPendingRetryWindow =
-      account.activitySubscriptionStatus === "pending_retry" &&
-      typeof account.activitySubscriptionsNextRetryAt === "number" &&
-      account.activitySubscriptionsNextRetryAt > now;
+      dmHealth.status === "pending_retry" &&
+      typeof dmHealth.nextRetryAt === "number" &&
+      dmHealth.nextRetryAt > now;
     const shouldAttemptDuplicateReconciliation =
       isPendingRetryWindow &&
-      isDuplicateXActivitySubscriptionError(
-        account.activitySubscriptionsLastError
-      );
+      isDuplicateXActivitySubscriptionError(dmHealth.lastError);
 
     if (isPendingRetryWindow && !shouldAttemptDuplicateReconciliation) {
       return { ensured: false };
@@ -639,7 +638,7 @@ export const ensureDmActivitySubscriptionsForUserInternal = internalAction({
     await ctx.runMutation(internal.xStore.patchXAccountInternal, {
       userId: args.userId,
       patch: {
-        activitySubscriptionsLastAttemptAt: now,
+        dmActivitySubscriptionsLastAttemptAt: now,
       },
     });
 
@@ -670,13 +669,13 @@ export const ensureDmActivitySubscriptionsForUserInternal = internalAction({
       await ctx.runMutation(internal.xStore.patchXAccountInternal, {
         userId: args.userId,
         patch: {
-          activitySubscriptionStatus: "healthy",
-          activitySubscriptionsEnsuredAt: now,
-          activitySubscriptionsLastAttemptAt: now,
-          activitySubscriptionsNextRetryAt:
+          dmActivitySubscriptionStatus: "healthy",
+          dmActivitySubscriptionsEnsuredAt: now,
+          dmActivitySubscriptionsLastAttemptAt: now,
+          dmActivitySubscriptionsNextRetryAt:
             now + ACTIVITY_ENSURE_SUCCESS_TTL_MS,
-          activitySubscriptionsLastError: undefined,
-          activitySubscriptionsLastAuthMode: authMode,
+          dmActivitySubscriptionsLastError: undefined,
+          dmActivitySubscriptionsLastAuthMode: authMode,
         },
       });
 
@@ -692,10 +691,10 @@ export const ensureDmActivitySubscriptionsForUserInternal = internalAction({
       await ctx.runMutation(internal.xStore.patchXAccountInternal, {
         userId: args.userId,
         patch: {
-          activitySubscriptionStatus: "pending_retry",
-          activitySubscriptionsLastAttemptAt: now,
-          activitySubscriptionsNextRetryAt: nextRetryAt,
-          activitySubscriptionsLastError: message,
+          dmActivitySubscriptionStatus: "pending_retry",
+          dmActivitySubscriptionsLastAttemptAt: now,
+          dmActivitySubscriptionsNextRetryAt: nextRetryAt,
+          dmActivitySubscriptionsLastError: message,
         },
       });
 
@@ -769,25 +768,19 @@ export const ensurePostCreateActivitySubscriptionForUserInternal =
           typeof subscription.webhookId === "string" &&
           validLocalWebhookIds.has(subscription.webhookId)
       )?.webhookId;
-      if (localWebhookId && hasLocalPostCreate) {
-        await ctx.runMutation(internal.xStore.patchXAccountInternal, {
-          userId: args.userId,
-          patch: {
-            activitySubscriptionStatus: "healthy",
-            activitySubscriptionsEnsuredAt: now,
-            activitySubscriptionsLastAttemptAt: now,
-            activitySubscriptionsNextRetryAt:
-              now + ACTIVITY_ENSURE_SUCCESS_TTL_MS,
-            activitySubscriptionsLastError: undefined,
-          },
-        });
+      const postHealth = getXActivitySubscriptionHealth(account, "post");
+      const isRecentlyVerified =
+        postHealth.status === "healthy" &&
+        typeof postHealth.nextRetryAt === "number" &&
+        postHealth.nextRetryAt > now;
+      if (localWebhookId && hasLocalPostCreate && isRecentlyVerified) {
         return { ensured: true, webhookId: localWebhookId };
       }
 
       const isPendingRetryWindow =
-        account.activitySubscriptionStatus === "pending_retry" &&
-        typeof account.activitySubscriptionsNextRetryAt === "number" &&
-        account.activitySubscriptionsNextRetryAt > now;
+        postHealth.status === "pending_retry" &&
+        typeof postHealth.nextRetryAt === "number" &&
+        postHealth.nextRetryAt > now;
       if (isPendingRetryWindow) {
         return { ensured: false };
       }
@@ -795,7 +788,7 @@ export const ensurePostCreateActivitySubscriptionForUserInternal =
       await ctx.runMutation(internal.xStore.patchXAccountInternal, {
         userId: args.userId,
         patch: {
-          activitySubscriptionsLastAttemptAt: now,
+          postActivitySubscriptionsLastAttemptAt: now,
         },
       });
 
@@ -820,13 +813,13 @@ export const ensurePostCreateActivitySubscriptionForUserInternal =
         await ctx.runMutation(internal.xStore.patchXAccountInternal, {
           userId: args.userId,
           patch: {
-            activitySubscriptionStatus: "healthy",
-            activitySubscriptionsEnsuredAt: now,
-            activitySubscriptionsLastAttemptAt: now,
-            activitySubscriptionsNextRetryAt:
+            postActivitySubscriptionStatus: "healthy",
+            postActivitySubscriptionsEnsuredAt: now,
+            postActivitySubscriptionsLastAttemptAt: now,
+            postActivitySubscriptionsNextRetryAt:
               now + ACTIVITY_ENSURE_SUCCESS_TTL_MS,
-            activitySubscriptionsLastError: undefined,
-            activitySubscriptionsLastAuthMode: authMode,
+            postActivitySubscriptionsLastError: undefined,
+            postActivitySubscriptionsLastAuthMode: authMode,
           },
         });
         return { ensured: true, webhookId };
@@ -840,10 +833,10 @@ export const ensurePostCreateActivitySubscriptionForUserInternal =
         await ctx.runMutation(internal.xStore.patchXAccountInternal, {
           userId: args.userId,
           patch: {
-            activitySubscriptionStatus: "pending_retry",
-            activitySubscriptionsLastAttemptAt: now,
-            activitySubscriptionsNextRetryAt: nextRetryAt,
-            activitySubscriptionsLastError: message,
+            postActivitySubscriptionStatus: "pending_retry",
+            postActivitySubscriptionsLastAttemptAt: now,
+            postActivitySubscriptionsNextRetryAt: nextRetryAt,
+            postActivitySubscriptionsLastError: message,
           },
         });
         console.warn("[XActivity] Failed to ensure post.create subscription", {
@@ -854,6 +847,68 @@ export const ensurePostCreateActivitySubscriptionForUserInternal =
       }
     },
   });
+
+type ConnectedXAccountUserIdPage = {
+  page: Id<"users">[];
+  isDone: boolean;
+  continueCursor: string;
+};
+
+/**
+ * Reconcile every connected account in bounded pages. Each per-user ensure is
+ * already idempotent and avoids provider calls while the complete local DM
+ * subscription set is healthy.
+ */
+export const retryDmActivitySubscriptionsCron = internalAction({
+  args: {
+    cursor: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const accounts: ConnectedXAccountUserIdPage = await ctx.runQuery(
+      internal.xStore.listConnectedXAccountUserIdsInternal,
+      {
+        paginationOpts: {
+          numItems: 10,
+          cursor: args.cursor ?? null,
+        },
+      }
+    );
+    let ensured = 0;
+    for (const userId of accounts.page) {
+      try {
+        const result: { ensured: boolean } = await ctx.runAction(
+          internal.xActivity.ensureDmActivitySubscriptionsForUserInternal,
+          { userId }
+        );
+        if (result.ensured) {
+          ensured += 1;
+        }
+      } catch (error) {
+        console.warn(
+          "[XActivity] Scheduled DM subscription reconciliation failed",
+          {
+            userId: String(userId),
+            error: error instanceof Error ? error.message : String(error),
+          }
+        );
+      }
+    }
+
+    if (!accounts.isDone) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.xActivity.retryDmActivitySubscriptionsCron,
+        { cursor: accounts.continueCursor }
+      );
+    }
+
+    return {
+      checked: accounts.page.length,
+      ensured,
+      hasMore: !accounts.isDone,
+    };
+  },
+});
 
 export const handleWebhookPayloadInternal = internalAction({
   args: {

--- a/convex/xStore.ts
+++ b/convex/xStore.ts
@@ -1,4 +1,5 @@
 import { v } from "convex/values";
+import { paginationOptsValidator } from "convex/server";
 import { internalMutation, internalQuery } from "./lib/functionBuilders";
 import { buildChangedPatchWithUpdatedAt } from "./lib/patchHelpers";
 import {
@@ -29,6 +30,23 @@ export const getXAccountByXUserIdInternal = internalQuery({
       .query("xAccounts")
       .withIndex("by_x_user_id", (q) => q.eq("xUserId", xUserId))
       .first();
+  },
+});
+
+/** Bounded account pages for scheduled subscription reconciliation. */
+export const listConnectedXAccountUserIdsInternal = internalQuery({
+  args: {
+    paginationOpts: paginationOptsValidator,
+  },
+  handler: async (ctx, args) => {
+    const result = await ctx.db
+      .query("xAccounts")
+      .withIndex("by_status", (q) => q.eq("status", "connected"))
+      .paginate(args.paginationOpts);
+    return {
+      ...result,
+      page: result.page.map((account) => account.userId),
+    };
   },
 });
 
@@ -142,7 +160,20 @@ export const patchXAccountInternal = internalMutation({
       return null;
     }
 
-    await ctx.db.patch(existing._id, patch);
+    const normalizedPatch = {
+      ...(patch as Record<string, unknown>),
+    };
+    // `undefined` does not survive Convex function argument serialization.
+    // Clear capability-specific errors inside the mutation that owns the DB
+    // write whenever that capability has just been verified healthy.
+    if (normalizedPatch.dmActivitySubscriptionStatus === "healthy") {
+      normalizedPatch.dmActivitySubscriptionsLastError = undefined;
+    }
+    if (normalizedPatch.postActivitySubscriptionStatus === "healthy") {
+      normalizedPatch.postActivitySubscriptionsLastError = undefined;
+    }
+
+    await ctx.db.patch(existing._id, normalizedPatch);
     return existing._id;
   },
 });
@@ -198,6 +229,18 @@ export const disconnectXAccountInternal = internalMutation({
         activitySubscriptionsNextRetryAt: undefined,
         activitySubscriptionsLastError: undefined,
         activitySubscriptionsLastAuthMode: undefined,
+        dmActivitySubscriptionStatus: undefined,
+        dmActivitySubscriptionsEnsuredAt: undefined,
+        dmActivitySubscriptionsLastAttemptAt: undefined,
+        dmActivitySubscriptionsNextRetryAt: undefined,
+        dmActivitySubscriptionsLastError: undefined,
+        dmActivitySubscriptionsLastAuthMode: undefined,
+        postActivitySubscriptionStatus: undefined,
+        postActivitySubscriptionsEnsuredAt: undefined,
+        postActivitySubscriptionsLastAttemptAt: undefined,
+        postActivitySubscriptionsNextRetryAt: undefined,
+        postActivitySubscriptionsLastError: undefined,
+        postActivitySubscriptionsLastAuthMode: undefined,
         updatedAt: now,
       },
       now

--- a/features/prospects/hooks/useProspectDmPanel.ts
+++ b/features/prospects/hooks/useProspectDmPanel.ts
@@ -167,6 +167,7 @@ export function useProspectDmPanel(args: {
     const cursor = currentData?.history?.nextCursor;
     if (
       !prospectId ||
+      !currentData?.eligibility.enabled ||
       !currentData?.history?.hasMore ||
       !cursor ||
       isLoadingOlder

--- a/features/prospects/ui/components/XConversationPanel.tsx
+++ b/features/prospects/ui/components/XConversationPanel.tsx
@@ -488,7 +488,9 @@ export function XConversationPanel({
                   <ConversationHistoryPagination
                     conversationKey={`${prospectId}:${data.conversationId ?? "pending"}`}
                     messageCount={data.messages.length}
-                    hasMore={data.history?.hasMore === true}
+                    hasMore={
+                      data.eligibility.enabled && data.history?.hasMore === true
+                    }
                     isLoading={isLoadingOlder}
                     loadMoreError={loadOlderError}
                     onLoadMore={() => void loadOlder()}

--- a/shared/lib/twitter/dm.ts
+++ b/shared/lib/twitter/dm.ts
@@ -54,7 +54,7 @@ export interface XDmProspectSummary {
 }
 
 export interface XDmPanelWarning {
-  code: "rate_limited" | "activity_degraded";
+  code: "rate_limited" | "activity_degraded" | "provider_error";
   message: string;
   retryAfterMs?: number;
 }


### PR DESCRIPTION
## Summary
- keep provider cursors backend-owned and return live/cached/failed evidence to the real Agent
- fetch bounded latest/since X and LinkedIn DM pages without hard-coded response gates
- split X DM/post subscription health, reconcile remote subscriptions idempotently, and retry on reconnect/cron/read
- preserve cached panel history while connection state controls live pagination and sending

## Verification
- pnpm lint:strict
- pnpm exec tsc --noEmit
- pnpm test:convex (36 files, 188 tests)
- pnpm build
- npx convex dev --once
- React Doctor changed-scope scan
- browser E2E in ReacherX (lead gen local) with testing_userss and sd-designs: panels, X continuation, cached/reconnect Agent answers, recovered live Agent answers, and LinkedIn since coverage
- dev reconciliation confirmed both X accounts healthy with all expected DM/chat subscriptions