### PR TITLE
fix: use supported XChat event request shape

### DIFF
--- a/convex/lib/conversationHistoryPaginationCore.test.ts
+++ b/convex/lib/conversationHistoryPaginationCore.test.ts
@@ -4,6 +4,7 @@ import {
   applyConversationHistorySince,
   buildConversationHistoryPageMetadata,
   getProviderPageCursor,
+  getProviderPageHasMore,
   isCurrentConversationHistoryCursor,
   normalizeConversationHistoryPageLimit,
   selectDeterministicLinkedInChat,
@@ -23,6 +24,12 @@ describe("conversation history pagination", () => {
     expect(getProviderPageCursor({ cursor: "unipile-cursor" })).toBe(
       "unipile-cursor"
     );
+    expect(getProviderPageCursor({ next_cursor: "xchat-cursor" })).toBe(
+      "xchat-cursor"
+    );
+    expect(getProviderPageHasMore({ has_more: true })).toBe(true);
+    expect(getProviderPageHasMore({ meta: { hasMore: true } })).toBe(true);
+    expect(getProviderPageHasMore({ meta: { has_more: false } })).toBe(false);
   });
 
   test("stops a date-range read at the requested lower boundary", () => {

--- a/convex/lib/conversationHistoryPaginationCore.ts
+++ b/convex/lib/conversationHistoryPaginationCore.ts
@@ -1,5 +1,5 @@
 import { parseIsoToTimestamp } from "../../shared/lib/utils/time/timeUtils";
-import { getNestedRecord, getStringProperty } from "./typeGuards";
+import { getNestedRecord, getStringProperty, isRecord } from "./typeGuards";
 
 /** Keep provider reads small enough for panels and agent tools. */
 export const DEFAULT_CONVERSATION_HISTORY_PAGE_SIZE = 25;
@@ -74,6 +74,9 @@ export function getProviderPageCursor(payload: unknown): string | undefined {
     getStringProperty(meta, "nextToken"),
     getStringProperty(meta, "next_token"),
     getStringProperty(meta, "paginationToken"),
+    getStringProperty(payload, "nextToken"),
+    getStringProperty(payload, "next_token"),
+    getStringProperty(payload, "paginationToken"),
     getStringProperty(payload, "cursor"),
     getStringProperty(payload, "nextCursor"),
     getStringProperty(payload, "next_cursor"),
@@ -81,6 +84,19 @@ export function getProviderPageCursor(payload: unknown): string | undefined {
   return candidates
     .map((candidate) => candidate?.trim())
     .find((candidate): candidate is string => Boolean(candidate));
+}
+
+/**
+ * Providers do not consistently pair a positive continuation flag with an
+ * opaque cursor. Preserve that signal so callers do not label a partial page
+ * as complete when the provider does not expose a supported continuation.
+ */
+export function getProviderPageHasMore(payload: unknown): boolean {
+  const meta = getNestedRecord(payload, "meta");
+  return [payload, meta].some(
+    (value) =>
+      isRecord(value) && (value.hasMore === true || value.has_more === true)
+  );
 }
 
 /**

--- a/convex/lib/xChatConversationHistoryCore.test.ts
+++ b/convex/lib/xChatConversationHistoryCore.test.ts
@@ -48,6 +48,7 @@ describe("XChat conversation-history metadata", () => {
     const page = normalizeXChatEventPage({
       data,
       meta: { next_token: "older-encrypted-events" },
+      hasMore: true,
     });
     const summary = summarizeXChatEventPage({
       page,
@@ -65,6 +66,7 @@ describe("XChat conversation-history metadata", () => {
       nextCursor: "older-encrypted-events",
     });
     expect(page.events[0]).not.toHaveProperty("encodedEvent");
+    expect(page.hasMore).toBe(true);
     expect(JSON.stringify(summary)).not.toContain("ciphertext-");
   });
 
@@ -100,7 +102,7 @@ describe("XChat conversation-history metadata", () => {
     });
   });
 
-  test("reads participant events when the bounded account-wide listing omits the conversation", async () => {
+  test("uses the bare participant-events request and preserves partial encrypted coverage", async () => {
     const data = Array.from({ length: 23 }, (_, index) => ({
       encoded_event: `ciphertext-${index}`,
       sender_id: index < 8 ? participantUserId : viewerUserId,
@@ -116,7 +118,7 @@ describe("XChat conversation-history metadata", () => {
       const url = String(input);
       requests.push(url);
       const payload = url.includes("/events")
-        ? { data }
+        ? { data, has_more: true }
         : boundedAccountWideListing;
       return new Response(JSON.stringify(payload), { status: 200 });
     }) as typeof fetch;
@@ -135,6 +137,7 @@ describe("XChat conversation-history metadata", () => {
       expect(new URL(requests[0]!).pathname).toBe(
         `/2/chat/conversations/${participantUserId}/events`
       );
+      expect(new URL(requests[0]!).search).toBe("");
       expect(evidence).toMatchObject({
         conversationFound: true,
         conversationLookupComplete: true,
@@ -143,8 +146,9 @@ describe("XChat conversation-history metadata", () => {
         eventCount: 23,
         inboundEventCount: 8,
         outboundEventCount: 15,
-        hasMore: false,
-        boundary: "complete",
+        hasMore: true,
+        pageLimitReached: true,
+        boundary: "page_limit",
       });
       expect(JSON.stringify(evidence)).not.toContain("ciphertext-");
     } finally {

--- a/convex/lib/xChatConversationHistoryCore.ts
+++ b/convex/lib/xChatConversationHistoryCore.ts
@@ -1,7 +1,11 @@
 import type { Infer } from "convex/values";
 import type { xChatConversationHistoryEvidenceValidator } from "../validators";
 import { parseIsoToTimestamp } from "../../shared/lib/utils/time/timeUtils";
-import { getNestedRecord, getStringProperty, isRecord } from "./typeGuards";
+import { getStringProperty, isRecord } from "./typeGuards";
+import {
+  getProviderPageCursor,
+  getProviderPageHasMore,
+} from "./conversationHistoryPaginationCore";
 
 export type XChatConversationHistoryEvidence = Infer<
   typeof xChatConversationHistoryEvidenceValidator
@@ -28,6 +32,7 @@ export type XChatEventPage = {
     createdAtMs?: number;
   }>;
   nextCursor?: string;
+  hasMore: boolean;
 };
 
 export type XChatEventPageSummary = {
@@ -106,12 +111,7 @@ export function normalizeXChatConversationPage(
         )
     : [];
 
-  const meta = getNestedRecord(payload, "meta");
-  const nextCursor =
-    getStringProperty(meta, "nextToken")?.trim() ||
-    getStringProperty(meta, "next_token")?.trim() ||
-    getStringProperty(meta, "paginationToken")?.trim() ||
-    undefined;
+  const nextCursor = getProviderPageCursor(payload);
 
   return {
     conversations,
@@ -184,16 +184,12 @@ export function normalizeXChatEventPage(payload: unknown): XChatEventPage {
         )
     : [];
 
-  const meta = getNestedRecord(payload, "meta");
-  const nextCursor =
-    getStringProperty(meta, "nextToken")?.trim() ||
-    getStringProperty(meta, "next_token")?.trim() ||
-    getStringProperty(meta, "paginationToken")?.trim() ||
-    undefined;
+  const nextCursor = getProviderPageCursor(payload);
 
   return {
     events,
     ...(nextCursor ? { nextCursor } : {}),
+    hasMore: getProviderPageHasMore(payload),
   };
 }
 

--- a/convex/lib/xChatDecryptBundleCore.test.ts
+++ b/convex/lib/xChatDecryptBundleCore.test.ts
@@ -1,3 +1,4 @@
+import { Client } from "@xdevplatform/xdk";
 import { describe, expect, it } from "vitest";
 import {
   buildSanitizedXChatJuiceboxConfig,
@@ -5,6 +6,7 @@ import {
   normalizeXChatEncryptedEventPage,
   normalizeXChatPublicKeyRecords,
 } from "./xChatDecryptBundleCore";
+import { getXChatBrowserDecryptBundle } from "./xdkTwitterProvider";
 
 const PUBLIC_KEYS_PAYLOAD = {
   data: [
@@ -26,6 +28,9 @@ const PUBLIC_KEYS_PAYLOAD = {
     },
   ],
 };
+
+const viewerUserId = "1743216568451125248";
+const participantUserId = "2035575047868583936";
 
 describe("XChat decrypt bundle normalization", () => {
   it("keeps signing material but strips realm tokens from browser config", () => {
@@ -62,6 +67,7 @@ describe("XChat decrypt bundle normalization", () => {
           { id: "missing-ciphertext" },
         ],
         meta: { next_token: "next" },
+        has_more: true,
       })
     ).toEqual({
       events: [
@@ -74,6 +80,53 @@ describe("XChat decrypt bundle normalization", () => {
         },
       ],
       nextCursor: "next",
+      hasMore: true,
     });
+  });
+
+  it("uses a bare initial participant-events request and preserves partial encrypted coverage", async () => {
+    const events = Array.from({ length: 23 }, (_, index) => ({
+      id: `event-${index}`,
+      conversation_id: "direct-conversation",
+      sender_id: index < 8 ? participantUserId : viewerUserId,
+      created_at_msec: String(1_700_000_000_000 + index),
+      encoded_event: `ciphertext-${index}`,
+    }));
+    const requests: string[] = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = String(input);
+      requests.push(url);
+      const payload = url.includes("/events")
+        ? { data: events, hasMore: true }
+        : PUBLIC_KEYS_PAYLOAD;
+      return new Response(JSON.stringify(payload), { status: 200 });
+    }) as typeof fetch;
+
+    try {
+      const bundle = await getXChatBrowserDecryptBundle(
+        {
+          client: new Client({ accessToken: "test-user-access-token" }),
+          xUserId: viewerUserId,
+        },
+        participantUserId
+      );
+
+      const eventRequests = requests.filter((request) =>
+        request.includes(`/2/chat/conversations/${participantUserId}/events`)
+      );
+      expect(eventRequests).toHaveLength(1);
+      expect(new URL(eventRequests[0]!).search).toBe("");
+      expect(bundle.events).toHaveLength(23);
+      expect(
+        bundle.events.filter((event) => event.senderId === participantUserId)
+      ).toHaveLength(8);
+      expect(
+        bundle.events.filter((event) => event.senderId === viewerUserId)
+      ).toHaveLength(15);
+      expect(bundle.hasMore).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });

--- a/convex/lib/xChatDecryptBundleCore.ts
+++ b/convex/lib/xChatDecryptBundleCore.ts
@@ -1,4 +1,8 @@
 import { getNestedRecord, getStringProperty, isRecord } from "./typeGuards";
+import {
+  getProviderPageCursor,
+  getProviderPageHasMore,
+} from "./conversationHistoryPaginationCore";
 
 export type XChatSigningKey = {
   userId: string;
@@ -172,6 +176,7 @@ export function getXChatRealmAuthToken(
 export function normalizeXChatEncryptedEventPage(payload: unknown): {
   events: XChatEncryptedEvent[];
   nextCursor?: string;
+  hasMore: boolean;
 } {
   const root = isRecord(payload) ? payload : undefined;
   const events = Array.isArray(root?.data)
@@ -208,11 +213,10 @@ export function normalizeXChatEncryptedEventPage(payload: unknown): {
         ];
       })
     : [];
-  const meta = getNestedRecord(payload, "meta");
-  const nextCursor =
-    getStringProperty(meta, "nextToken")?.trim() ||
-    getStringProperty(meta, "next_token")?.trim() ||
-    getStringProperty(meta, "paginationToken")?.trim() ||
-    undefined;
-  return { events, ...(nextCursor ? { nextCursor } : {}) };
+  const nextCursor = getProviderPageCursor(payload);
+  return {
+    events,
+    ...(nextCursor ? { nextCursor } : {}),
+    hasMore: getProviderPageHasMore(payload),
+  };
 }

--- a/convex/lib/xdkTwitterProvider.ts
+++ b/convex/lib/xdkTwitterProvider.ts
@@ -18,7 +18,6 @@ import {
   type XChatPublicKeyRecord,
   type XChatSigningKey,
 } from "./xChatDecryptBundleCore";
-import { normalizeConversationHistoryPageLimit } from "./conversationHistoryPaginationCore";
 import { MAX_AGENT_PROVIDER_HISTORY_PAGES } from "./prospectInteractionHistoryCore";
 import type {
   Entities,
@@ -1872,20 +1871,14 @@ function getXChatPageBudget(maxPages?: number): number {
   );
 }
 
-function getXChatHistoryParams(args: {
-  limit: number;
-  cursor?: string;
-  fieldName: "chat_conversation.fields" | "chat_message_event.fields";
-  fields: string[];
-}): URLSearchParams {
-  const params = new URLSearchParams({
-    max_results: String(args.limit),
-  });
-  params.set(args.fieldName, args.fields.join(","));
-  if (args.cursor) {
-    params.set("pagination_token", args.cursor);
+function getXChatEventContinuationParams(
+  cursor?: string
+): URLSearchParams | undefined {
+  if (!cursor) {
+    return undefined;
   }
-  return params;
+
+  return new URLSearchParams({ pagination_token: cursor });
 }
 
 /**
@@ -1901,9 +1894,9 @@ export async function getXChatConversationHistoryEvidence(
     sinceMs?: number;
   }
 ): Promise<XChatConversationHistoryEvidence> {
-  const limit = normalizeConversationHistoryPageLimit(options?.limit);
   const pageBudget = getXChatPageBudget(options?.maxPages);
   let eventCursor: string | undefined;
+  let eventPageHasMore = false;
   let eventPagesFetched = 0;
   let eventCount = 0;
   let inboundEventCount = 0;
@@ -1918,18 +1911,7 @@ export async function getXChatConversationHistoryEvidence(
     const eventResponse = await getXChatJson(
       context,
       `/2/chat/conversations/${encodeURIComponent(participantUserId)}/events`,
-      getXChatHistoryParams({
-        limit,
-        cursor: eventCursor,
-        fieldName: "chat_message_event.fields",
-        fields: [
-          "id",
-          "sender_id",
-          "created_at_msec",
-          "conversation_id",
-          "encoded_event",
-        ],
-      })
+      getXChatEventContinuationParams(eventCursor)
     );
     eventPagesFetched += 1;
     const eventPage = normalizeXChatEventPage(eventResponse);
@@ -1960,9 +1942,10 @@ export async function getXChatConversationHistoryEvidence(
         : oldestEventAt;
     reachedSince = summary.reachedSince;
     eventCursor = summary.nextCursor;
+    eventPageHasMore = eventPage.hasMore;
   } while (!reachedSince && eventCursor && eventPagesFetched < pageBudget);
 
-  const hasMore = !reachedSince && Boolean(eventCursor);
+  const hasMore = !reachedSince && (Boolean(eventCursor) || eventPageHasMore);
   return {
     conversationFound,
     conversationLookupComplete: conversationFound || !hasMore,
@@ -2085,28 +2068,19 @@ export async function getXChatBrowserDecryptBundle(
 
   const events: XChatEncryptedEvent[] = [];
   let cursor: string | undefined;
+  let eventPageHasMore = false;
   let eventPagesFetched = 0;
   do {
     const payload = await getXChatJson(
       context,
       `/2/chat/conversations/${encodeURIComponent(participantUserId)}/events`,
-      getXChatHistoryParams({
-        limit: 100,
-        cursor,
-        fieldName: "chat_message_event.fields",
-        fields: [
-          "id",
-          "sender_id",
-          "created_at_msec",
-          "conversation_id",
-          "encoded_event",
-        ],
-      })
+      getXChatEventContinuationParams(cursor)
     );
     eventPagesFetched += 1;
     const page = normalizeXChatEncryptedEventPage(payload);
     events.push(...page.events);
     cursor = page.nextCursor;
+    eventPageHasMore = page.hasMore;
   } while (cursor && eventPagesFetched < MAX_AGENT_PROVIDER_HISTORY_PAGES);
 
   const conversationId =
@@ -2135,7 +2109,7 @@ export async function getXChatBrowserDecryptBundle(
     ),
     events,
     eventPagesFetched,
-    hasMore: Boolean(cursor),
+    hasMore: Boolean(cursor) || eventPageHasMore,
   };
 }
 


### PR DESCRIPTION
## Summary
- send the initial participant XChat events request without unsupported legacy query parameters
- preserve provider `has_more` coverage even when no continuation cursor is exposed
- use the same request contract for Agent evidence and browser decrypt bundles

## Verification
- `pnpm test:convex` (201 tests)
- `pnpm exec tsc --noEmit`
- `pnpm lint:strict`
- `pnpm build`
- `git diff --check`

## Production acceptance
The existing production task must report 23 XChat events, including 8 inbound, for the selected test prospect.