### PR TITLE
Read XChat history directly by participant

### DIFF
--- a/convex/lib/xChatConversationHistoryCore.test.ts
+++ b/convex/lib/xChatConversationHistoryCore.test.ts
@@ -100,12 +100,16 @@ describe("XChat conversation-history metadata", () => {
     });
   });
 
-  test("uses the documented participant-events route and returns metadata only", async () => {
+  test("reads participant events when the bounded account-wide listing omits the conversation", async () => {
     const data = Array.from({ length: 23 }, (_, index) => ({
       encoded_event: `ciphertext-${index}`,
       sender_id: index < 8 ? participantUserId : viewerUserId,
       created_at_msec: String(1_700_000_000_000 + index),
     }));
+    const boundedAccountWideListing = {
+      data: [],
+      meta: { next_token: "unread-account-wide-page" },
+    };
     const requests: string[] = [];
     const originalFetch = globalThis.fetch;
     globalThis.fetch = (async (input: string | URL | Request) => {
@@ -113,15 +117,7 @@ describe("XChat conversation-history metadata", () => {
       requests.push(url);
       const payload = url.includes("/events")
         ? { data }
-        : {
-            data: [
-              {
-                id: "direct-conversation",
-                participant_ids: [viewerUserId, participantUserId],
-                type: "direct",
-              },
-            ],
-          };
+        : boundedAccountWideListing;
       return new Response(JSON.stringify(payload), { status: 200 });
     }) as typeof fetch;
 
@@ -135,9 +131,8 @@ describe("XChat conversation-history metadata", () => {
         { limit: 25 }
       );
 
-      expect(requests).toHaveLength(2);
-      expect(new URL(requests[0]!).pathname).toBe("/2/chat/conversations");
-      expect(new URL(requests[1]!).pathname).toBe(
+      expect(requests).toHaveLength(1);
+      expect(new URL(requests[0]!).pathname).toBe(
         `/2/chat/conversations/${participantUserId}/events`
       );
       expect(evidence).toMatchObject({
@@ -152,6 +147,71 @@ describe("XChat conversation-history metadata", () => {
         boundary: "complete",
       });
       expect(JSON.stringify(evidence)).not.toContain("ciphertext-");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("marks the conversation found before a since filter excludes its encrypted event", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          data: [
+            {
+              encoded_event: "older-ciphertext",
+              sender_id: participantUserId,
+              created_at_msec: "1000",
+            },
+          ],
+        }),
+        { status: 200 }
+      )) as typeof fetch;
+
+    try {
+      const evidence = await getXChatConversationHistoryEvidence(
+        {
+          client: new Client({ accessToken: "test-user-access-token" }),
+          xUserId: viewerUserId,
+        },
+        participantUserId,
+        { sinceMs: 2_000 }
+      );
+
+      expect(evidence).toMatchObject({
+        conversationFound: true,
+        eventCount: 0,
+        inboundEventCount: 0,
+        outboundEventCount: 0,
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("does not report a conversation for an empty participant-events response", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+      })) as typeof fetch;
+
+    try {
+      const evidence = await getXChatConversationHistoryEvidence(
+        {
+          client: new Client({ accessToken: "test-user-access-token" }),
+          xUserId: viewerUserId,
+        },
+        participantUserId
+      );
+
+      expect(evidence).toMatchObject({
+        conversationFound: false,
+        conversationLookupComplete: true,
+        conversationPagesFetched: 0,
+        eventPagesFetched: 1,
+        eventCount: 0,
+      });
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/convex/lib/xChatConversationHistoryCore.ts
+++ b/convex/lib/xChatConversationHistoryCore.ts
@@ -9,8 +9,9 @@ export type XChatConversationHistoryEvidence = Infer<
 
 /**
  * XChat responses expose encrypted envelopes. These types intentionally omit
- * `encodedEvent`, so no caller can accidentally treat ciphertext as message
- * text while building Agent-facing history evidence.
+ * `encodedEvent`, so callers cannot treat ciphertext as message text. The
+ * account-wide listing is normalized for isolated uses, but it is not a
+ * prerequisite for direct participant-event retrieval.
  */
 export type XChatConversationPage = {
   conversations: Array<{

--- a/convex/lib/xdkTwitterProvider.ts
+++ b/convex/lib/xdkTwitterProvider.ts
@@ -5,8 +5,6 @@ import { ApiError, type Client } from "@xdevplatform/xdk";
 import type { CuratedTwitterActionKey } from "./twitterActionCatalog";
 import { getXAppBearerToken } from "./xdkClient";
 import {
-  findDirectXChatConversation,
-  normalizeXChatConversationPage,
   normalizeXChatEventPage,
   summarizeXChatEventPage,
   type XChatConversationHistoryEvidence,
@@ -1905,55 +1903,6 @@ export async function getXChatConversationHistoryEvidence(
 ): Promise<XChatConversationHistoryEvidence> {
   const limit = normalizeConversationHistoryPageLimit(options?.limit);
   const pageBudget = getXChatPageBudget(options?.maxPages);
-  let conversationCursor: string | undefined;
-  let conversationPagesFetched = 0;
-  let directConversation: ReturnType<typeof findDirectXChatConversation> = null;
-
-  do {
-    const conversationResponse = await getXChatJson(
-      context,
-      "/2/chat/conversations",
-      getXChatHistoryParams({
-        limit,
-        cursor: conversationCursor,
-        fieldName: "chat_conversation.fields",
-        fields: ["id", "participant_ids", "type"],
-      })
-    );
-    conversationPagesFetched += 1;
-    const conversationPage =
-      normalizeXChatConversationPage(conversationResponse);
-    directConversation = findDirectXChatConversation({
-      conversations: conversationPage.conversations,
-      viewerUserId: context.xUserId,
-      participantUserId,
-    });
-    conversationCursor = conversationPage.nextCursor;
-  } while (
-    !directConversation &&
-    conversationCursor &&
-    conversationPagesFetched < pageBudget
-  );
-
-  if (!directConversation) {
-    const hasMore = Boolean(conversationCursor);
-    return {
-      conversationFound: false,
-      conversationLookupComplete: !hasMore,
-      encrypted: true,
-      contentState: "encrypted_locked",
-      conversationPagesFetched,
-      eventPagesFetched: 0,
-      eventCount: 0,
-      inboundEventCount: 0,
-      outboundEventCount: 0,
-      unattributedEventCount: 0,
-      hasMore,
-      pageLimitReached: hasMore,
-      boundary: hasMore ? "page_limit" : "complete",
-    };
-  }
-
   let eventCursor: string | undefined;
   let eventPagesFetched = 0;
   let eventCount = 0;
@@ -1963,6 +1912,7 @@ export async function getXChatConversationHistoryEvidence(
   let latestEventAt: number | undefined;
   let oldestEventAt: number | undefined;
   let reachedSince = false;
+  let conversationFound = false;
 
   do {
     const eventResponse = await getXChatJson(
@@ -1982,8 +1932,12 @@ export async function getXChatConversationHistoryEvidence(
       })
     );
     eventPagesFetched += 1;
+    const eventPage = normalizeXChatEventPage(eventResponse);
+    // An observed encrypted envelope proves the participant conversation
+    // exists even if a requested date range filters every event out.
+    conversationFound ||= eventPage.events.length > 0;
     const summary = summarizeXChatEventPage({
-      page: normalizeXChatEventPage(eventResponse),
+      page: eventPage,
       viewerUserId: context.xUserId,
       participantUserId,
       sinceMs: options?.sinceMs,
@@ -2010,11 +1964,14 @@ export async function getXChatConversationHistoryEvidence(
 
   const hasMore = !reachedSince && Boolean(eventCursor);
   return {
-    conversationFound: true,
-    conversationLookupComplete: true,
+    conversationFound,
+    conversationLookupComplete: conversationFound || !hasMore,
     encrypted: true,
     contentState: "encrypted_locked",
-    conversationPagesFetched,
+    // The participant-specific endpoint itself establishes this direct
+    // conversation. Do not preflight the paginated account-wide listing: it
+    // can omit an otherwise retrievable participant conversation.
+    conversationPagesFetched: 0,
     eventPagesFetched,
     eventCount,
     inboundEventCount,


### PR DESCRIPTION
## Production finding
The first deployed fix preserved Nikolay across untagged follow-ups, but the XChat evidence read still paginated the account-wide conversation list first. Nikolay was outside that bounded window, so the tool returned page_limit without calling the participant endpoint already proven to contain 23 events.

## Fix
- call /2/chat/conversations/{participantId}/events directly
- remove account-wide conversation listing as a prerequisite
- derive conversationFound from observed encrypted envelopes before since filtering
- keep empty participant responses as no conversation

## Verification
- full Convex suite: 40 files / 200 tests pass
- TypeScript passes
- strict lint passes
- regression asserts exactly one participant-events request and 23 events / 8 inbound
- since-filter and empty-response regressions added