### PR TITLE
feat: add workspace-scoped agent attachments

### DIFF
--- a/app/(webapp)/post/x/[id]/page.tsx
+++ b/app/(webapp)/post/x/[id]/page.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/features/webapp/ui/components";
 import { Tweet as TweetComponent } from "@/features/webapp/ui/components";
 import { ReplyComposer } from "@/features/composer/ui/components/ReplyComposer";
+import type { ComposerMediaKind } from "@/features/composer/types";
 import { XReplyFallbackAlert } from "@/features/composer/ui/components/XReplyFallbackAlert";
 import { useViewerXComposerIdentity } from "@/features/composer/hooks/useViewerXComposerIdentity";
 import { X_POST_WEIGHTED_MAX } from "@/shared/lib/twitter/xPostTextLimit";
@@ -86,7 +87,7 @@ function PostDetailInner() {
       content: unknown,
       mediaUrls?: string[],
       mediaDescriptions?: string[],
-      _mediaKinds?: ("image" | "gif" | "video")[]
+      _mediaKinds?: ComposerMediaKind[]
     ) => {
       const text = extractTextFromEditorState(content).trim();
       const hasMedia = Array.isArray(mediaUrls) && mediaUrls.length > 0;

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -57,6 +57,7 @@ import type * as agents_tools_searchWorkspaceMemories from "../agents/tools/sear
 import type * as agents_tools_setupSessionChat from "../agents/tools/setupSessionChat.js";
 import type * as agents_tools_startWorkspacePlans from "../agents/tools/startWorkspacePlans.js";
 import type * as agents_tools_updateWorkspace from "../agents/tools/updateWorkspace.js";
+import type * as agents_tools_workspaceAttachments from "../agents/tools/workspaceAttachments.js";
 import type * as agents_tools_workspaceMemoryHelpers from "../agents/tools/workspaceMemoryHelpers.js";
 import type * as agents_tools_workspaceProfileChanges from "../agents/tools/workspaceProfileChanges.js";
 import type * as agents_tools_workspaceSetupContext from "../agents/tools/workspaceSetupContext.js";
@@ -221,6 +222,7 @@ import type * as lib_workflow from "../lib/workflow.js";
 import type * as lib_workflowSafeProspect from "../lib/workflowSafeProspect.js";
 import type * as lib_workspaceActivity from "../lib/workspaceActivity.js";
 import type * as lib_workspaceAgentSettingsCore from "../lib/workspaceAgentSettingsCore.js";
+import type * as lib_workspaceAttachmentCore from "../lib/workspaceAttachmentCore.js";
 import type * as lib_workspaceCapacityCore from "../lib/workspaceCapacityCore.js";
 import type * as lib_workspaceEntitlements from "../lib/workspaceEntitlements.js";
 import type * as lib_workspaceIcpSignalsCore from "../lib/workspaceIcpSignalsCore.js";
@@ -317,6 +319,7 @@ import type * as workflows_readModels from "../workflows/readModels.js";
 import type * as workflows_setup from "../workflows/setup.js";
 import type * as workspaceAgentOpsDaily from "../workspaceAgentOpsDaily.js";
 import type * as workspaceAnalyticsDaily from "../workspaceAnalyticsDaily.js";
+import type * as workspaceAttachments from "../workspaceAttachments.js";
 import type * as workspaceIcpSignals from "../workspaceIcpSignals.js";
 import type * as workspacePlanStarts from "../workspacePlanStarts.js";
 import type * as workspaceProfileChanges from "../workspaceProfileChanges.js";
@@ -389,6 +392,7 @@ declare const fullApi: ApiFromModules<{
   "agents/tools/setupSessionChat": typeof agents_tools_setupSessionChat;
   "agents/tools/startWorkspacePlans": typeof agents_tools_startWorkspacePlans;
   "agents/tools/updateWorkspace": typeof agents_tools_updateWorkspace;
+  "agents/tools/workspaceAttachments": typeof agents_tools_workspaceAttachments;
   "agents/tools/workspaceMemoryHelpers": typeof agents_tools_workspaceMemoryHelpers;
   "agents/tools/workspaceProfileChanges": typeof agents_tools_workspaceProfileChanges;
   "agents/tools/workspaceSetupContext": typeof agents_tools_workspaceSetupContext;
@@ -553,6 +557,7 @@ declare const fullApi: ApiFromModules<{
   "lib/workflowSafeProspect": typeof lib_workflowSafeProspect;
   "lib/workspaceActivity": typeof lib_workspaceActivity;
   "lib/workspaceAgentSettingsCore": typeof lib_workspaceAgentSettingsCore;
+  "lib/workspaceAttachmentCore": typeof lib_workspaceAttachmentCore;
   "lib/workspaceCapacityCore": typeof lib_workspaceCapacityCore;
   "lib/workspaceEntitlements": typeof lib_workspaceEntitlements;
   "lib/workspaceIcpSignalsCore": typeof lib_workspaceIcpSignalsCore;
@@ -649,6 +654,7 @@ declare const fullApi: ApiFromModules<{
   "workflows/setup": typeof workflows_setup;
   workspaceAgentOpsDaily: typeof workspaceAgentOpsDaily;
   workspaceAnalyticsDaily: typeof workspaceAnalyticsDaily;
+  workspaceAttachments: typeof workspaceAttachments;
   workspaceIcpSignals: typeof workspaceIcpSignals;
   workspacePlanStarts: typeof workspacePlanStarts;
   workspaceProfileChanges: typeof workspaceProfileChanges;

--- a/convex/agentAttachments.integration.test.ts
+++ b/convex/agentAttachments.integration.test.ts
@@ -4,6 +4,11 @@ import { convexTest } from "convex-test";
 import { describe, expect, test } from "vitest";
 import { internal } from "./_generated/api";
 import { createOutreachPlan } from "./lib/outreachCore";
+import {
+  assertOutreachMediaCapability,
+  resolveOwnedOutreachMedia,
+} from "./lib/mediaCapabilityCore";
+import { upsertCanonicalWorkspaceMemory } from "./lib/workspaceMemoryCore";
 import schema from "./schema";
 
 const modules = import.meta.glob("./**/*.ts");
@@ -38,6 +43,83 @@ async function seedProspect(t: ReturnType<typeof convexTest>, suffix: string) {
 }
 
 describe("prospect Agent attachment references", () => {
+  test("resolves verified memory-bound attachments and rejects cross-workspace bindings", async () => {
+    const t = convexTest(schema, modules);
+    const seeded = await seedProspect(t, "memory-binding");
+    const foreign = await seedProspect(t, "foreign-memory-binding");
+
+    const { uploadId, foreignUploadId } = await t.run(async (ctx) => {
+      const storageId = await ctx.storage.store(
+        new Blob(["case-study"], { type: "application/pdf" })
+      );
+      const foreignStorageId = await ctx.storage.store(
+        new Blob(["foreign"], { type: "image/png" })
+      );
+      const uploadId = await ctx.db.insert("mediaUploads", {
+        storageId,
+        userId: seeded.userId,
+        workspaceId: seeded.workspaceId,
+        fileName: "case-study.pdf",
+        mimeType: "application/pdf",
+        size: 10,
+        uploadedAt: 1,
+      });
+      const foreignUploadId = await ctx.db.insert("mediaUploads", {
+        storageId: foreignStorageId,
+        userId: foreign.userId,
+        workspaceId: foreign.workspaceId,
+        fileName: "foreign.png",
+        mimeType: "image/png",
+        size: 10,
+        uploadedAt: 1,
+      });
+
+      await upsertCanonicalWorkspaceMemory(ctx.db, {
+        userId: seeded.userId,
+        workspaceId: seeded.workspaceId,
+        source: "operator",
+        namespace: "patterns",
+        title: "Use the case study",
+        summary: "Share proof when the prospect asks for results.",
+        canonicalContent: "Use the case study when proof is relevant.",
+        conflictKey: "outreach.proof_attachment",
+        confidence: 1,
+        impactScore: 1,
+        attachmentUploadIds: [uploadId],
+      });
+
+      return { uploadId, foreignUploadId };
+    });
+
+    const resolved = await t.query(
+      internal.workspaceAttachments.getMemoryAttachmentIdsForAgentInternal,
+      {
+        workspaceId: seeded.workspaceId,
+        userId: seeded.userId,
+        memoryKey: "outreach.proof_attachment",
+      }
+    );
+    expect(resolved).toEqual([uploadId]);
+
+    await expect(
+      t.run(async (ctx) => {
+        await upsertCanonicalWorkspaceMemory(ctx.db, {
+          userId: seeded.userId,
+          workspaceId: seeded.workspaceId,
+          source: "operator",
+          namespace: "patterns",
+          title: "Invalid foreign file",
+          summary: "This must not be stored.",
+          canonicalContent: "Never cross workspace boundaries.",
+          conflictKey: "outreach.invalid_attachment",
+          confidence: 1,
+          impactScore: 1,
+          attachmentUploadIds: [foreignUploadId],
+        });
+      })
+    ).rejects.toThrow("Workspace memory attachment validation failed");
+  });
+
   test("keeps recent selected attachments available on follow-up turns", async () => {
     const t = convexTest(schema, modules);
     const seeded = await seedProspect(t, "follow-up");
@@ -225,6 +307,203 @@ describe("prospect Agent attachment references", () => {
       mediaUploadIds: [uploadId],
       mediaDescriptions: ["Product demo"],
       mediaKinds: ["video"],
+    });
+  });
+
+  test("resolves a verified PDF upload ID for LinkedIn DMs and fails closed elsewhere", async () => {
+    const t = convexTest(schema, modules);
+    const seeded = await seedProspect(t, "pdf-linkedin-dm");
+
+    await t.run(async (ctx) => {
+      const storageId = await ctx.storage.store(
+        new Blob(["pdf"], { type: "application/pdf" })
+      );
+      const uploadId = await ctx.db.insert("mediaUploads", {
+        storageId,
+        userId: seeded.userId,
+        workspaceId: seeded.workspaceId,
+        fileName: "case-study.pdf",
+        mimeType: "application/pdf",
+        size: 3,
+        uploadedAt: 1,
+      });
+      const mediaUrl = await ctx.storage.getUrl(storageId);
+      if (!mediaUrl) throw new Error("Test PDF URL was not created.");
+
+      const resolved = await resolveOwnedOutreachMedia(ctx, {
+        userId: seeded.userId,
+        workspaceId: seeded.workspaceId,
+        mediaUrls: [mediaUrl],
+        mediaUploadIds: [uploadId],
+      });
+
+      expect(resolved).toMatchObject([
+        {
+          uploadId,
+          fileName: "case-study.pdf",
+          mimeType: "application/pdf",
+          kind: "file",
+        },
+      ]);
+      expect(() =>
+        assertOutreachMediaCapability({
+          platform: "linkedin",
+          surface: "dm",
+          media: resolved,
+        })
+      ).not.toThrow();
+      expect(() =>
+        assertOutreachMediaCapability({
+          platform: "linkedin",
+          surface: "comment",
+          media: resolved,
+        })
+      ).toThrow(/cannot be attached to a LinkedIn comment/);
+      expect(() =>
+        assertOutreachMediaCapability({
+          platform: "twitter",
+          surface: "dm",
+          media: resolved,
+        })
+      ).toThrow(/cannot be attached to X\/Twitter/);
+    });
+  });
+
+  test("keeps main Agent attachments workspace-scoped across turns", async () => {
+    const t = convexTest(schema, modules);
+    const seeded = await seedProspect(t, "main-workspace-scope");
+    const other = await seedProspect(t, "other-workspace-scope");
+    const threadId = "main-attachment-thread";
+    const { firstUploadId, secondUploadId } = await t.run(async (ctx) => {
+      const firstStorageId = await ctx.storage.store(
+        new Blob(["first"], { type: "image/png" })
+      );
+      const secondStorageId = await ctx.storage.store(
+        new Blob(["second"], { type: "video/mp4" })
+      );
+      const foreignStorageId = await ctx.storage.store(
+        new Blob(["foreign"], { type: "image/png" })
+      );
+      const firstUploadId = await ctx.db.insert("mediaUploads", {
+        storageId: firstStorageId,
+        userId: seeded.userId,
+        workspaceId: seeded.workspaceId,
+        fileName: "first.png",
+        mimeType: "image/png",
+        size: 5,
+        uploadedAt: 1,
+      });
+      const secondUploadId = await ctx.db.insert("mediaUploads", {
+        storageId: secondStorageId,
+        userId: seeded.userId,
+        workspaceId: seeded.workspaceId,
+        fileName: "second.mp4",
+        mimeType: "video/mp4",
+        size: 6,
+        uploadedAt: 2,
+      });
+      const foreignUploadId = await ctx.db.insert("mediaUploads", {
+        storageId: foreignStorageId,
+        userId: other.userId,
+        workspaceId: other.workspaceId,
+        fileName: "foreign.png",
+        mimeType: "image/png",
+        size: 7,
+        uploadedAt: 3,
+      });
+      await ctx.db.insert("agentMessageContexts", {
+        threadId,
+        messageId: "main-first",
+        userId: seeded.userId,
+        workspaceId: seeded.workspaceId,
+        promptTextSource: "user",
+        taggedEntities: [],
+        attachments: [
+          { uploadId: String(firstUploadId), fileName: "first.png" },
+        ],
+        createdAt: 1,
+      });
+      await ctx.db.insert("agentMessageContexts", {
+        threadId,
+        messageId: "main-second",
+        userId: seeded.userId,
+        workspaceId: seeded.workspaceId,
+        promptTextSource: "user",
+        taggedEntities: [
+          {
+            id: `attachment:${String(foreignUploadId)}`,
+            kind: "attachment",
+            entityId: String(foreignUploadId),
+            label: "foreign.png",
+            mentionText: "Attachment: foreign.png",
+            secondaryLabel: "Workspace attachment",
+            verified: false,
+            referenceText: "foreign.png",
+            attachmentMediaKind: "image",
+          },
+        ],
+        attachments: [
+          { uploadId: String(secondUploadId), fileName: "second.mp4" },
+        ],
+        createdAt: 2,
+      });
+      return { firstUploadId, secondUploadId };
+    });
+
+    const references = await t.query(
+      internal.agentAttachments.listAvailableForAgentTool,
+      {
+        threadId,
+        messageId: "main-second",
+        userId: seeded.userId,
+      }
+    );
+    expect(references).toMatchObject([
+      {
+        reference: "attachment_1",
+        uploadId: secondUploadId,
+        selectedInCurrentMessage: true,
+      },
+      {
+        reference: "attachment_2",
+        uploadId: firstUploadId,
+        selectedInCurrentMessage: false,
+      },
+    ]);
+    expect(references).toHaveLength(2);
+  });
+
+  test("deletes a newly uploaded blob when post-upload validation rejects it", async () => {
+    const t = convexTest(schema, modules);
+    const suffix = "invalid-upload-cleanup";
+    const seeded = await seedProspect(t, suffix);
+    const storageId = await t.run(
+      async (ctx) =>
+        await ctx.storage.store(
+          new Blob(["archive"], { type: "application/zip" })
+        )
+    );
+    const authenticated = t.withIdentity({ subject: `workos-${suffix}` });
+
+    const result = await authenticated.mutation(
+      internal.mediaUploadMutations.storeMediaMetadataInternal,
+      {
+        mediaId: storageId,
+        fileName: "unsupported.zip",
+        mimeType: "application/zip",
+        size: 5,
+        workspaceId: seeded.workspaceId,
+      }
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      error:
+        "unsupported.zip is not compatible with any supported X/Twitter or LinkedIn attachment destination.",
+    });
+    await t.run(async (ctx) => {
+      expect(await ctx.db.system.get("_storage", storageId)).toBeNull();
+      expect(await ctx.db.query("mediaUploads").collect()).toHaveLength(0);
     });
   });
 });

--- a/convex/agentAttachments.ts
+++ b/convex/agentAttachments.ts
@@ -2,7 +2,7 @@ import { v } from "convex/values";
 import { internalQuery } from "./lib/functionBuilders";
 import { agentAttachmentToolReferenceValidator } from "./validators";
 import type { Doc, Id } from "./_generated/dataModel";
-import { inferAttachmentMediaKind } from "../shared/lib/utils/media/inferAttachmentMediaKind";
+import { getWorkspaceAttachmentKind } from "./lib/workspaceAttachmentCore";
 import {
   AGENT_ATTACHMENT_CONTEXT_WINDOW,
   getAgentAttachmentReference,
@@ -14,7 +14,7 @@ type AttachmentCandidate = {
   context: Doc<"agentMessageContexts">;
   uploadId: string | null;
   fileName: string;
-  mediaKind?: "image" | "gif" | "video" | null;
+  mediaKind?: "image" | "gif" | "video" | "file" | null;
 };
 
 function getContextAttachmentCandidates(
@@ -57,7 +57,8 @@ export const listAvailableForAgentTool = internalQuery({
     if (
       !currentContext ||
       currentContext.threadId !== args.threadId ||
-      currentContext.userId !== args.userId
+      currentContext.userId !== args.userId ||
+      !currentContext.workspaceId
     ) {
       return [];
     }
@@ -97,19 +98,14 @@ export const listAvailableForAgentTool = internalQuery({
       if (
         !upload ||
         upload.userId !== args.userId ||
-        (currentContext.workspaceId &&
-          upload.workspaceId !== currentContext.workspaceId)
+        upload.workspaceId !== currentContext.workspaceId
       ) {
         continue;
       }
 
       const url = await ctx.storage.getUrl(upload.storageId);
       const mediaKind =
-        candidate.mediaKind ??
-        inferAttachmentMediaKind({
-          mimeType: upload.mimeType,
-          url: upload.fileName,
-        });
+        candidate.mediaKind ?? getWorkspaceAttachmentKind(upload);
       if (!url || !mediaKind) {
         continue;
       }

--- a/convex/agents/index.ts
+++ b/convex/agents/index.ts
@@ -62,6 +62,7 @@ import { researchProspect } from "./outreach/tools/researchProspect";
 import { socialAction } from "./outreach/tools/socialAction";
 import { stopOnDeferredAgentExecution } from "../lib/deferredAgentTurn";
 import { createWorkspaceMemoryContextHandler } from "./workspaceMemoryContext";
+import { workspaceAttachments } from "./tools/workspaceAttachments";
 
 // ============================================================================
 // Lazy Model Provider
@@ -127,6 +128,7 @@ export const workspaceVisionLanguageModel = createWorkspaceLanguageModel(
 const mainAgentBaseTools = {
   // Workspace context. Global discovery is intentionally setup-only.
   inspectWorkspace,
+  workspaceAttachments,
   queryWorkspace,
   listProspectPlans,
   managePlanBatch,

--- a/convex/agents/outreach/index.ts
+++ b/convex/agents/outreach/index.ts
@@ -56,6 +56,7 @@ import {
   rememberWorkspaceMemory,
   searchWorkspaceMemories,
   socialAction,
+  workspaceAttachments,
 } from "./tools";
 import { getStoredXPostLimitContextForAgentUser } from "./tools/xPostLimitHelpers";
 import { logger } from "../../../shared/lib/logger";
@@ -96,6 +97,7 @@ export const outreachAgentBaseTools = {
   getProspectInteractionHistory,
   getProspectPlan,
   inspectWorkspace,
+  workspaceAttachments,
   proposeWorkspaceProfiles,
   approveWorkspaceProfiles,
   rejectWorkspaceProfiles,

--- a/convex/agents/outreach/tools/generatePlan.ts
+++ b/convex/agents/outreach/tools/generatePlan.ts
@@ -62,7 +62,7 @@ const taskSchema = z.object({
     ),
   mediaDescriptions: z.array(z.string().max(1_000)).max(4).optional(),
   mediaKinds: z
-    .array(z.enum(["image", "gif", "video"]))
+    .array(z.enum(["image", "gif", "video", "file"]))
     .max(4)
     .optional(),
 });
@@ -113,7 +113,7 @@ export interface GeneratePlanResult {
     reactionType?: string;
     mediaUrls?: string[];
     mediaDescriptions?: string[];
-    mediaKinds?: Array<"image" | "gif" | "video">;
+    mediaKinds?: Array<"image" | "gif" | "video" | "file">;
   }>;
   artifact?: AgentArtifactEnvelope;
   error?: string;

--- a/convex/agents/outreach/tools/getProspectPlan.ts
+++ b/convex/agents/outreach/tools/getProspectPlan.ts
@@ -45,7 +45,7 @@ export interface GetProspectPlanResult {
     targetTweetId?: string;
     mediaUrls?: string[];
     mediaDescriptions?: string[];
-    mediaKinds?: Array<"image" | "gif" | "video">;
+    mediaKinds?: Array<"image" | "gif" | "video" | "file">;
   }>;
   artifact?: AgentArtifactEnvelope;
   error?: string;

--- a/convex/agents/outreach/tools/index.ts
+++ b/convex/agents/outreach/tools/index.ts
@@ -33,3 +33,4 @@ export {
 // Shared workspace memory tools (defined in the main agents/tools folder)
 export { rememberWorkspaceMemory } from "../../tools/rememberWorkspaceMemory";
 export { searchWorkspaceMemories } from "../../tools/searchWorkspaceMemories";
+export { workspaceAttachments } from "../../tools/workspaceAttachments";

--- a/convex/agents/outreach/tools/refinePlan.ts
+++ b/convex/agents/outreach/tools/refinePlan.ts
@@ -73,7 +73,7 @@ const taskSchema = z.object({
     ),
   mediaDescriptions: z.array(z.string().max(1_000)).max(4).optional(),
   mediaKinds: z
-    .array(z.enum(["image", "gif", "video"]))
+    .array(z.enum(["image", "gif", "video", "file"]))
     .max(4)
     .optional(),
 });
@@ -121,7 +121,7 @@ export interface RefinePlanResult {
     reactionType?: string;
     mediaUrls?: string[];
     mediaDescriptions?: string[];
-    mediaKinds?: Array<"image" | "gif" | "video">;
+    mediaKinds?: Array<"image" | "gif" | "video" | "file">;
   }>;
   artifact?: AgentArtifactEnvelope;
   error?: string;

--- a/convex/agents/outreach/tools/socialAction.ts
+++ b/convex/agents/outreach/tools/socialAction.ts
@@ -116,7 +116,7 @@ const socialActionArgsSchema = z.object({
       "Optional media descriptions/alt text aligned by index with mediaUrls."
     ),
   mediaKinds: z
-    .array(z.enum(["image", "gif", "video"]))
+    .array(z.enum(["image", "gif", "video", "file"]))
     .optional()
     .describe(
       "Optional media kinds aligned by index with mediaUrls. Use this when the URL does not make the attachment type obvious."
@@ -276,6 +276,7 @@ export const socialAction = createTool({
           postId: args.postId ?? args.tweetId,
           text: normalizedText,
           mediaUrls: resolvedMedia.mediaUrls,
+          mediaUploadIds: resolvedMedia.mediaUploadIds,
           mediaDescriptions: resolvedMedia.mediaDescriptions,
           mediaKinds: resolvedMedia.mediaKinds,
           reactionType: args.reactionType,
@@ -293,6 +294,7 @@ export const socialAction = createTool({
             conversationId: args.conversationId,
             text: normalizedText,
             mediaUrls: resolvedMedia.mediaUrls,
+            mediaUploadIds: resolvedMedia.mediaUploadIds,
             mediaDescriptions: resolvedMedia.mediaDescriptions,
             mediaKinds: resolvedMedia.mediaKinds,
             replaceExistingPending: args.replaceExistingPending,

--- a/convex/agents/prompts.ts
+++ b/convex/agents/prompts.ts
@@ -329,6 +329,7 @@ ${buildUseCaseContextBlock(useCase)}
 
 **Workspace tools:**
 - inspectWorkspace
+- workspaceAttachments
 - queryWorkspace
 - listProspectPlans
 - managePlanBatch
@@ -354,6 +355,10 @@ ${buildUseCaseContextBlock(useCase)}
 **Memory tools:**
 - rememberWorkspaceMemory
 - searchWorkspaceMemories
+
+When the user asks how many attachments/files exist, searches for a file, or asks to see one, call workspaceAttachments against live workspace data. Use operation=show for inline rendering. When applicable memory context contains a memoryKey with linked attachments, call operation=resolve_memory before selecting files for an outreach task. Never guess file counts, URLs, IDs, or attachment references.
+
+Attachment references selected in the current user message take precedence when the user says "this attachment" or otherwise refers to the file they just added. Earlier attachments in the same thread remain available by their visible names and relative order. If the user adds a second attachment in a later turn, treat that new file as the current attachment without forgetting the first. Ask one short clarification question only when multiple available files genuinely fit the user's wording and neither the current message, an exact visible name, a live workspaceAttachments result, nor an applicable memory binding resolves which file they mean.
 
 Remember: stay workspace-scoped when no ${entitySingularLower} is selected, and act on exactly one selected ${entitySingularLower} when the user has clearly tagged or focused one.`;
 }
@@ -584,6 +589,7 @@ When you are in a record-specific conversation, context is automatically injecte
 - getProspectInteractionHistory: Read the real X/LinkedIn DM, comment, and reply history between the workspace user and this ${entitySingularLower}. Use it for conversation-history and relationship-progress questions. It returns live/cached/failed evidence, connection state, freshness, coverage boundary, and bounded-page metadata for your reasoning. X evidence separates plaintext legacy DMs from encrypted XChat envelope metadata, so reason from each source's actual coverage.
 - getProspectPlan: Get an existing plan for the internal prospect record
 - inspectWorkspace: Get the workspace's offering description, ideal customer profiles, connected accounts, and autonomy settings. Use this to ground strategy in the user's real goals before generating or refining plans.
+- workspaceAttachments: Count, search, inspect, show, or resolve memory-linked workspace attachments from live data. Use operation=show for inline rendering and operation=resolve_memory when an applicable memory supplies a memoryKey with linked attachments.
 - researchProspect: Deep web research on the prospect and their company (recent news, launches, funding, hiring, public opinions). Use BEFORE generating a plan when prospect context is thin, and whenever the user asks for deeper research. Cite what you learned when proposing angles.
 - proposeWorkspaceProfiles: Create or refine the workspace-wide ${useCase.profileLabelPlural.toLowerCase()} proposal after an explicit user request.
 - approveWorkspaceProfiles: Apply the pending workspace profile proposal after explicit approval.
@@ -612,6 +618,11 @@ When you are in a record-specific conversation, context is automatically injecte
 **Memory Tools:**
 - rememberWorkspaceMemory: Save a reusable workspace lesson based on the current conversation (auto-scoped to the current workspace and prospect).
 - searchWorkspaceMemories: Retrieve relevant workspace memories before answering questions about what has worked, what failed, or which patterns to repeat or avoid.
+
+**Attachment Resolution:**
+- Treat attachments selected in the current user message as the primary referent for "this attachment" or "the file I just uploaded". A file added in a later turn becomes current context; files from earlier turns remain addressable by visible name and relative order.
+- Use \`workspaceAttachments\` for live counts, search, inspection, inline display, and memory-bound lookup. Never infer a count from thread history or invent a file reference.
+- Ask one short clarification question only when multiple files genuinely match and current-turn selection, exact naming, live search, and memory binding do not disambiguate the request.
 
 ## Generative UI Rules (CRITICAL)
 When the user asks to see a post or wants to visualize content:

--- a/convex/agents/tools/rememberWorkspaceMemory.ts
+++ b/convex/agents/tools/rememberWorkspaceMemory.ts
@@ -27,6 +27,10 @@ import {
 } from "./workspaceMemoryHelpers";
 import { createMemoryArtifact } from "../../../shared/lib/json-render/agentArtifacts";
 import { runLoggedAgentTool } from "./logging";
+import {
+  attachmentRefsSchema,
+  resolveToolAttachmentMediaInput,
+} from "../outreach/tools/attachmentReferences";
 
 const workspaceMemoryCategoryEnum = z.enum(WORKSPACE_MEMORY_CATEGORIES);
 const workspaceMemorySurfaceEnum = z.enum([
@@ -128,6 +132,9 @@ const rememberWorkspaceMemoryInputSchema = z.object({
     .describe(
       "When the user says to remember something from an earlier message, copy only the exact relevant user text here verbatim. Never paraphrase it or include unrelated conversation."
     ),
+  attachmentRefs: attachmentRefsSchema.describe(
+    "Optional application-issued attachment references to bind durably to this memory. Never provide upload IDs or storage URLs."
+  ),
   scope: z
     .enum(["workspace", "prospect"])
     .default("workspace")
@@ -236,6 +243,10 @@ export const rememberWorkspaceMemory = createTool({
               ? (context.prospectId ?? undefined)
               : undefined;
           const provenanceMessageId = getToolPromptMessageId(ctx);
+          const resolvedAttachments = await resolveToolAttachmentMediaInput(
+            ctx,
+            { attachmentRefs: args.attachmentRefs }
+          );
           const openMetadata = {
             ...args.metadata,
             signals: args.signals ?? [],
@@ -272,6 +283,7 @@ export const rememberWorkspaceMemory = createTool({
                 channels: args.channels,
                 provenanceKind: "user_instruction",
                 provenanceMessageId,
+                attachmentUploadIds: resolvedAttachments.mediaUploadIds,
               }
             );
 
@@ -367,6 +379,7 @@ export const rememberWorkspaceMemory = createTool({
                 channels: args.channels,
                 provenanceKind: "user_instruction",
                 provenanceMessageId,
+                attachmentUploadIds: resolvedAttachments.mediaUploadIds,
               }
             );
             inserted.push(result);

--- a/convex/agents/tools/workspaceAttachments.ts
+++ b/convex/agents/tools/workspaceAttachments.ts
@@ -1,0 +1,325 @@
+"use node";
+
+import { createTool } from "@convex-dev/agent";
+import { z } from "zod";
+import { internal } from "../../_generated/api";
+import type { Id } from "../../_generated/dataModel";
+import {
+  createAttachmentPreviewArtifact,
+  type AgentArtifactEnvelope,
+} from "../../../shared/lib/json-render/agentArtifacts";
+import { buildWorkspaceAttachmentCountSummary } from "../../lib/workspaceAttachmentCore";
+import type { WorkspaceAttachmentCompatibility } from "../../lib/workspaceAttachmentCore";
+import type { AgentAttachmentToolReference } from "../../lib/agentAttachmentReferenceCore";
+import {
+  getToolPromptMessageId,
+  resolveWorkspaceMemoryContext,
+} from "./workspaceMemoryHelpers";
+
+const operationSchema = z.enum([
+  "count",
+  "search",
+  "inspect",
+  "show",
+  "resolve_memory",
+]);
+const mediaKindSchema = z.enum(["image", "gif", "video", "file"]);
+const destinationSchema = z.object({
+  platform: z.enum(["twitter", "linkedin"]),
+  surface: z.enum(["comment", "dm"]),
+});
+
+type ToolAttachment = {
+  attachmentRef: string;
+  fileName: string;
+  displayName: string;
+  mimeType: string;
+  mediaKind: "image" | "gif" | "video" | "file";
+  size: number;
+  tags: string[];
+  uploadedAt: number;
+  mediaUrl: string;
+  compatible: boolean | null;
+  disabledReason: string | null;
+};
+
+type AgentAttachmentRecord = {
+  uploadId: Id<"mediaUploads">;
+  fileName: string;
+  displayName: string;
+  mimeType: string;
+  mediaKind: "image" | "gif" | "video" | "file";
+  size: number;
+  tags: string[];
+  uploadedAt: number;
+  mediaUrl: string;
+  compatibility: {
+    twitterReply: WorkspaceAttachmentCompatibility;
+    twitterDm: WorkspaceAttachmentCompatibility;
+    linkedInComment: WorkspaceAttachmentCompatibility;
+    linkedInDm: WorkspaceAttachmentCompatibility;
+  };
+};
+
+export type WorkspaceAttachmentsToolResult = {
+  success: boolean;
+  operation: z.infer<typeof operationSchema>;
+  message: string;
+  count?: number;
+  breakdown?: {
+    images: number;
+    gifs: number;
+    videos: number;
+    files: number;
+  };
+  attachments?: ToolAttachment[];
+  requiresClarification?: boolean;
+  artifact?: AgentArtifactEnvelope;
+};
+
+function normalizeName(value: string): string {
+  return value.trim().toLocaleLowerCase();
+}
+
+function getDestinationCompatibility(
+  attachment: AgentAttachmentRecord,
+  destination: z.infer<typeof destinationSchema> | undefined
+) {
+  if (!destination) return null;
+  if (destination.platform === "twitter") {
+    return destination.surface === "dm"
+      ? attachment.compatibility.twitterDm
+      : attachment.compatibility.twitterReply;
+  }
+  return destination.surface === "dm"
+    ? attachment.compatibility.linkedInDm
+    : attachment.compatibility.linkedInComment;
+}
+
+export const workspaceAttachments = createTool({
+  description:
+    "Count, search, inspect, show, or resolve memory-linked attachments in the current workspace. Results come from live workspace data. Use show when the user asks to see a file. Use resolve_memory when an applicable workspace memory names a memoryKey with linked attachments. Never invent an attachment reference, storage URL, or database ID.",
+  inputSchema: z.object({
+    operation: operationSchema.describe(
+      "count for totals, search for discovery, inspect for metadata, show for inline rendering, or resolve_memory for attachments bound to an applicable workspace memory."
+    ),
+    query: z
+      .string()
+      .max(240)
+      .optional()
+      .describe(
+        "Natural file-name, display-name, tag, or type query. Required for inspect/show unless selecting latest or oldest."
+      ),
+    memoryKey: z
+      .string()
+      .max(120)
+      .optional()
+      .describe(
+        "The exact memoryKey supplied in workspace memory context. Use only with resolve_memory."
+      ),
+    mediaKind: mediaKindSchema
+      .optional()
+      .describe("Optional image, GIF, video, or generic file filter."),
+    selection: z
+      .enum(["best_match", "latest", "oldest"])
+      .optional()
+      .default("best_match")
+      .describe("How to choose among live workspace attachments."),
+    limit: z.number().int().min(1).max(8).optional().default(5),
+    destination: destinationSchema
+      .optional()
+      .describe(
+        "Optional outreach destination used to report whether each result can be selected. Internal platform value twitter is rendered to users as X/Twitter."
+      ),
+  }),
+  execute: async (ctx, args): Promise<WorkspaceAttachmentsToolResult> => {
+    const context = await resolveWorkspaceMemoryContext(
+      ctx,
+      "workspaceAttachments"
+    );
+    if (!context.userId || !context.workspaceId) {
+      return {
+        success: false,
+        operation: args.operation,
+        message: "I couldn't determine the current workspace.",
+      };
+    }
+    const workspaceId = context.workspaceId as Id<"workspaces">;
+    const userId = context.userId;
+
+    if (args.operation === "count") {
+      const counts = await ctx.runQuery(
+        internal.workspaceAttachments.getCountForAgentInternal,
+        { workspaceId, userId }
+      );
+      return {
+        success: true,
+        operation: "count",
+        message: buildWorkspaceAttachmentCountSummary(counts),
+        count: counts.total,
+        breakdown: {
+          images: counts.images,
+          gifs: counts.gifs,
+          videos: counts.videos,
+          files: counts.files,
+        },
+      };
+    }
+
+    let records: AgentAttachmentRecord[];
+    if (args.operation === "resolve_memory") {
+      if (!args.memoryKey?.trim()) {
+        return {
+          success: false,
+          operation: args.operation,
+          message: "A workspace memory key is required to resolve its files.",
+        };
+      }
+      const uploadIds = await ctx.runQuery(
+        internal.workspaceAttachments.getMemoryAttachmentIdsForAgentInternal,
+        { workspaceId, userId, memoryKey: args.memoryKey }
+      );
+      records = await ctx.runQuery(
+        internal.workspaceAttachments.getByIdsForAgentInternal,
+        { workspaceId, userId, uploadIds }
+      );
+    } else {
+      if (
+        (args.operation === "show" || args.operation === "inspect") &&
+        !args.query?.trim() &&
+        args.selection === "best_match"
+      ) {
+        return {
+          success: false,
+          operation: args.operation,
+          message:
+            "Name the attachment to find, or ask for the latest or oldest matching file.",
+        };
+      }
+      records = await ctx.runQuery(
+        internal.workspaceAttachments.searchForAgentInternal,
+        {
+          workspaceId,
+          userId,
+          query: args.query,
+          mediaKind: args.mediaKind,
+          selection: args.selection,
+          limit:
+            args.operation === "show" || args.operation === "inspect"
+              ? Math.max(args.limit, 2)
+              : args.limit,
+        }
+      );
+    }
+
+    if (records.length === 0) {
+      return {
+        success: true,
+        operation: args.operation,
+        message:
+          args.operation === "resolve_memory"
+            ? "That workspace memory has no available linked attachments."
+            : "No matching attachments were found in this workspace.",
+        attachments: [],
+      };
+    }
+
+    if (args.operation === "show" || args.operation === "inspect") {
+      const normalizedQuery = args.query ? normalizeName(args.query) : "";
+      const exactMatches = normalizedQuery
+        ? records.filter(
+            (record) =>
+              normalizeName(record.fileName) === normalizedQuery ||
+              normalizeName(record.displayName) === normalizedQuery
+          )
+        : [];
+      if (exactMatches.length === 1) {
+        records = exactMatches;
+      } else if (records.length === 1 || args.selection !== "best_match") {
+        records = records.slice(0, 1);
+      } else {
+        return {
+          success: true,
+          operation: args.operation,
+          message: `I found multiple matching attachments: ${records
+            .map((record) => record.displayName)
+            .join(", ")}. Ask the user which one they mean.`,
+          requiresClarification: true,
+        };
+      }
+    }
+
+    const messageId = getToolPromptMessageId(ctx);
+    if (!ctx.threadId || !messageId) {
+      return {
+        success: false,
+        operation: args.operation,
+        message:
+          "The attachments were found, but this Agent turn cannot safely stage them. Try again in the workspace conversation.",
+      };
+    }
+    await ctx.runMutation(
+      internal.workspaceAttachments.stageForAgentToolInternal,
+      {
+        threadId: ctx.threadId,
+        messageId,
+        workspaceId,
+        userId,
+        uploadIds: records.map((record) => record.uploadId).slice(0, 4),
+      }
+    );
+    const references: AgentAttachmentToolReference[] = await ctx.runQuery(
+      internal.agentAttachments.listAvailableForAgentTool,
+      { threadId: ctx.threadId, messageId, userId }
+    );
+    const referenceByUploadId = new Map(
+      references.map((reference) => [String(reference.uploadId), reference])
+    );
+    const attachments = records.flatMap((record) => {
+      const reference = referenceByUploadId.get(String(record.uploadId));
+      if (!reference) return [];
+      const compatibility = getDestinationCompatibility(
+        record,
+        args.destination
+      );
+      return [
+        {
+          attachmentRef: reference.reference,
+          fileName: record.fileName,
+          displayName: record.displayName,
+          mimeType: record.mimeType,
+          mediaKind: record.mediaKind,
+          size: record.size,
+          tags: record.tags,
+          uploadedAt: record.uploadedAt,
+          mediaUrl: record.mediaUrl,
+          compatible: compatibility?.compatible ?? null,
+          disabledReason: compatibility?.reason ?? null,
+        } satisfies ToolAttachment,
+      ];
+    });
+
+    if (attachments.length === 0) {
+      return {
+        success: false,
+        operation: args.operation,
+        message:
+          "The matching attachments could not be staged in this Agent turn.",
+      };
+    }
+
+    const result: WorkspaceAttachmentsToolResult = {
+      success: true,
+      operation: args.operation,
+      message:
+        args.operation === "show"
+          ? `Showing ${attachments.map((attachment) => attachment.displayName).join(", ")}.`
+          : `Found ${attachments.length} matching ${attachments.length === 1 ? "attachment" : "attachments"}.`,
+      attachments,
+    };
+    if (args.operation === "show") {
+      result.artifact = createAttachmentPreviewArtifact({ attachments });
+    }
+    return result;
+  },
+});

--- a/convex/chat.ts
+++ b/convex/chat.ts
@@ -546,8 +546,9 @@ async function resolveAttachmentReference(
     });
     if (upload) {
       if (
-        scope.workspaceId &&
-        upload.workspaceId &&
+        !scope.userId ||
+        upload.userId !== scope.userId ||
+        !scope.workspaceId ||
         upload.workspaceId !== scope.workspaceId
       ) {
         return null;
@@ -563,7 +564,7 @@ async function resolveAttachmentReference(
     }
   }
 
-  if (!attachment.mediaUrl) {
+  if (!attachment.mediaUrl || scope.workspaceId) {
     return null;
   }
 
@@ -893,7 +894,7 @@ async function buildAgentTurnContextMessages(
     )
   ).filter((line): line is string => Boolean(line));
   const attachmentReferences =
-    scope.kind === "prospect"
+    (scope.kind === "prospect" || scope.kind === "workspace") && scope.userId
       ? await ctx.runQuery(
           internal.agentAttachments.listAvailableForAgentTool,
           {

--- a/convex/lib/agentAttachmentReferenceCore.ts
+++ b/convex/lib/agentAttachmentReferenceCore.ts
@@ -8,7 +8,7 @@ export type AgentAttachmentToolReference = {
   uploadId: Id<"mediaUploads">;
   url: string;
   fileName: string;
-  mediaKind: "image" | "gif" | "video";
+  mediaKind: "image" | "gif" | "video" | "file";
   selectedInCurrentMessage: boolean;
 };
 
@@ -16,14 +16,14 @@ export type AgentAttachmentMediaInput = {
   attachmentRefs?: string[];
   mediaUrls?: string[];
   mediaDescriptions?: string[];
-  mediaKinds?: Array<"image" | "gif" | "video">;
+  mediaKinds?: Array<"image" | "gif" | "video" | "file">;
 };
 
 export type ResolvedAgentAttachmentMediaInput = {
   mediaUrls?: string[];
   mediaUploadIds?: Id<"mediaUploads">[];
   mediaDescriptions?: string[];
-  mediaKinds?: Array<"image" | "gif" | "video">;
+  mediaKinds?: Array<"image" | "gif" | "video" | "file">;
 };
 
 export function getAgentAttachmentReference(index: number): string {
@@ -44,7 +44,7 @@ export function buildAgentAttachmentReferenceContext(
         `- ${attachment.reference}: ${attachment.fileName} (type: ${attachment.mediaKind}; ${
           attachment.selectedInCurrentMessage
             ? "selected in the current message"
-            : "selected earlier in this prospect thread"
+            : "selected earlier in this thread"
         })`
     ),
     "Use these exact reference names in a tool's attachmentRefs field. Never put storage URLs or upload IDs in tool input.",

--- a/convex/lib/agentMemoryCore.ts
+++ b/convex/lib/agentMemoryCore.ts
@@ -190,6 +190,7 @@ export type PromoteAgentMemoryArgs = {
   channels?: string[];
   provenanceKind?: WorkspaceMemoryProvenanceKind;
   provenanceMessageId?: string;
+  attachmentUploadIds?: Id<"mediaUploads">[];
 };
 
 export type AgentMemoryPromotionResult = {
@@ -1123,6 +1124,7 @@ async function attachCanonicalWorkspaceMemory(
     provenanceKind: args.provenanceKind,
     provenanceThreadId: args.threadId,
     provenanceMessageId: args.provenanceMessageId,
+    attachmentUploadIds: args.attachmentUploadIds,
   });
   const canonicalRagText = buildCanonicalWorkspaceMemoryRagText({
     title: canonical.memory.title,

--- a/convex/lib/deleteWorkspaceCore.ts
+++ b/convex/lib/deleteWorkspaceCore.ts
@@ -36,6 +36,7 @@ export const sweepWorkspaceRowsInternal = internalMutation({
       auditItems,
       memoryQueues,
       mediaUploads,
+      attachmentStats,
       conversationMessages,
       conversations,
       socialMonitors,
@@ -92,6 +93,10 @@ export const sweepWorkspaceRowsInternal = internalMutation({
       ctx.db
         .query("mediaUploads")
         .withIndex("by_workspace_uploaded_at", (q) => q.eq("workspaceId", w))
+        .take(n),
+      ctx.db
+        .query("workspaceAttachmentStats")
+        .withIndex("by_workspace", (q) => q.eq("workspaceId", w))
         .take(n),
       ctx.db
         .query("platformConversationMessages")
@@ -238,6 +243,7 @@ export const sweepWorkspaceRowsInternal = internalMutation({
     deleted += await deleteDocuments(ctx, keywords);
     deleted += await deleteDocuments(ctx, auditItems);
     deleted += await deleteDocuments(ctx, memoryQueues);
+    deleted += await deleteDocuments(ctx, attachmentStats);
     deleted += await deleteDocuments(ctx, conversationMessages);
     deleted += await deleteDocuments(ctx, conversations);
     deleted += await deleteDocuments(ctx, socialMonitors);

--- a/convex/lib/mediaCapabilityCore.ts
+++ b/convex/lib/mediaCapabilityCore.ts
@@ -1,8 +1,9 @@
 import type { Id } from "../_generated/dataModel";
 import type { MutationCtx, QueryCtx } from "../_generated/server";
 import { inferAttachmentMediaKind } from "../../shared/lib/utils/media/inferAttachmentMediaKind";
+import { LINKEDIN_MESSAGE_DOCUMENT_MIME_TYPES } from "../../shared/lib/utils/media/linkedinMessageAttachmentTypes";
 
-export type OutreachMediaKind = "image" | "gif" | "video";
+export type OutreachMediaKind = "image" | "gif" | "video" | "file";
 export type OutreachMediaPlatform = "twitter" | "linkedin";
 export type OutreachMediaSurface = "comment" | "dm";
 
@@ -34,6 +35,7 @@ const LINKEDIN_MESSAGE_MIME_TYPES = new Set([
   "image/png",
   "image/bmp",
   "video/mp4",
+  ...LINKEDIN_MESSAGE_DOCUMENT_MIME_TYPES,
 ]);
 
 export interface ResolvedOutreachMedia {
@@ -143,25 +145,35 @@ export function assertOutreachMediaCapability(args: {
     return;
   }
 
+  const files = media.filter((attachment) => attachment.kind === "file");
+  if (files.length > 0) {
+    throw mediaCapabilityError(
+      `${files[0].fileName} cannot be attached to X/Twitter. Use it in a supported LinkedIn DM or choose an image, GIF, or video.`
+    );
+  }
+
   const images = media.filter((attachment) => attachment.kind === "image");
   const gifs = media.filter((attachment) => attachment.kind === "gif");
   const videos = media.filter((attachment) => attachment.kind === "video");
-  const destination = surface === "dm" ? "an X DM" : "an X reply";
+  const destination =
+    surface === "dm" ? "an X/Twitter DM" : "an X/Twitter reply";
 
   if (surface === "dm" && media.length > 1) {
-    throw mediaCapabilityError("X DMs support at most one media attachment.");
+    throw mediaCapabilityError(
+      "X/Twitter DMs support at most one media attachment."
+    );
   }
   if (surface === "comment" && images.length > 4) {
-    throw mediaCapabilityError("X replies support up to four images.");
+    throw mediaCapabilityError("X/Twitter replies support up to four images.");
   }
   if (gifs.length > 1 || videos.length > 1 || gifs.length + videos.length > 1) {
     throw mediaCapabilityError(
-      "X supports one GIF or one video per reply/message."
+      "X/Twitter supports one GIF or one video per reply/message."
     );
   }
   if ((gifs.length > 0 || videos.length > 0) && images.length > 0) {
     throw mediaCapabilityError(
-      "X cannot mix images with a GIF or video in the same reply/message."
+      "X/Twitter cannot mix images with a GIF or video in the same reply/message."
     );
   }
 
@@ -202,20 +214,26 @@ export async function resolveOwnedOutreachMedia(
         if (
           !upload ||
           upload.userId !== args.userId ||
-          (upload.workspaceId && upload.workspaceId !== args.workspaceId)
+          upload.workspaceId !== args.workspaceId
         ) {
           throw mediaCapabilityError(
             "The selected attachment could not be verified in this workspace. Re-select or upload the file and try again."
           );
         }
         const url = await ctx.storage.getUrl(upload.storageId);
-        const kind = inferAttachmentMediaKind({
-          mimeType: upload.mimeType,
-          url: upload.fileName,
-        });
+        const kind =
+          inferAttachmentMediaKind({
+            mimeType: upload.mimeType,
+            url: upload.fileName,
+          }) ??
+          (LINKEDIN_MESSAGE_DOCUMENT_MIME_TYPES.has(
+            upload.mimeType.toLowerCase()
+          )
+            ? "file"
+            : null);
         if (!url || !kind) {
           throw mediaCapabilityError(
-            `${upload.displayName?.trim() || upload.fileName} is no longer available or is not a supported image, GIF, or video.`
+            `${upload.displayName?.trim() || upload.fileName} is no longer available or is not a supported attachment.`
           );
         }
         return {
@@ -234,19 +252,24 @@ export async function resolveOwnedOutreachMedia(
 
   const uploads = await ctx.db
     .query("mediaUploads")
-    .withIndex("by_user_uploaded_at", (q) => q.eq("userId", args.userId))
+    .withIndex("by_workspace_and_user_and_uploaded_at", (q) =>
+      q.eq("workspaceId", args.workspaceId).eq("userId", args.userId)
+    )
     .order("desc")
     .take(MAX_RESOLVABLE_UPLOADS);
   const byUrl = new Map<string, ResolvedOutreachMedia>();
 
   await Promise.all(
     uploads.map(async (upload) => {
-      if (upload.workspaceId && upload.workspaceId !== args.workspaceId) return;
       const url = await ctx.storage.getUrl(upload.storageId);
-      const kind = inferAttachmentMediaKind({
-        mimeType: upload.mimeType,
-        url: upload.fileName,
-      });
+      const kind =
+        inferAttachmentMediaKind({
+          mimeType: upload.mimeType,
+          url: upload.fileName,
+        }) ??
+        (LINKEDIN_MESSAGE_DOCUMENT_MIME_TYPES.has(upload.mimeType.toLowerCase())
+          ? "file"
+          : null);
       if (!url || !kind) return;
       byUrl.set(url, {
         uploadId: upload._id,

--- a/convex/lib/outreachCore.ts
+++ b/convex/lib/outreachCore.ts
@@ -110,7 +110,7 @@ export interface OutreachTaskInput {
   mediaUrls?: string[];
   mediaUploadIds?: Id<"mediaUploads">[];
   mediaDescriptions?: string[];
-  mediaKinds?: Array<"image" | "gif" | "video">;
+  mediaKinds?: Array<"image" | "gif" | "video" | "file">;
   approvalContext?: {
     panelMode?: "approval" | "posted";
     platform?: "twitter" | "linkedin";

--- a/convex/lib/planBatchCore.ts
+++ b/convex/lib/planBatchCore.ts
@@ -14,7 +14,7 @@ export type PlanBatchItemOperation = "create" | "update";
 export type PlanBatchAttachment = {
   url: string;
   fileName: string;
-  mediaKind: "image" | "gif" | "video";
+  mediaKind: "image" | "gif" | "video" | "file";
 };
 
 export type PlanBatchTaggedTarget = {

--- a/convex/lib/prospectProfileContextCore.ts
+++ b/convex/lib/prospectProfileContextCore.ts
@@ -79,7 +79,7 @@ export type AgentProspectProfileRelatedContext = {
       targetTweetId?: string;
       mediaUrls?: string[];
       mediaDescriptions?: string[];
-      mediaKinds?: Array<"image" | "gif" | "video">;
+      mediaKinds?: Array<"image" | "gif" | "video" | "file">;
     }>;
   } | null;
   interactionHistory: unknown | null;

--- a/convex/lib/workspaceAttachmentCore.ts
+++ b/convex/lib/workspaceAttachmentCore.ts
@@ -1,0 +1,263 @@
+import type { Doc, Id } from "../_generated/dataModel";
+import type { MutationCtx } from "../_generated/server";
+import { getCurrentUTCTimestamp } from "../../shared/lib/utils/time/timeUtils";
+import { inferAttachmentMediaKind } from "../../shared/lib/utils/media/inferAttachmentMediaKind";
+import {
+  assertOutreachMediaCapability,
+  getMediaCapabilityErrorMessage,
+  type OutreachMediaPlatform,
+  type OutreachMediaSurface,
+  type ResolvedOutreachMedia,
+} from "./mediaCapabilityCore";
+
+export const MAX_WORKSPACE_ATTACHMENT_RESULTS = 20;
+export const MAX_AGENT_WORKSPACE_ATTACHMENT_RESULTS = 8;
+export const MAX_ATTACHMENT_FILE_NAME_LENGTH = 255;
+export const MAX_ATTACHMENT_TAG_COUNT = 20;
+export const MAX_ATTACHMENT_TAG_LENGTH = 80;
+
+export type WorkspaceAttachmentKind = "image" | "gif" | "video" | "file";
+
+export type WorkspaceAttachmentDestination = {
+  platform: OutreachMediaPlatform;
+  surface: OutreachMediaSurface;
+};
+
+export type WorkspaceAttachmentCompatibility = {
+  compatible: boolean;
+  reason: string | null;
+};
+
+export type WorkspaceAttachmentCountBreakdown = {
+  total: number;
+  images: number;
+  gifs: number;
+  videos: number;
+  files: number;
+};
+
+type WorkspaceAttachmentMetadata = Pick<
+  Doc<"mediaUploads">,
+  "fileName" | "displayName" | "mimeType" | "size"
+> & { _id?: Id<"mediaUploads"> };
+
+export function sanitizeWorkspaceAttachmentFileName(fileName: string): string {
+  const sanitized = fileName.trim();
+  if (!sanitized) {
+    throw new Error("Attachment file name is required.");
+  }
+  if (sanitized.length > MAX_ATTACHMENT_FILE_NAME_LENGTH) {
+    throw new Error(
+      `Attachment file names must be ${MAX_ATTACHMENT_FILE_NAME_LENGTH} characters or fewer.`
+    );
+  }
+  return sanitized;
+}
+
+export function sanitizeWorkspaceAttachmentTags(
+  tags: string[] | undefined
+): string[] | undefined {
+  if (!tags) return undefined;
+  const sanitized = [
+    ...new Set(
+      tags
+        .map((tag) => tag.trim())
+        .filter(Boolean)
+        .map((tag) => tag.slice(0, MAX_ATTACHMENT_TAG_LENGTH))
+    ),
+  ].slice(0, MAX_ATTACHMENT_TAG_COUNT);
+  return sanitized.length > 0 ? sanitized : undefined;
+}
+
+export function getWorkspaceAttachmentKind(args: {
+  mimeType: string;
+  fileName: string;
+}): WorkspaceAttachmentKind {
+  return (
+    inferAttachmentMediaKind({
+      mimeType: args.mimeType,
+      url: args.fileName,
+    }) ?? "file"
+  );
+}
+
+export function buildWorkspaceAttachmentSearchText(args: {
+  fileName: string;
+  displayName?: string;
+  mimeType: string;
+  tags?: string[];
+}): string {
+  return [
+    args.displayName?.trim(),
+    args.fileName.trim(),
+    args.mimeType.trim().toLowerCase(),
+    ...(args.tags ?? []),
+  ]
+    .filter((value): value is string => Boolean(value))
+    .join(" ");
+}
+
+function getDestinationLabel(
+  destination: WorkspaceAttachmentDestination
+): string {
+  if (destination.platform === "linkedin") {
+    return destination.surface === "dm"
+      ? "a LinkedIn DM"
+      : "a LinkedIn comment";
+  }
+  return destination.surface === "dm"
+    ? "an X/Twitter DM"
+    : "an X/Twitter reply";
+}
+
+export function getWorkspaceAttachmentCompatibility(args: {
+  attachment: WorkspaceAttachmentMetadata;
+  url?: string;
+  destination: WorkspaceAttachmentDestination;
+}): WorkspaceAttachmentCompatibility {
+  const kind = getWorkspaceAttachmentKind(args.attachment);
+  const media: ResolvedOutreachMedia = {
+    // The capability validator never reads the ID; pending uploads do not have
+    // a mediaUploads row yet.
+    uploadId: args.attachment._id ?? ("pending" as Id<"mediaUploads">),
+    url: args.url ?? "",
+    fileName:
+      args.attachment.displayName?.trim() || args.attachment.fileName.trim(),
+    mimeType: args.attachment.mimeType.trim().toLowerCase(),
+    size: args.attachment.size,
+    kind,
+  };
+
+  try {
+    assertOutreachMediaCapability({
+      ...args.destination,
+      media: [media],
+    });
+    return { compatible: true, reason: null };
+  } catch (error) {
+    return {
+      compatible: false,
+      reason:
+        getMediaCapabilityErrorMessage(error) ??
+        `${media.fileName} cannot be attached to ${getDestinationLabel(args.destination)}.`,
+    };
+  }
+}
+
+export function getWorkspaceAttachmentCompatibilityMatrix(
+  attachment: WorkspaceAttachmentMetadata
+) {
+  return {
+    twitterReply: getWorkspaceAttachmentCompatibility({
+      attachment,
+      destination: { platform: "twitter", surface: "comment" },
+    }),
+    twitterDm: getWorkspaceAttachmentCompatibility({
+      attachment,
+      destination: { platform: "twitter", surface: "dm" },
+    }),
+    linkedInComment: getWorkspaceAttachmentCompatibility({
+      attachment,
+      destination: { platform: "linkedin", surface: "comment" },
+    }),
+    linkedInDm: getWorkspaceAttachmentCompatibility({
+      attachment,
+      destination: { platform: "linkedin", surface: "dm" },
+    }),
+  };
+}
+
+export function isSupportedWorkspaceAttachment(
+  attachment: WorkspaceAttachmentMetadata
+): boolean {
+  return Object.values(
+    getWorkspaceAttachmentCompatibilityMatrix(attachment)
+  ).some((compatibility) => compatibility.compatible);
+}
+
+export function buildWorkspaceAttachmentCountSummary(
+  counts: WorkspaceAttachmentCountBreakdown
+): string {
+  if (counts.total === 0) {
+    return "This workspace has no attachments.";
+  }
+
+  const details = [
+    counts.images > 0
+      ? `${counts.images} ${counts.images === 1 ? "image" : "images"}`
+      : null,
+    counts.gifs > 0
+      ? `${counts.gifs} ${counts.gifs === 1 ? "GIF" : "GIFs"}`
+      : null,
+    counts.videos > 0
+      ? `${counts.videos} ${counts.videos === 1 ? "video" : "videos"}`
+      : null,
+    counts.files > 0
+      ? `${counts.files} ${counts.files === 1 ? "file" : "files"}`
+      : null,
+  ].filter((value): value is string => Boolean(value));
+
+  return `This workspace has ${counts.total} ${counts.total === 1 ? "attachment" : "attachments"}: ${details.join(", ")}.`;
+}
+
+export async function updateWorkspaceAttachmentStats(
+  ctx: Pick<MutationCtx, "db">,
+  args: {
+    workspaceId: Doc<"workspaces">["_id"];
+    kind: WorkspaceAttachmentKind;
+    delta: 1 | -1;
+  }
+): Promise<void> {
+  const existing = await ctx.db
+    .query("workspaceAttachmentStats")
+    .withIndex("by_workspace", (query) =>
+      query.eq("workspaceId", args.workspaceId)
+    )
+    .unique();
+  const now = getCurrentUTCTimestamp();
+  const current: WorkspaceAttachmentCountBreakdown = existing
+    ? {
+        total: existing.total,
+        images: existing.images,
+        gifs: existing.gifs,
+        videos: existing.videos,
+        files: existing.files,
+      }
+    : { total: 0, images: 0, gifs: 0, videos: 0, files: 0 };
+  const next = {
+    ...current,
+    total: Math.max(0, current.total + args.delta),
+    images:
+      args.kind === "image"
+        ? Math.max(0, current.images + args.delta)
+        : current.images,
+    gifs:
+      args.kind === "gif"
+        ? Math.max(0, current.gifs + args.delta)
+        : current.gifs,
+    videos:
+      args.kind === "video"
+        ? Math.max(0, current.videos + args.delta)
+        : current.videos,
+    files:
+      args.kind === "file"
+        ? Math.max(0, current.files + args.delta)
+        : current.files,
+  };
+
+  if (existing) {
+    await ctx.db.patch("workspaceAttachmentStats", existing._id, {
+      ...next,
+      updatedAt: now,
+    });
+    return;
+  }
+
+  if (args.delta > 0) {
+    await ctx.db.insert("workspaceAttachmentStats", {
+      workspaceId: args.workspaceId,
+      ...next,
+      updatedAt: now,
+    });
+  }
+}

--- a/convex/lib/workspaceMemoryCore.ts
+++ b/convex/lib/workspaceMemoryCore.ts
@@ -69,6 +69,7 @@ export type CanonicalWorkspaceMemory = {
   prospectId?: string;
   surfaces?: string[];
   channels?: string[];
+  attachmentUploadIds?: string[];
   provenanceKind: WorkspaceMemoryProvenanceKind;
   provenanceThreadId?: string;
   provenanceMessageId?: string;
@@ -108,6 +109,7 @@ export type CanonicalWorkspaceMemoryWriteArgs = {
   prospectId?: Id<"prospects">;
   surfaces?: string[];
   channels?: string[];
+  attachmentUploadIds?: Id<"mediaUploads">[];
   provenanceKind?: WorkspaceMemoryProvenanceKind;
   provenanceThreadId?: string;
   provenanceMessageId?: string;
@@ -195,6 +197,7 @@ export function buildCanonicalWorkspaceMemoryIdentity(args: {
   prospectId?: string;
   surfaces?: string[];
   channels?: string[];
+  attachmentUploadIds?: Array<Id<"mediaUploads"> | string>;
 }): string {
   const identity = JSON.stringify({
     workspaceId: args.workspaceId,
@@ -203,6 +206,9 @@ export function buildCanonicalWorkspaceMemoryIdentity(args: {
     prospectId: args.prospectId ?? null,
     surfaces: sanitizeStringList(args.surfaces) ?? [],
     channels: sanitizeStringList(args.channels) ?? [],
+    attachmentUploadIds: [...(args.attachmentUploadIds ?? [])]
+      .map(String)
+      .sort(),
   });
   return `workspace-memory-v2:${createStableHash(identity)}`;
 }
@@ -331,6 +337,7 @@ function serializePromptMemory(memory: CanonicalWorkspaceMemory): string {
     prospectId: memory.prospectId ?? null,
     surfaces: memory.surfaces ?? [],
     channels: memory.channels ?? [],
+    linkedAttachmentCount: memory.attachmentUploadIds?.length ?? 0,
     provenance: memory.provenanceKind,
   });
 }
@@ -401,6 +408,7 @@ export function toCanonicalWorkspaceMemory(row: any): CanonicalWorkspaceMemory {
     prospectId: row.prospectId ? String(row.prospectId) : undefined,
     surfaces: row.surfaces,
     channels: row.channels,
+    attachmentUploadIds: row.attachmentUploadIds?.map(String),
     provenanceKind: row.provenanceKind,
     provenanceThreadId: row.provenanceThreadId,
     provenanceMessageId: row.provenanceMessageId,
@@ -453,6 +461,24 @@ export async function upsertCanonicalWorkspaceMemory(
   }
   const surfaces = sanitizeStringList(args.surfaces);
   const channels = sanitizeStringList(args.channels);
+  const attachmentUploadIds = args.attachmentUploadIds
+    ? [...new Set(args.attachmentUploadIds)].slice(0, 4)
+    : undefined;
+  const attachmentUploads = await Promise.all(
+    (attachmentUploadIds ?? []).map((uploadId) =>
+      db.get("mediaUploads", uploadId)
+    )
+  );
+  if (
+    attachmentUploads.some(
+      (upload) =>
+        !upload ||
+        upload.userId !== args.userId ||
+        upload.workspaceId !== args.workspaceId
+    )
+  ) {
+    throw new Error("Workspace memory attachment validation failed");
+  }
   const conflictKey = requestedConflictKey
     ? [
         authority,
@@ -472,6 +498,7 @@ export async function upsertCanonicalWorkspaceMemory(
     prospectId: args.prospectId ? String(args.prospectId) : undefined,
     surfaces,
     channels,
+    attachmentUploadIds,
   });
   const ragText = buildCanonicalWorkspaceMemoryRagText({
     title: args.title,
@@ -512,6 +539,7 @@ export async function upsertCanonicalWorkspaceMemory(
     prospectId: args.prospectId,
     surfaces,
     channels,
+    attachmentUploadIds,
     provenanceKind: getWorkspaceMemoryProvenanceKind(
       args.source,
       args.provenanceKind

--- a/convex/linkedin.ts
+++ b/convex/linkedin.ts
@@ -76,7 +76,14 @@ import {
   buildStyleSourceKey,
   getNextStyleSourceVersion,
 } from "./lib/styleSourceCore";
-import { linkedinProfileIdentityValidator } from "./validators";
+import {
+  linkedinProfileIdentityValidator,
+  twitterMediaKindValidator,
+} from "./validators";
+import {
+  getMediaCapabilityErrorMessage,
+  type ResolvedOutreachMedia,
+} from "./lib/mediaCapabilityCore";
 import type { LinkedInProfileIdentity } from "../shared/lib/linkedin/profile";
 import {
   getWebhookArray,
@@ -4453,10 +4460,9 @@ export const submitLinkedInActionForThread = internalAction({
     postId: v.optional(v.string()),
     text: v.optional(v.string()),
     mediaUrls: v.optional(v.array(v.string())),
+    mediaUploadIds: v.optional(v.array(v.id("mediaUploads"))),
     mediaDescriptions: v.optional(v.array(v.string())),
-    mediaKinds: v.optional(
-      v.array(v.union(v.literal("image"), v.literal("gif"), v.literal("video")))
-    ),
+    mediaKinds: v.optional(v.array(twitterMediaKindValidator)),
     reactionType: v.optional(v.string()),
     targetLabel: v.optional(v.string()),
     context: v.optional(v.string()),
@@ -4477,6 +4483,55 @@ export const submitLinkedInActionForThread = internalAction({
         message: "LinkedIn actions require a prospect in the current thread.",
         error: "Missing prospect context for LinkedIn action.",
       };
+    }
+
+    const destination =
+      args.actionKey === "linkedin_comment_on_post"
+        ? ({ platform: "linkedin", surface: "comment" } as const)
+        : args.actionKey === "linkedin_send_message" ||
+            args.actionKey === "linkedin_send_message_existing_conversation"
+          ? ({ platform: "linkedin", surface: "dm" } as const)
+          : null;
+    if ((args.mediaUrls?.length ?? 0) > 0) {
+      if (!destination || !threadContext.workspaceId) {
+        return {
+          success: false,
+          executed: false,
+          pendingApproval: false,
+          actionKey: args.actionKey,
+          title: "Attachment unavailable",
+          message: "Attachments are not supported for this LinkedIn action.",
+          error: "Unsupported attachment context",
+        };
+      }
+      try {
+        const media: ResolvedOutreachMedia[] = await ctx.runQuery(
+          internal.workspaceAttachments.resolveAndValidateOutreachMediaInternal,
+          {
+            userId: threadContext.userId,
+            workspaceId: threadContext.workspaceId,
+            destination,
+            mediaUrls: args.mediaUrls ?? [],
+            mediaUploadIds: args.mediaUploadIds,
+          }
+        );
+        args.mediaUrls = media.map((attachment) => attachment.url);
+        args.mediaUploadIds = media.map((attachment) => attachment.uploadId);
+        args.mediaKinds = media.map((attachment) => attachment.kind);
+      } catch (error) {
+        const message =
+          getMediaCapabilityErrorMessage(error) ??
+          "The selected attachment could not be verified for this LinkedIn action.";
+        return {
+          success: false,
+          executed: false,
+          pendingApproval: false,
+          actionKey: args.actionKey,
+          title: "Attachment unavailable",
+          message,
+          error: message,
+        };
+      }
     }
 
     const metadata = getTwitterActionCatalogEntry(args.actionKey);
@@ -4694,6 +4749,7 @@ export const submitLinkedInActionForThread = internalAction({
               postId: args.postId,
               text: draftContent,
               mediaUrls: args.mediaUrls ?? [],
+              mediaUploadIds: args.mediaUploadIds ?? [],
               mediaDescriptions: args.mediaDescriptions ?? [],
               mediaKinds: args.mediaKinds ?? [],
               targetLabel,
@@ -4754,6 +4810,7 @@ export const submitLinkedInActionForThread = internalAction({
           reactionType: normalizedReactionType,
           text: draftContent,
           mediaUrls: args.mediaUrls ?? [],
+          mediaUploadIds: args.mediaUploadIds ?? [],
           mediaDescriptions: args.mediaDescriptions ?? [],
           mediaKinds: args.mediaKinds ?? [],
           targetLabel,

--- a/convex/mediaMentions.ts
+++ b/convex/mediaMentions.ts
@@ -15,12 +15,18 @@ import {
   buildPostMentionEntity,
   buildTwitterReplyMentionEntity,
 } from "../shared/lib/mentions/postMentions";
-import { inferAttachmentMediaKind } from "../shared/lib/utils/media/inferAttachmentMediaKind";
 import type {
   MentionEntityKind,
   MentionEntitySearchResult,
 } from "../shared/lib/mentions/mentionEntities";
-import { mentionEntityKindValidator } from "./validators";
+import {
+  mentionEntityKindValidator,
+  workspaceAttachmentDestinationValidator,
+} from "./validators";
+import {
+  getWorkspaceAttachmentCompatibility,
+  getWorkspaceAttachmentKind,
+} from "./lib/workspaceAttachmentCore";
 
 const ACTIVE_PLAN_STATUSES = [
   "draft",
@@ -310,6 +316,7 @@ export const searchMentionEntities = query({
     prospectId: v.optional(v.id("prospects")),
     limit: v.optional(v.number()),
     allowedKinds: v.optional(v.array(mentionEntityKindValidator)),
+    attachmentDestination: v.optional(workspaceAttachmentDestinationValidator),
   },
   handler: async (ctx, args) => {
     const identity = await ctx.auth.getUserIdentity();
@@ -400,13 +407,25 @@ export const searchMentionEntities = query({
         .map(buildProspectSnapshotFromSummary);
     }
 
-    const uploads = shouldIncludeAttachments
-      ? await ctx.db
-          .query("mediaUploads")
-          .withIndex("by_user_uploaded_at", (q) => q.eq("userId", user._id))
-          .order("desc")
-          .take(40)
-      : [];
+    const uploads = !shouldIncludeAttachments
+      ? []
+      : normalizedQuery
+        ? await ctx.db
+            .query("mediaUploads")
+            .withSearchIndex("search_workspace_attachments", (q) =>
+              q
+                .search("searchText", normalizedQuery)
+                .eq("workspaceId", workspace._id)
+                .eq("userId", user._id)
+            )
+            .take(Math.max(resultLimit * 3, 12))
+        : await ctx.db
+            .query("mediaUploads")
+            .withIndex("by_workspace_and_user_and_uploaded_at", (q) =>
+              q.eq("workspaceId", workspace._id).eq("userId", user._id)
+            )
+            .order("desc")
+            .take(Math.max(resultLimit * 3, 12));
 
     const plans =
       shouldIncludePlans || shouldIncludeTasks
@@ -452,34 +471,35 @@ export const searchMentionEntities = query({
     );
 
     const uploadMentionEntities = await Promise.all(
-      uploads
-        .filter(
-          (upload) =>
-            !upload.workspaceId || upload.workspaceId === workspace._id
-        )
-        .map(async (upload) => {
-          const displayName = upload.displayName ?? upload.fileName;
-          const attachmentUrl = await ctx.storage.getUrl(upload.storageId);
-          return {
-            id: `attachment:${String(upload._id)}`,
-            entityId: String(upload._id),
-            kind: "attachment" as const,
-            label: displayName,
-            mentionText: `Attachment: ${displayName}`,
-            secondaryLabel: "Workspace attachment",
-            avatarUrl: null,
-            verified: false,
-            referenceText: `Attachment: ${displayName}${attachmentUrl ? ` (${attachmentUrl})` : ""}`,
-            workspaceId: upload.workspaceId
-              ? String(upload.workspaceId)
-              : String(workspace._id),
-            attachmentUrl,
-            attachmentMimeType: upload.mimeType,
-            attachmentMediaKind: inferAttachmentMediaKind({
-              mimeType: upload.mimeType,
-            }),
-          };
-        })
+      uploads.map(async (upload) => {
+        const displayName = upload.displayName ?? upload.fileName;
+        const attachmentUrl = await ctx.storage.getUrl(upload.storageId);
+        const attachmentMediaKind = getWorkspaceAttachmentKind(upload);
+        const compatibility = args.attachmentDestination
+          ? getWorkspaceAttachmentCompatibility({
+              attachment: upload,
+              destination: args.attachmentDestination,
+            })
+          : null;
+        return {
+          id: `attachment:${String(upload._id)}`,
+          entityId: String(upload._id),
+          kind: "attachment" as const,
+          label: displayName,
+          mentionText: `Attachment: ${displayName}`,
+          secondaryLabel: "Workspace attachment",
+          avatarUrl: null,
+          verified: false,
+          referenceText: `Attachment: ${displayName}`,
+          workspaceId: String(workspace._id),
+          attachmentUrl,
+          attachmentMimeType: upload.mimeType,
+          attachmentSize: upload.size,
+          attachmentMediaKind,
+          attachmentDisabled: compatibility ? !compatibility.compatible : false,
+          attachmentDisabledReason: compatibility?.reason ?? null,
+        };
+      })
     );
 
     const postMentionEntities =

--- a/convex/mediaUpload.ts
+++ b/convex/mediaUpload.ts
@@ -1,41 +1,50 @@
 "use node";
 
-import { action } from "./lib/functionBuilders";
 import { v } from "convex/values";
-import { api } from "./_generated/api";
+import { action } from "./lib/functionBuilders";
+import { internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
 
-/**
- * Process media after direct upload to Convex storage
- * This action is called after the client uploads the file directly to Convex storage
- * and provides the storage ID. This bypasses the 5MB argument size limit.
- */
+type ProcessedMediaUpload = {
+  uploadId: Id<"mediaUploads">;
+  mediaUrl: string | null;
+  mediaId: Id<"_storage">;
+  fileName: string;
+  displayName: string;
+  mimeType: string;
+  size: number;
+};
+
+type FinalizedMediaUpload =
+  | ({ success: true } & Omit<ProcessedMediaUpload, "mediaUrl" | "mediaId">)
+  | { success: false; error: string };
+
+/** Finalize a direct upload and return its canonical workspace attachment. */
 export const processUploadedMedia = action({
   args: {
     storageId: v.id("_storage"),
     fileName: v.string(),
     mimeType: v.string(),
     size: v.number(),
-    workspaceId: v.optional(v.id("workspaces")),
+    workspaceId: v.id("workspaces"),
     displayName: v.optional(v.string()),
     tags: v.optional(v.array(v.string())),
   },
-  handler: async (
-    ctx,
-    args
-  ): Promise<{
-    uploadId: string | null;
-    mediaUrl: string | null;
-    mediaId: string;
-  }> => {
+  returns: v.object({
+    uploadId: v.id("mediaUploads"),
+    mediaUrl: v.union(v.string(), v.null()),
+    mediaId: v.id("_storage"),
+    fileName: v.string(),
+    displayName: v.string(),
+    mimeType: v.string(),
+    size: v.number(),
+  }),
+  handler: async (ctx, args): Promise<ProcessedMediaUpload> => {
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) throw new Error("Not authenticated");
 
-    // Get the media URL from storage
-    const mediaUrl = await ctx.storage.getUrl(args.storageId);
-
-    // Store metadata
-    const uploadId = await ctx.runMutation(
-      api.mediaUploadMutations.storeMediaMetadata,
+    const finalized: FinalizedMediaUpload = await ctx.runMutation(
+      internal.mediaUploadMutations.storeMediaMetadataInternal,
       {
         mediaId: args.storageId,
         fileName: args.fileName,
@@ -46,10 +55,17 @@ export const processUploadedMedia = action({
         tags: args.tags,
       }
     );
+    if (!finalized.success) {
+      throw new Error(finalized.error);
+    }
 
     return {
-      uploadId,
-      mediaUrl,
+      uploadId: finalized.uploadId,
+      fileName: finalized.fileName,
+      displayName: finalized.displayName,
+      mimeType: finalized.mimeType,
+      size: finalized.size,
+      mediaUrl: await ctx.storage.getUrl(args.storageId),
       mediaId: args.storageId,
     };
   },

--- a/convex/mediaUploadMutations.ts
+++ b/convex/mediaUploadMutations.ts
@@ -1,83 +1,158 @@
-import { mutation, query } from "./lib/functionBuilders";
 import { v } from "convex/values";
 import { getCurrentUTCTimestamp } from "../shared/lib/utils/time/timeUtils";
-import { getUserByIdentity } from "./lib/accessHelpers";
+import { internalMutation, mutation, query } from "./lib/functionBuilders";
+import { requireOwnedWorkspace, requireUser } from "./lib/accessHelpers";
+import {
+  buildWorkspaceAttachmentSearchText,
+  getWorkspaceAttachmentKind,
+  isSupportedWorkspaceAttachment,
+  sanitizeWorkspaceAttachmentFileName,
+  sanitizeWorkspaceAttachmentTags,
+  updateWorkspaceAttachmentStats,
+} from "./lib/workspaceAttachmentCore";
 
-/**
- * Generate an upload URL for direct file upload to Convex storage
- * This bypasses the 5MB argument size limit for large files
- */
+/** Generate a one-use Convex upload URL for an authenticated workspace owner. */
 export const generateUploadUrl = mutation({
-  handler: async (ctx) => {
+  args: { workspaceId: v.id("workspaces") },
+  returns: v.string(),
+  handler: async (ctx, args) => {
+    const user = await requireUser(ctx);
+    await requireOwnedWorkspace(ctx, args.workspaceId, { user });
     return await ctx.storage.generateUploadUrl();
   },
 });
 
-export const storeMediaMetadata = mutation({
+/**
+ * Finalize one direct upload using authoritative `_storage` metadata.
+ * This stays internal so clients cannot create forged attachment rows.
+ */
+export const storeMediaMetadataInternal = internalMutation({
   args: {
     mediaId: v.id("_storage"),
     fileName: v.string(),
     mimeType: v.string(),
     size: v.number(),
-    workspaceId: v.optional(v.id("workspaces")),
+    workspaceId: v.id("workspaces"),
     displayName: v.optional(v.string()),
     tags: v.optional(v.array(v.string())),
   },
+  returns: v.union(
+    v.object({
+      success: v.literal(true),
+      uploadId: v.id("mediaUploads"),
+      fileName: v.string(),
+      displayName: v.string(),
+      mimeType: v.string(),
+      size: v.number(),
+    }),
+    v.object({ success: v.literal(false), error: v.string() })
+  ),
   handler: async (ctx, args) => {
-    const identity = await ctx.auth.getUserIdentity();
-    if (!identity) {
-      throw new Error("Not authenticated");
-    }
-    const user = await getUserByIdentity(ctx, identity);
-    if (!user) {
-      throw new Error("User not found");
+    const user = await requireUser(ctx);
+    await requireOwnedWorkspace(ctx, args.workspaceId, { user });
+
+    const storageMetadata = await ctx.db.system.get("_storage", args.mediaId);
+    if (!storageMetadata) {
+      throw new Error("The uploaded attachment is no longer available.");
     }
 
-    return await ctx.db.insert("mediaUploads", {
+    let fileName: string;
+    let displayName: string;
+    let mimeType: string;
+    let size: number;
+    let tags: string[] | undefined;
+    try {
+      fileName = sanitizeWorkspaceAttachmentFileName(args.fileName);
+      displayName = args.displayName?.trim().slice(0, 255) || fileName;
+      mimeType = (
+        storageMetadata.contentType?.trim() || args.mimeType.trim()
+      ).toLowerCase();
+      size = storageMetadata.size;
+      tags = sanitizeWorkspaceAttachmentTags(args.tags);
+      if (
+        !isSupportedWorkspaceAttachment({
+          fileName,
+          displayName,
+          mimeType,
+          size,
+        })
+      ) {
+        throw new Error(
+          `${displayName} is not compatible with any supported X/Twitter or LinkedIn attachment destination.`
+        );
+      }
+    } catch (error) {
+      // Return instead of throwing so the storage deletion commits with this
+      // mutation. The calling action converts the failure back into an error.
+      await ctx.storage.delete(args.mediaId);
+      return {
+        success: false as const,
+        error:
+          error instanceof Error
+            ? error.message
+            : "The uploaded attachment is not supported.",
+      };
+    }
+
+    const now = getCurrentUTCTimestamp();
+    const kind = getWorkspaceAttachmentKind({ fileName, mimeType });
+    const uploadId = await ctx.db.insert("mediaUploads", {
       storageId: args.mediaId,
       userId: user._id,
       workspaceId: args.workspaceId,
-      fileName: args.fileName,
-      displayName: args.displayName?.trim() || args.fileName,
-      mimeType: args.mimeType,
-      size: args.size,
-      tags: args.tags?.map((tag) => tag.trim()).filter(Boolean),
-      uploadedAt: getCurrentUTCTimestamp(),
+      fileName,
+      displayName,
+      mimeType,
+      size,
+      tags,
+      sha256: storageMetadata.sha256,
+      searchText: buildWorkspaceAttachmentSearchText({
+        fileName,
+        displayName,
+        mimeType,
+        tags,
+      }),
+      statsRecordedAt: now,
+      uploadedAt: now,
     });
+    await updateWorkspaceAttachmentStats(ctx, {
+      workspaceId: args.workspaceId,
+      kind,
+      delta: 1,
+    });
+
+    return {
+      success: true as const,
+      uploadId,
+      fileName,
+      displayName,
+      mimeType,
+      size,
+    };
   },
 });
 
-/**
- * List the current user's media library (most recent first).
- * Powers attachment reuse in chat and composers.
- */
+/** List the current workspace's recent attachments, newest first. */
 export const listMediaLibrary = query({
   args: {
-    workspaceId: v.optional(v.id("workspaces")),
+    workspaceId: v.id("workspaces"),
     limit: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
-    const identity = await ctx.auth.getUserIdentity();
-    if (!identity) return [];
-    const user = await getUserByIdentity(ctx, identity);
-    if (!user) return [];
+    const user = await requireUser(ctx);
+    await requireOwnedWorkspace(ctx, args.workspaceId, { user });
 
-    const limit = Math.min(Math.max(args.limit ?? 30, 1), 100);
+    const limit = Math.min(Math.max(Math.floor(args.limit ?? 30), 1), 100);
     const uploads = await ctx.db
       .query("mediaUploads")
-      .withIndex("by_user_uploaded_at", (q) => q.eq("userId", user._id))
+      .withIndex("by_workspace_and_user_and_uploaded_at", (q) =>
+        q.eq("workspaceId", args.workspaceId).eq("userId", user._id)
+      )
       .order("desc")
       .take(limit);
 
-    const scoped = args.workspaceId
-      ? uploads.filter(
-          (upload) =>
-            !upload.workspaceId || upload.workspaceId === args.workspaceId
-        )
-      : uploads;
-
     return await Promise.all(
-      scoped.map(async (upload) => ({
+      uploads.map(async (upload) => ({
         uploadId: upload._id,
         fileName: upload.fileName,
         displayName: upload.displayName ?? upload.fileName,
@@ -91,23 +166,45 @@ export const listMediaLibrary = query({
   },
 });
 
+/** Resolve a fresh URL only after validating user and workspace ownership. */
 export const getMediaUrl = query({
-  args: { mediaId: v.id("_storage") },
+  args: { uploadId: v.id("mediaUploads") },
+  returns: v.union(v.string(), v.null()),
   handler: async (ctx, args) => {
-    return await ctx.storage.getUrl(args.mediaId);
+    const user = await requireUser(ctx);
+    const upload = await ctx.db.get(args.uploadId);
+    if (!upload || !upload.workspaceId) {
+      return null;
+    }
+    await requireOwnedWorkspace(ctx, upload.workspaceId, { user });
+    if (upload.userId !== user._id) {
+      return null;
+    }
+    return await ctx.storage.getUrl(upload.storageId);
   },
 });
 
 export const deleteMedia = mutation({
   args: { uploadId: v.id("mediaUploads") },
+  returns: v.null(),
   handler: async (ctx, args) => {
+    const user = await requireUser(ctx);
     const upload = await ctx.db.get(args.uploadId);
-    if (!upload) return;
+    if (!upload) return null;
+    if (!upload.workspaceId || upload.userId !== user._id) {
+      throw new Error("Not authorized to delete this attachment.");
+    }
+    await requireOwnedWorkspace(ctx, upload.workspaceId, { user });
 
-    // Delete from storage
     await ctx.storage.delete(upload.storageId);
-
-    // Delete metadata
     await ctx.db.delete(args.uploadId);
+    if (upload.statsRecordedAt !== undefined) {
+      await updateWorkspaceAttachmentStats(ctx, {
+        workspaceId: upload.workspaceId,
+        kind: getWorkspaceAttachmentKind(upload),
+        delta: -1,
+      });
+    }
+    return null;
   },
 });

--- a/convex/memory.ts
+++ b/convex/memory.ts
@@ -236,6 +236,7 @@ async function persistWorkspaceMemoryDraft(
     channels?: string[];
     provenanceKind?: WorkspaceMemoryProvenanceKind;
     provenanceMessageId?: string;
+    attachmentUploadIds?: Id<"mediaUploads">[];
   }
 ): Promise<AgentMemoryPromotionResult> {
   const inserted = await ctx.runMutation(
@@ -498,6 +499,7 @@ export const insertBuiltInAgentMemoryInternal = internalMutation({
       )
     ),
     provenanceMessageId: v.optional(v.string()),
+    attachmentUploadIds: v.optional(v.array(v.id("mediaUploads"))),
   },
   handler: async (ctx, args) => {
     return await promoteAgentMemory(ctx.db, {
@@ -526,6 +528,7 @@ export const insertBuiltInAgentMemoryInternal = internalMutation({
       channels: args.channels,
       provenanceKind: args.provenanceKind,
       provenanceMessageId: args.provenanceMessageId,
+      attachmentUploadIds: args.attachmentUploadIds,
     });
   },
 });
@@ -568,6 +571,7 @@ export const persistCanonicalWorkspaceMemoryInternal = internalAction({
       )
     ),
     provenanceMessageId: v.optional(v.string()),
+    attachmentUploadIds: v.optional(v.array(v.id("mediaUploads"))),
   },
   handler: async (ctx, args): Promise<AgentMemoryPromotionResult> =>
     await persistWorkspaceMemoryDraft(ctx, {

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -17,6 +17,12 @@ import {
   getWorkspaceAgentMemoryById,
 } from "./lib/agentMemoryCore";
 import { upsertCanonicalWorkspaceMemory } from "./lib/workspaceMemoryCore";
+import {
+  buildWorkspaceAttachmentSearchText,
+  getWorkspaceAttachmentKind,
+  updateWorkspaceAttachmentStats,
+} from "./lib/workspaceAttachmentCore";
+import { getCurrentUTCTimestamp } from "../shared/lib/utils/time/timeUtils";
 
 export const migrations = new Migrations<DataModel, typeof schema>(
   components.migrations,
@@ -330,3 +336,57 @@ export const backfillCanonicalWorkspaceMemories = migrations.define({
     }
   },
 });
+
+/**
+ * Additive attachment-library backfill. Unscoped legacy rows intentionally
+ * remain quarantined; scoped rows become searchable and enter exact counters.
+ */
+export const backfillWorkspaceAttachmentSearchAndStats = migrations.define({
+  table: "mediaUploads",
+  batchSize: 25,
+  migrateOne: async (ctx, upload) => {
+    const searchText = buildWorkspaceAttachmentSearchText({
+      fileName: upload.fileName,
+      displayName: upload.displayName,
+      mimeType: upload.mimeType,
+      tags: upload.tags,
+    });
+    const workspace = upload.workspaceId
+      ? await ctx.db.get("workspaces", upload.workspaceId)
+      : null;
+    const isOwnedScopedUpload = Boolean(
+      workspace && upload.userId && workspace.userId === upload.userId
+    );
+    const patch: {
+      searchText?: string;
+      statsRecordedAt?: number;
+    } = {};
+    if (upload.searchText !== searchText) {
+      patch.searchText = searchText;
+    }
+    if (
+      isOwnedScopedUpload &&
+      upload.workspaceId &&
+      upload.statsRecordedAt === undefined
+    ) {
+      const statsRecordedAt = getCurrentUTCTimestamp();
+      await updateWorkspaceAttachmentStats(ctx, {
+        workspaceId: upload.workspaceId,
+        kind: getWorkspaceAttachmentKind(upload),
+        delta: 1,
+      });
+      patch.statsRecordedAt = statsRecordedAt;
+    }
+    if (Object.keys(patch).length > 0) {
+      await ctx.db.patch("mediaUploads", upload._id, patch);
+    }
+  },
+});
+
+/**
+ * Deliberately scoped runner for the attachment rollout. Keeping this runner
+ * explicit avoids exposing the component's generic "run any migration" API.
+ */
+export const runWorkspaceAttachmentBackfill = migrations.runner([
+  internal.migrations.backfillWorkspaceAttachmentSearchAndStats,
+]);

--- a/convex/outreach.ts
+++ b/convex/outreach.ts
@@ -214,11 +214,14 @@ async function requireViewerUser(ctx: QueryCtx | MutationCtx) {
 function normalizeMediaKinds(
   mediaKinds: unknown,
   mediaUrls: string[]
-): Array<"image" | "gif" | "video"> {
+): Array<"image" | "gif" | "video" | "file"> {
   const normalized = Array.isArray(mediaKinds)
     ? mediaKinds.filter(
-        (value): value is "image" | "gif" | "video" =>
-          value === "image" || value === "gif" || value === "video"
+        (value): value is "image" | "gif" | "video" | "file" =>
+          value === "image" ||
+          value === "gif" ||
+          value === "video" ||
+          value === "file"
       )
     : [];
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1026,11 +1026,37 @@ export default defineSchema({
     mimeType: v.string(),
     size: v.number(),
     tags: v.optional(v.array(v.string())),
+    /** Actual Convex storage digest; additive until legacy rows are backfilled. */
+    sha256: v.optional(v.string()),
+    /** Normalized text used by workspace-scoped full-text attachment search. */
+    searchText: v.optional(v.string()),
+    /** Marks rows included in the denormalized workspace attachment counts. */
+    statsRecordedAt: v.optional(v.number()),
     uploadedAt: v.number(),
   })
     .index("by_uploaded_at", ["uploadedAt"])
     .index("by_user_uploaded_at", ["userId", "uploadedAt"])
-    .index("by_workspace_uploaded_at", ["workspaceId", "uploadedAt"]),
+    .index("by_workspace_uploaded_at", ["workspaceId", "uploadedAt"])
+    .index("by_workspace_and_user_and_uploaded_at", [
+      "workspaceId",
+      "userId",
+      "uploadedAt",
+    ])
+    .searchIndex("search_workspace_attachments", {
+      searchField: "searchText",
+      filterFields: ["workspaceId", "userId"],
+    }),
+
+  /** Transactionally maintained counts for accurate Agent answers at scale. */
+  workspaceAttachmentStats: defineTable({
+    workspaceId: v.id("workspaces"),
+    total: v.number(),
+    images: v.number(),
+    gifs: v.number(),
+    videos: v.number(),
+    files: v.number(),
+    updatedAt: v.number(),
+  }).index("by_workspace", ["workspaceId"]),
 
   platformConversations: defineTable({
     userId: v.id("users"),
@@ -2025,6 +2051,8 @@ export default defineSchema({
     prospectId: v.optional(v.id("prospects")),
     surfaces: v.optional(v.array(v.string())),
     channels: v.optional(v.array(v.string())),
+    /** Verified workspace attachment bindings selected through opaque refs. */
+    attachmentUploadIds: v.optional(v.array(v.id("mediaUploads"))),
     provenanceKind: workspaceMemoryProvenanceKindValidator,
     provenanceThreadId: v.optional(v.string()),
     provenanceMessageId: v.optional(v.string()),
@@ -2046,6 +2074,11 @@ export default defineSchema({
     updatedAt: v.number(),
   })
     .index("by_workspace_and_identity_key", ["workspaceId", "identityKey"])
+    .index("by_workspace_and_topic_key_and_status", [
+      "workspaceId",
+      "topicKey",
+      "status",
+    ])
     .index("by_workspace_and_conflict_key_and_status", [
       "workspaceId",
       "conflictKey",

--- a/convex/socialActionExecutors.ts
+++ b/convex/socialActionExecutors.ts
@@ -28,6 +28,11 @@ import {
 import { logger } from "../shared/lib/logger";
 import { resolveProspectTwitterIdentity } from "../shared/lib/twitter/prospectTwitterIdentity";
 import { assertTwitterActionTextValid } from "../shared/lib/twitter/xPostTextLimit";
+import {
+  getMediaCapabilityErrorMessage,
+  type ResolvedOutreachMedia,
+} from "./lib/mediaCapabilityCore";
+import { twitterMediaKindValidator } from "./validators";
 
 const internalLinkedInApi = (internal as any).linkedin;
 const socialActionExecutorsLogger = logger.withScope("SocialActionExecutors");
@@ -402,11 +407,44 @@ export const executeActionRequestInternal = internalAction({
           typeof argsSnapshot.text === "string"
             ? argsSnapshot.text
             : request.draftContent;
-        const mediaUrls = Array.isArray(argsSnapshot.mediaUrls)
+        let mediaUrls = Array.isArray(argsSnapshot.mediaUrls)
           ? argsSnapshot.mediaUrls.filter(
               (value: unknown): value is string => typeof value === "string"
             )
           : undefined;
+        const mediaUploadIds = Array.isArray(argsSnapshot.mediaUploadIds)
+          ? argsSnapshot.mediaUploadIds.filter(
+              (value: unknown): value is Id<"mediaUploads"> =>
+                typeof value === "string"
+            )
+          : undefined;
+        const linkedInDestination =
+          request.actionKey === "linkedin_comment_on_post"
+            ? ({ platform: "linkedin", surface: "comment" } as const)
+            : request.actionKey === "linkedin_send_message" ||
+                request.actionKey ===
+                  "linkedin_send_message_existing_conversation"
+              ? ({ platform: "linkedin", surface: "dm" } as const)
+              : null;
+        if (mediaUrls?.length) {
+          if (!linkedInDestination || !request.workspaceId) {
+            throw new Error(
+              "Attachments are not supported for this LinkedIn action."
+            );
+          }
+          const validated: ResolvedOutreachMedia[] = await ctx.runQuery(
+            internal.workspaceAttachments
+              .resolveAndValidateOutreachMediaInternal,
+            {
+              userId: request.userId,
+              workspaceId: request.workspaceId,
+              destination: linkedInDestination,
+              mediaUrls,
+              mediaUploadIds,
+            }
+          );
+          mediaUrls = validated.map((attachment) => attachment.url);
+        }
         const postId =
           typeof argsSnapshot.postId === "string"
             ? argsSnapshot.postId.trim()
@@ -646,9 +684,17 @@ export const executeActionRequestInternal = internalAction({
         typeof argsSnapshot.text === "string"
           ? argsSnapshot.text
           : request.draftContent;
-      const mediaUrlsForValidation = Array.isArray(argsSnapshot.mediaUrls)
+      let mediaUrlsForValidation = Array.isArray(argsSnapshot.mediaUrls)
         ? argsSnapshot.mediaUrls.filter(
             (value: unknown): value is string => typeof value === "string"
+          )
+        : undefined;
+      const mediaUploadIdsForValidation = Array.isArray(
+        argsSnapshot.mediaUploadIds
+      )
+        ? argsSnapshot.mediaUploadIds.filter(
+            (value: unknown): value is Id<"mediaUploads"> =>
+              typeof value === "string"
           )
         : undefined;
       const mediaDescriptionsForExecution = Array.isArray(
@@ -670,6 +716,31 @@ export const executeActionRequestInternal = internalAction({
       );
 
       const actionKey = request.actionKey as CuratedTwitterActionKey;
+      const xAttachmentDestination =
+        actionKey === "reply_to_post" || actionKey === "create_post"
+          ? ({ platform: "twitter", surface: "comment" } as const)
+          : actionKey === "send_dm" ||
+              actionKey === "send_dm_in_existing_conversation"
+            ? ({ platform: "twitter", surface: "dm" } as const)
+            : null;
+      if (mediaUrlsForValidation?.length) {
+        if (!xAttachmentDestination || !request.workspaceId) {
+          throw new Error(
+            "Attachments are not supported for this X/Twitter action."
+          );
+        }
+        const validated: ResolvedOutreachMedia[] = await ctx.runQuery(
+          internal.workspaceAttachments.resolveAndValidateOutreachMediaInternal,
+          {
+            userId: request.userId,
+            workspaceId: request.workspaceId,
+            destination: xAttachmentDestination,
+            mediaUrls: mediaUrlsForValidation,
+            mediaUploadIds: mediaUploadIdsForValidation,
+          }
+        );
+        mediaUrlsForValidation = validated.map((attachment) => attachment.url);
+      }
       let resolvedTargetUserId =
         typeof argsSnapshot.targetUserId === "string"
           ? argsSnapshot.targetUserId.trim()
@@ -923,16 +994,64 @@ export const submitTwitterActionForThread = internalAction({
     conversationId: v.optional(v.string()),
     text: v.optional(v.string()),
     mediaUrls: v.optional(v.array(v.string())),
+    mediaUploadIds: v.optional(v.array(v.id("mediaUploads"))),
     mediaDescriptions: v.optional(v.array(v.string())),
-    mediaKinds: v.optional(
-      v.array(v.union(v.literal("image"), v.literal("gif"), v.literal("video")))
-    ),
+    mediaKinds: v.optional(v.array(twitterMediaKindValidator)),
     targetLabel: v.optional(v.string()),
     context: v.optional(v.string()),
     replaceExistingPending: v.optional(v.boolean()),
   },
   handler: async (ctx, args): Promise<SubmitTwitterActionResult> => {
     const threadContext = await resolveThreadContext(ctx, args.threadId);
+    const destination =
+      args.actionKey === "reply_to_post" || args.actionKey === "create_post"
+        ? ({ platform: "twitter", surface: "comment" } as const)
+        : args.actionKey === "send_dm" ||
+            args.actionKey === "send_dm_in_existing_conversation"
+          ? ({ platform: "twitter", surface: "dm" } as const)
+          : null;
+    if ((args.mediaUrls?.length ?? 0) > 0) {
+      if (!destination || !threadContext.workspaceId) {
+        return {
+          success: false,
+          executed: false,
+          pendingApproval: false,
+          actionKey: args.actionKey,
+          title: "Attachment unavailable",
+          message:
+            "Attachments are not supported for this X/Twitter action in the current workspace context.",
+          error: "Unsupported attachment context",
+        };
+      }
+      try {
+        const media: ResolvedOutreachMedia[] = await ctx.runQuery(
+          internal.workspaceAttachments.resolveAndValidateOutreachMediaInternal,
+          {
+            userId: threadContext.userId,
+            workspaceId: threadContext.workspaceId,
+            destination,
+            mediaUrls: args.mediaUrls ?? [],
+            mediaUploadIds: args.mediaUploadIds,
+          }
+        );
+        args.mediaUrls = media.map((attachment) => attachment.url);
+        args.mediaUploadIds = media.map((attachment) => attachment.uploadId);
+        args.mediaKinds = media.map((attachment) => attachment.kind);
+      } catch (error) {
+        const message =
+          getMediaCapabilityErrorMessage(error) ??
+          "The selected attachment could not be verified for this X/Twitter action.";
+        return {
+          success: false,
+          executed: false,
+          pendingApproval: false,
+          actionKey: args.actionKey,
+          title: "Attachment unavailable",
+          message,
+          error: message,
+        };
+      }
+    }
     const limit = await ctx.runQuery(
       internal.xPostLimits.getEffectivePostLimitInternal,
       { userId: threadContext.userId }
@@ -1134,6 +1253,7 @@ export const submitTwitterActionForThread = internalAction({
                 resolvedConversationIdForRequest ?? args.conversationId,
               text: args.text,
               mediaUrls: args.mediaUrls ?? [],
+              mediaUploadIds: args.mediaUploadIds ?? [],
               mediaDescriptions: args.mediaDescriptions ?? [],
               mediaKinds: args.mediaKinds ?? [],
               targetLabel: effectiveTargetLabel,
@@ -1203,6 +1323,7 @@ export const submitTwitterActionForThread = internalAction({
             resolvedConversationIdForRequest ?? args.conversationId,
           text: args.text,
           mediaUrls: args.mediaUrls ?? [],
+          mediaUploadIds: args.mediaUploadIds ?? [],
           mediaDescriptions: args.mediaDescriptions ?? [],
           mediaKinds: args.mediaKinds ?? [],
           targetLabel: effectiveTargetLabel,

--- a/convex/socialActions.ts
+++ b/convex/socialActions.ts
@@ -192,11 +192,14 @@ function normalizeMediaUrls(mediaUrls?: unknown): string[] {
 function normalizeMediaKinds(
   mediaKinds: unknown,
   mediaUrls: string[]
-): Array<"image" | "gif" | "video"> {
+): Array<"image" | "gif" | "video" | "file"> {
   const normalized = Array.isArray(mediaKinds)
     ? mediaKinds.filter(
-        (value): value is "image" | "gif" | "video" =>
-          value === "image" || value === "gif" || value === "video"
+        (value): value is "image" | "gif" | "video" | "file" =>
+          value === "image" ||
+          value === "gif" ||
+          value === "video" ||
+          value === "file"
       )
     : [];
 
@@ -596,6 +599,7 @@ export const updatePendingActionRequestDraft = mutation({
         ...(hasMediaSnapshot
           ? {
               mediaUrls,
+              mediaUploadIds: [],
               mediaDescriptions: args.mediaDescriptions,
               mediaKinds: args.mediaKinds,
             }
@@ -623,9 +627,7 @@ export const approveActionRequestWithEdits = mutation({
     content: v.string(),
     mediaUrls: v.optional(v.array(v.string())),
     mediaDescriptions: v.optional(v.array(v.string())),
-    mediaKinds: v.optional(
-      v.array(v.union(v.literal("image"), v.literal("gif"), v.literal("video")))
-    ),
+    mediaKinds: v.optional(v.array(twitterMediaKindValidator)),
   },
   handler: async (ctx, args) => {
     const user = await requireUser(ctx, {
@@ -682,6 +684,7 @@ export const approveActionRequestWithEdits = mutation({
         ...snapshot,
         text: trimmedContent,
         mediaUrls,
+        mediaUploadIds: [],
         mediaDescriptions: args.mediaDescriptions ?? [],
         mediaKinds,
       },

--- a/convex/validators.ts
+++ b/convex/validators.ts
@@ -479,7 +479,8 @@ export const twitterActionErrorSummaryValidator = v.object({
 export const twitterMediaKindValidator = v.union(
   v.literal("image"),
   v.literal("gif"),
-  v.literal("video")
+  v.literal("video"),
+  v.literal("file")
 );
 
 export const twitterActionArgumentsSnapshotValidator = v.object({
@@ -498,6 +499,7 @@ export const twitterActionArgumentsSnapshotValidator = v.object({
   profileUrl: v.optional(v.string()),
   text: v.optional(v.string()),
   mediaUrls: v.optional(v.array(v.string())),
+  mediaUploadIds: v.optional(v.array(v.id("mediaUploads"))),
   mediaDescriptions: v.optional(v.array(v.string())),
   mediaKinds: v.optional(v.array(twitterMediaKindValidator)),
   reactionType: v.optional(v.string()),
@@ -1110,8 +1112,63 @@ export const mentionEntityKindValidator = v.union(
 export const mentionAttachmentMediaKindValidator = v.union(
   v.literal("image"),
   v.literal("gif"),
-  v.literal("video")
+  v.literal("video"),
+  v.literal("file")
 );
+
+export const workspaceAttachmentDestinationValidator = v.object({
+  platform: v.union(v.literal("twitter"), v.literal("linkedin")),
+  surface: v.union(v.literal("comment"), v.literal("dm")),
+});
+
+export const workspaceAttachmentKindValidator = v.union(
+  v.literal("image"),
+  v.literal("gif"),
+  v.literal("video"),
+  v.literal("file")
+);
+
+export const workspaceAttachmentCompatibilityValidator = v.object({
+  compatible: v.boolean(),
+  reason: v.union(v.string(), v.null()),
+});
+
+export const workspaceAttachmentCompatibilityMatrixValidator = v.object({
+  twitterReply: workspaceAttachmentCompatibilityValidator,
+  twitterDm: workspaceAttachmentCompatibilityValidator,
+  linkedInComment: workspaceAttachmentCompatibilityValidator,
+  linkedInDm: workspaceAttachmentCompatibilityValidator,
+});
+
+export const workspaceAttachmentRecordValidator = v.object({
+  uploadId: v.id("mediaUploads"),
+  fileName: v.string(),
+  displayName: v.string(),
+  mimeType: v.string(),
+  mediaKind: workspaceAttachmentKindValidator,
+  size: v.number(),
+  tags: v.array(v.string()),
+  uploadedAt: v.number(),
+  mediaUrl: v.string(),
+  compatibility: workspaceAttachmentCompatibilityMatrixValidator,
+});
+
+export const workspaceAttachmentCountBreakdownValidator = v.object({
+  total: v.number(),
+  images: v.number(),
+  gifs: v.number(),
+  videos: v.number(),
+  files: v.number(),
+});
+
+export const resolvedOutreachMediaValidator = v.object({
+  uploadId: v.id("mediaUploads"),
+  url: v.string(),
+  fileName: v.string(),
+  mimeType: v.string(),
+  size: v.number(),
+  kind: workspaceAttachmentKindValidator,
+});
 
 export const mentionPostPlatformValidator = v.union(
   v.literal("twitter"),

--- a/convex/workspaceAttachments.ts
+++ b/convex/workspaceAttachments.ts
@@ -1,0 +1,319 @@
+import { v } from "convex/values";
+import type { Doc, Id } from "./_generated/dataModel";
+import type { QueryCtx } from "./_generated/server";
+import { internalMutation, internalQuery, query } from "./lib/functionBuilders";
+import { requireOwnedWorkspace, requireUser } from "./lib/accessHelpers";
+import {
+  assertOutreachMediaCapability,
+  resolveOwnedOutreachMedia,
+} from "./lib/mediaCapabilityCore";
+import {
+  getWorkspaceAttachmentCompatibilityMatrix,
+  getWorkspaceAttachmentKind,
+  MAX_AGENT_WORKSPACE_ATTACHMENT_RESULTS,
+  MAX_WORKSPACE_ATTACHMENT_RESULTS,
+  type WorkspaceAttachmentKind,
+} from "./lib/workspaceAttachmentCore";
+import {
+  resolvedOutreachMediaValidator,
+  workspaceAttachmentCountBreakdownValidator,
+  workspaceAttachmentDestinationValidator,
+  workspaceAttachmentKindValidator,
+  workspaceAttachmentRecordValidator,
+} from "./validators";
+import { normalizeMemoryText } from "./lib/memoryHelpers";
+
+type AttachmentRecord = {
+  uploadId: Id<"mediaUploads">;
+  fileName: string;
+  displayName: string;
+  mimeType: string;
+  mediaKind: WorkspaceAttachmentKind;
+  size: number;
+  tags: string[];
+  uploadedAt: number;
+  mediaUrl: string;
+  compatibility: ReturnType<typeof getWorkspaceAttachmentCompatibilityMatrix>;
+};
+
+async function toAttachmentRecord(
+  ctx: Pick<QueryCtx, "storage">,
+  upload: Doc<"mediaUploads">
+): Promise<AttachmentRecord | null> {
+  const mediaUrl = await ctx.storage.getUrl(upload.storageId);
+  if (!mediaUrl) return null;
+  return {
+    uploadId: upload._id,
+    fileName: upload.fileName,
+    displayName: upload.displayName?.trim() || upload.fileName,
+    mimeType: upload.mimeType,
+    mediaKind: getWorkspaceAttachmentKind(upload),
+    size: upload.size,
+    tags: upload.tags ?? [],
+    uploadedAt: upload.uploadedAt,
+    mediaUrl,
+    compatibility: getWorkspaceAttachmentCompatibilityMatrix(upload),
+  };
+}
+
+async function loadAttachmentRecords(
+  ctx: Pick<QueryCtx, "storage">,
+  uploads: Doc<"mediaUploads">[],
+  mediaKind?: WorkspaceAttachmentKind
+): Promise<AttachmentRecord[]> {
+  const filtered = mediaKind
+    ? uploads.filter(
+        (upload) => getWorkspaceAttachmentKind(upload) === mediaKind
+      )
+    : uploads;
+  return (
+    await Promise.all(filtered.map((upload) => toAttachmentRecord(ctx, upload)))
+  ).filter((record): record is AttachmentRecord => record !== null);
+}
+
+async function getCounts(
+  ctx: QueryCtx,
+  workspaceId: Id<"workspaces">
+): Promise<{
+  total: number;
+  images: number;
+  gifs: number;
+  videos: number;
+  files: number;
+}> {
+  const stats = await ctx.db
+    .query("workspaceAttachmentStats")
+    .withIndex("by_workspace", (q) => q.eq("workspaceId", workspaceId))
+    .unique();
+  return stats
+    ? {
+        total: stats.total,
+        images: stats.images,
+        gifs: stats.gifs,
+        videos: stats.videos,
+        files: stats.files,
+      }
+    : { total: 0, images: 0, gifs: 0, videos: 0, files: 0 };
+}
+
+export const getWorkspaceAttachmentCount = query({
+  args: { workspaceId: v.id("workspaces") },
+  returns: workspaceAttachmentCountBreakdownValidator,
+  handler: async (ctx, args) => {
+    const user = await requireUser(ctx);
+    await requireOwnedWorkspace(ctx, args.workspaceId, { user });
+    return await getCounts(ctx, args.workspaceId);
+  },
+});
+
+export const getCountForAgentInternal = internalQuery({
+  args: {
+    workspaceId: v.id("workspaces"),
+    userId: v.id("users"),
+  },
+  returns: workspaceAttachmentCountBreakdownValidator,
+  handler: async (ctx, args) => {
+    const workspace = await ctx.db.get(args.workspaceId);
+    if (!workspace || workspace.userId !== args.userId) {
+      throw new Error("Workspace attachment ownership validation failed.");
+    }
+    return await getCounts(ctx, args.workspaceId);
+  },
+});
+
+export const searchForAgentInternal = internalQuery({
+  args: {
+    workspaceId: v.id("workspaces"),
+    userId: v.id("users"),
+    query: v.optional(v.string()),
+    mediaKind: v.optional(workspaceAttachmentKindValidator),
+    selection: v.optional(
+      v.union(v.literal("best_match"), v.literal("latest"), v.literal("oldest"))
+    ),
+    limit: v.optional(v.number()),
+  },
+  returns: v.array(workspaceAttachmentRecordValidator),
+  handler: async (ctx, args) => {
+    const workspace = await ctx.db.get(args.workspaceId);
+    if (!workspace || workspace.userId !== args.userId) {
+      return [];
+    }
+    const limit = Math.min(
+      Math.max(Math.floor(args.limit ?? 5), 1),
+      MAX_AGENT_WORKSPACE_ATTACHMENT_RESULTS
+    );
+    const normalizedQuery = args.query?.trim() ?? "";
+    const candidateLimit = Math.min(
+      MAX_WORKSPACE_ATTACHMENT_RESULTS,
+      Math.max(limit * 4, limit)
+    );
+    let uploads: Doc<"mediaUploads">[];
+    if (normalizedQuery) {
+      uploads = await ctx.db
+        .query("mediaUploads")
+        .withSearchIndex("search_workspace_attachments", (q) =>
+          q
+            .search("searchText", normalizedQuery)
+            .eq("workspaceId", args.workspaceId)
+            .eq("userId", args.userId)
+        )
+        .take(candidateLimit);
+    } else {
+      uploads = await ctx.db
+        .query("mediaUploads")
+        .withIndex("by_workspace_and_user_and_uploaded_at", (q) =>
+          q.eq("workspaceId", args.workspaceId).eq("userId", args.userId)
+        )
+        .order(args.selection === "oldest" ? "asc" : "desc")
+        .take(candidateLimit);
+    }
+
+    const records = await loadAttachmentRecords(ctx, uploads, args.mediaKind);
+    if (args.selection === "latest" || args.selection === "oldest") {
+      records.sort((left, right) =>
+        args.selection === "oldest"
+          ? left.uploadedAt - right.uploadedAt
+          : right.uploadedAt - left.uploadedAt
+      );
+    }
+    return records.slice(0, limit);
+  },
+});
+
+export const getByIdsForAgentInternal = internalQuery({
+  args: {
+    workspaceId: v.id("workspaces"),
+    userId: v.id("users"),
+    uploadIds: v.array(v.id("mediaUploads")),
+  },
+  returns: v.array(workspaceAttachmentRecordValidator),
+  handler: async (ctx, args) => {
+    const workspace = await ctx.db.get(args.workspaceId);
+    if (!workspace || workspace.userId !== args.userId) return [];
+    const uniqueIds = [...new Set(args.uploadIds)].slice(
+      0,
+      MAX_AGENT_WORKSPACE_ATTACHMENT_RESULTS
+    );
+    const uploads = (
+      await Promise.all(uniqueIds.map((uploadId) => ctx.db.get(uploadId)))
+    ).filter((upload): upload is Doc<"mediaUploads"> =>
+      Boolean(
+        upload &&
+        upload.userId === args.userId &&
+        upload.workspaceId === args.workspaceId
+      )
+    );
+    return await loadAttachmentRecords(ctx, uploads);
+  },
+});
+
+export const getMemoryAttachmentIdsForAgentInternal = internalQuery({
+  args: {
+    workspaceId: v.id("workspaces"),
+    userId: v.id("users"),
+    memoryKey: v.string(),
+  },
+  returns: v.array(v.id("mediaUploads")),
+  handler: async (ctx, args) => {
+    const workspace = await ctx.db.get(args.workspaceId);
+    if (!workspace || workspace.userId !== args.userId) return [];
+    const topicKey = normalizeMemoryText(args.memoryKey);
+    if (!topicKey) return [];
+    const memory = await ctx.db
+      .query("workspaceMemories")
+      .withIndex("by_workspace_and_topic_key_and_status", (q) =>
+        q
+          .eq("workspaceId", args.workspaceId)
+          .eq("topicKey", topicKey)
+          .eq("status", "active")
+      )
+      .first();
+    if (!memory || memory.userId !== args.userId) return [];
+    return memory.attachmentUploadIds ?? [];
+  },
+});
+
+/**
+ * Stage server-selected records in the current message context so every
+ * downstream Agent tool resolves the same opaque attachment_n references.
+ */
+export const stageForAgentToolInternal = internalMutation({
+  args: {
+    threadId: v.string(),
+    messageId: v.string(),
+    workspaceId: v.id("workspaces"),
+    userId: v.id("users"),
+    uploadIds: v.array(v.id("mediaUploads")),
+  },
+  returns: v.array(v.id("mediaUploads")),
+  handler: async (ctx, args) => {
+    const context = await ctx.db
+      .query("agentMessageContexts")
+      .withIndex("by_message", (q) => q.eq("messageId", args.messageId))
+      .order("desc")
+      .first();
+    if (
+      !context ||
+      context.threadId !== args.threadId ||
+      context.userId !== args.userId ||
+      context.workspaceId !== args.workspaceId
+    ) {
+      throw new Error("The current Agent message context is unavailable.");
+    }
+
+    const existingIds = new Set(
+      context.attachments
+        .map((attachment) => attachment.uploadId)
+        .filter((uploadId): uploadId is string => Boolean(uploadId))
+    );
+    const nextAttachments = [...context.attachments];
+    const staged: Id<"mediaUploads">[] = [];
+    for (const uploadId of new Set(args.uploadIds)) {
+      if (existingIds.has(String(uploadId))) {
+        staged.push(uploadId);
+        continue;
+      }
+      const upload = await ctx.db.get(uploadId);
+      if (
+        !upload ||
+        upload.userId !== args.userId ||
+        upload.workspaceId !== args.workspaceId
+      ) {
+        continue;
+      }
+      nextAttachments.push({
+        uploadId: String(upload._id),
+        fileName: upload.displayName?.trim() || upload.fileName,
+        mediaUrl: null,
+      });
+      existingIds.add(String(uploadId));
+      staged.push(uploadId);
+      if (staged.length >= 4) break;
+    }
+    await ctx.db.patch("agentMessageContexts", context._id, {
+      attachments: nextAttachments,
+    });
+    return staged;
+  },
+});
+
+/** Canonical ownership and destination validation used before staging/sending. */
+export const resolveAndValidateOutreachMediaInternal = internalQuery({
+  args: {
+    userId: v.id("users"),
+    workspaceId: v.id("workspaces"),
+    destination: workspaceAttachmentDestinationValidator,
+    mediaUrls: v.array(v.string()),
+    mediaUploadIds: v.optional(v.array(v.id("mediaUploads"))),
+  },
+  returns: v.array(resolvedOutreachMediaValidator),
+  handler: async (ctx, args) => {
+    const workspace = await ctx.db.get(args.workspaceId);
+    if (!workspace || workspace.userId !== args.userId) {
+      throw new Error("Workspace attachment ownership validation failed.");
+    }
+    const media = await resolveOwnedOutreachMedia(ctx, args);
+    assertOutreachMediaCapability({ ...args.destination, media });
+    return media;
+  },
+});

--- a/features/agent/ui/AgentChat.tsx
+++ b/features/agent/ui/AgentChat.tsx
@@ -125,6 +125,12 @@ import { Skeleton } from "@/shared/ui/components/Skeleton";
 import { Spinner } from "@/shared/ui/components/Spinner";
 import { Markdown } from "@/shared/ui/components/Markdown";
 import { cn, extractTextFromEditorState } from "@/shared/lib/utils";
+import { inferAttachmentMediaKind } from "@/shared/lib/utils/media/inferAttachmentMediaKind";
+import { inferFileVisualKind } from "@/shared/lib/utils/media/inferFileVisualKind";
+import {
+  isLinkedInMessageDocumentMimeType,
+  LINKEDIN_MESSAGE_DOCUMENT_ACCEPT,
+} from "@/shared/lib/utils/media/linkedinMessageAttachmentTypes";
 import {
   Copy,
   Check,
@@ -291,6 +297,23 @@ interface ChatAttachment {
 
 const MAX_CHAT_ATTACHMENTS = 4;
 const MAX_CHAT_ATTACHMENT_BYTES = 512 * 1024 * 1024;
+const MAX_CHAT_DOCUMENT_BYTES = 15 * 1024 * 1024;
+const MAX_CHAT_IMAGE_BYTES = 15 * 1024 * 1024;
+const MAX_CHAT_WEBP_BYTES = 5 * 1024 * 1024;
+const CHAT_IMAGE_MIME_TYPES = new Set([
+  "image/bmp",
+  "image/gif",
+  "image/jpeg",
+  "image/jpg",
+  "image/png",
+  "image/webp",
+]);
+const CHAT_VIDEO_MIME_TYPES = new Set(["video/mp4", "video/quicktime"]);
+const CHAT_ATTACHMENT_ACCEPT = [
+  ...CHAT_IMAGE_MIME_TYPES,
+  ...CHAT_VIDEO_MIME_TYPES,
+  LINKEDIN_MESSAGE_DOCUMENT_ACCEPT,
+].join(",");
 
 function buildStableKey(base: string, sequence: Map<string, number>) {
   const nextCount = (sequence.get(base) ?? 0) + 1;
@@ -372,6 +395,8 @@ export interface AgentChatProps {
   prospectId?: string;
   /** Thread ID to load (from URL) */
   threadId?: string;
+  /** Workspace resolved from the active thread, including setup drafts. */
+  workspaceId?: Id<"workspaces"> | null;
   /** Action mode: "generatePlan" for plan generation */
   action?: string;
   /** Notification ID to mark seen (from URL) */
@@ -1144,6 +1169,7 @@ function AssistantModelBadge({ model }: { model: string }) {
 type DisplayAttachment = {
   id: string;
   fileName: string;
+  mimeType?: string | null;
   mediaUrl: string | null;
   status: "uploading" | "ready";
   sourceLabel?: string;
@@ -1156,6 +1182,7 @@ function buildAttachmentReferenceFromEntity(
   id: string;
   uploadId: string | null;
   fileName: string;
+  mimeType: string | null;
   mediaUrl: string | null;
 } | null {
   if (entity.kind !== "attachment") {
@@ -1166,6 +1193,7 @@ function buildAttachmentReferenceFromEntity(
     id: entity.id,
     uploadId: entity.entityId || null,
     fileName: entity.label,
+    mimeType: entity.attachmentMimeType ?? null,
     mediaUrl: entity.attachmentUrl ?? null,
   };
 }
@@ -1182,6 +1210,7 @@ function buildDisplayAttachmentFromEntity(
   return {
     id: attachment.id,
     fileName: attachment.fileName,
+    mimeType: attachment.mimeType,
     mediaUrl: attachment.mediaUrl,
     status: "ready",
     sourceLabel: "Tagged attachment",
@@ -1190,51 +1219,33 @@ function buildDisplayAttachmentFromEntity(
 }
 
 function inferDisplayAttachmentMediaKind(
-  attachment: Pick<DisplayAttachment, "fileName" | "mediaUrl">
+  attachment: Pick<DisplayAttachment, "fileName" | "mediaUrl" | "mimeType">
 ): "image" | "gif" | "video" | null {
-  const candidates = [attachment.mediaUrl, attachment.fileName].map(
-    (value) => value?.toLowerCase() ?? ""
-  );
-
-  if (candidates.some((value) => /\.(gif)(?:$|[?#])/.test(value))) {
-    return "gif";
-  }
-  if (
-    candidates.some((value) => /\.(mp4|mov|webm|m4v)(?:$|[?#])/.test(value))
-  ) {
-    return "video";
-  }
-  if (
-    candidates.some((value) =>
-      /\.(png|jpe?g|webp|avif|bmp|svg)(?:$|[?#])/.test(value)
-    )
-  ) {
-    return "image";
-  }
-
-  return null;
+  return inferAttachmentMediaKind({
+    mimeType: attachment.mimeType,
+    url: [attachment.fileName, attachment.mediaUrl].filter(Boolean).join(" "),
+  });
 }
 
 function getDisplayAttachmentIcon(
-  attachment: Pick<DisplayAttachment, "fileName" | "mediaUrl">
+  attachment: Pick<DisplayAttachment, "fileName" | "mediaUrl" | "mimeType">
 ) {
-  const fileName = attachment.fileName.toLowerCase();
-  const mediaKind = inferDisplayAttachmentMediaKind(attachment);
+  const visualKind = inferFileVisualKind({
+    fileName: attachment.fileName,
+    mimeType: attachment.mimeType,
+    url: attachment.mediaUrl,
+  });
 
-  if (mediaKind === "video") {
+  if (visualKind === "video") {
     return <FileVideo className="size-4" />;
   }
-  if (mediaKind === "image" || mediaKind === "gif") {
+  if (visualKind === "image") {
     return <FileImage className="size-4" />;
   }
-  if (/\.(csv|tsv|xls|xlsx)(?:$|[?#])/.test(fileName)) {
+  if (visualKind === "spreadsheet") {
     return <FileSpreadsheet className="size-4" />;
   }
-  if (
-    /\.(ts|tsx|js|jsx|json|md|py|go|rs|java|rb|php|css|scss|html)(?:$|[?#])/.test(
-      fileName
-    )
-  ) {
+  if (visualKind === "code") {
     return <FileCode2 className="size-4" />;
   }
 
@@ -2258,6 +2269,7 @@ function ChatSkeleton({
 export function AgentChat({
   prospectId,
   threadId,
+  workspaceId,
   action,
   notificationId: _notificationId,
   onBack,
@@ -2281,6 +2293,7 @@ export function AgentChat({
   const { user: authUser } = useAuth();
   const { workspace: currentWorkspace, isLoading: isWorkspaceLoading } =
     useWorkspace();
+  const effectiveWorkspaceId = workspaceId ?? currentWorkspace?._id ?? null;
 
   const {
     messages,
@@ -2301,7 +2314,7 @@ export function AgentChat({
   } = useAgentChat({
     threadId: threadId ?? null,
     prospectId: prospectId ?? null,
-    workspaceId: currentWorkspace?._id ?? null,
+    workspaceId: effectiveWorkspaceId,
     action: action ?? null,
     newThreadSignal,
     deferSetupHandoff,
@@ -2544,7 +2557,7 @@ export function AgentChat({
             post:
               candidate.postSummary ?? candidate.postData ?? candidate.postRef,
             platformHint: candidate.platform,
-            workspaceId: currentWorkspace?._id ?? undefined,
+            workspaceId: effectiveWorkspaceId ?? undefined,
             prospectId: candidate.prospectId ?? prospectId ?? undefined,
           });
           if (!entity || seenIds.has(entity.id)) {
@@ -2557,7 +2570,7 @@ export function AgentChat({
     }
 
     return collected.slice(0, 8);
-  }, [currentWorkspace?._id, displayMessages, prospectId]);
+  }, [displayMessages, effectiveWorkspaceId, prospectId]);
 
   useEffect(() => {
     setMentionComposerState((current) =>
@@ -2666,12 +2679,47 @@ export function AgentChat({
   const handleAttachFiles = useCallback(
     async (files: FileList | null) => {
       if (!files || files.length === 0) return;
-      const fileArray = Array.from(files).slice(0, MAX_CHAT_ATTACHMENTS);
+      if (!effectiveWorkspaceId) {
+        toast.error("Attachment unavailable", {
+          description: "Select a workspace before uploading an attachment.",
+        });
+        return;
+      }
+
+      const availableSlots = Math.max(
+        0,
+        MAX_CHAT_ATTACHMENTS - chatAttachments.length
+      );
+      if (availableSlots === 0) {
+        toast.error(`Maximum ${MAX_CHAT_ATTACHMENTS} attachments are allowed.`);
+        return;
+      }
+      const fileArray = Array.from(files).slice(0, availableSlots);
 
       for (const file of fileArray) {
-        if (file.size > MAX_CHAT_ATTACHMENT_BYTES) {
+        const normalizedMimeType = file.type.toLowerCase();
+        const isDocument =
+          isLinkedInMessageDocumentMimeType(normalizedMimeType);
+        const isSupportedAttachment =
+          CHAT_IMAGE_MIME_TYPES.has(normalizedMimeType) ||
+          CHAT_VIDEO_MIME_TYPES.has(normalizedMimeType) ||
+          isDocument;
+        if (!isSupportedAttachment) {
+          toast.error("Unsupported attachment", {
+            description: `${file.name} is not supported. Use an image, GIF, video, or supported LinkedIn document.`,
+          });
+          continue;
+        }
+        const maxBytes = isDocument
+          ? MAX_CHAT_DOCUMENT_BYTES
+          : normalizedMimeType === "image/webp"
+            ? MAX_CHAT_WEBP_BYTES
+            : CHAT_IMAGE_MIME_TYPES.has(normalizedMimeType)
+              ? MAX_CHAT_IMAGE_BYTES
+              : MAX_CHAT_ATTACHMENT_BYTES;
+        if (file.size > maxBytes) {
           toast.error("File too large", {
-            description: `${file.name} exceeds 512 MB.`,
+            description: `${file.name} exceeds ${Math.round(maxBytes / (1024 * 1024))} MB.`,
           });
           continue;
         }
@@ -2689,7 +2737,9 @@ export function AgentChat({
         ]);
 
         try {
-          const uploadUrl = await generateUploadUrl();
+          const uploadUrl = await generateUploadUrl({
+            workspaceId: effectiveWorkspaceId,
+          });
           const uploadResponse = await fetch(uploadUrl, {
             method: "POST",
             headers: {
@@ -2708,7 +2758,7 @@ export function AgentChat({
             fileName: file.name,
             mimeType: file.type || "application/octet-stream",
             size: file.size,
-            workspaceId: currentWorkspace?._id,
+            workspaceId: effectiveWorkspaceId,
             displayName: file.name,
           });
 
@@ -2739,7 +2789,12 @@ export function AgentChat({
         }
       }
     },
-    [currentWorkspace?._id, generateUploadUrl, processUploadedMedia]
+    [
+      chatAttachments.length,
+      effectiveWorkspaceId,
+      generateUploadUrl,
+      processUploadedMedia,
+    ]
   );
 
   const handleRemoveAttachment = useCallback((attachmentId: string) => {
@@ -3543,6 +3598,7 @@ export function AgentChat({
             isSetupCollectingAudience
               ? undefined
               : {
+                  workspaceId: effectiveWorkspaceId,
                   prospectId: prospectId ?? null,
                   localEntities: threadPostMentionEntities,
                   remoteAllowedKinds: [
@@ -3572,7 +3628,7 @@ export function AgentChat({
                   ref={attachFileInputRef}
                   type="file"
                   multiple
-                  accept="image/*,video/*"
+                  accept={CHAT_ATTACHMENT_ACCEPT}
                   className="hidden"
                   onChange={(event) => {
                     void handleAttachFiles(event.target.files);

--- a/features/agent/ui/AgentPageShell.tsx
+++ b/features/agent/ui/AgentPageShell.tsx
@@ -1021,6 +1021,16 @@ export function AgentPageShell() {
     setupPanelDraft.setupDraft?.inputPhase === "awaiting_icp_approval"
       ? setupPanelDraft.setupDraft
       : null;
+  const setupWorkspaceId =
+    setupPanelDraft.setupDraft?.targetWorkspaceId ??
+    setupPanelDraft.setupDraft?.existingWorkspaceId ??
+    null;
+  const agentWorkspaceId =
+    threadRouteContext?.kind === "workspace"
+      ? threadRouteContext.workspaceId
+      : isSetupRoute
+        ? setupWorkspaceId
+        : workspaceId;
   const showSetupChatOnly =
     isSetupRoute && isMobile && setupOnboardingPanelOpen;
   const showWorkspaceProfilePanel =
@@ -1046,6 +1056,7 @@ export function AgentPageShell() {
           <AgentChat
             prospectId={prospectId ?? undefined}
             threadId={threadId ?? undefined}
+            workspaceId={agentWorkspaceId}
             action={action ?? undefined}
             notificationId={notificationId ?? undefined}
             threadActionsReady={canUseThreadHistory}

--- a/features/agent/ui/components/AgentDynamicPanel.tsx
+++ b/features/agent/ui/components/AgentDynamicPanel.tsx
@@ -142,7 +142,8 @@ function resolveMediaKind(
   if (
     explicitKind === "image" ||
     explicitKind === "gif" ||
-    explicitKind === "video"
+    explicitKind === "video" ||
+    explicitKind === "file"
   ) {
     return explicitKind;
   }
@@ -513,17 +514,22 @@ export function AgentDynamicPanel({
       ? actionPanelData?.mediaKinds || []
       : taskPanelData?.draft?.mediaKinds || [];
 
-    return mediaUrls.map((url: string, index: number) => ({
-      id: `${isActionRequestPanel ? "action" : "task"}-draft-media-${index}`,
-      url,
-      serverUrl: url,
-      type:
-        resolveMediaKind(mediaKinds[index], url) === "video"
-          ? "video"
-          : "image",
-      mediaKind: resolveMediaKind(mediaKinds[index], url),
-      description: mediaDescriptions[index] || undefined,
-    }));
+    return mediaUrls.map((url: string, index: number) => {
+      const mediaKind = resolveMediaKind(mediaKinds[index], url);
+      return {
+        id: `${isActionRequestPanel ? "action" : "task"}-draft-media-${index}`,
+        url,
+        serverUrl: url,
+        type:
+          mediaKind === "video"
+            ? "video"
+            : mediaKind === "file"
+              ? "file"
+              : "image",
+        mediaKind,
+        description: mediaDescriptions[index] || undefined,
+      };
+    });
   }, [
     actionPanelData?.mediaDescriptions,
     actionPanelData?.mediaKinds,

--- a/features/agent/ui/components/InlineAttachmentPreview.tsx
+++ b/features/agent/ui/components/InlineAttachmentPreview.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import * as React from "react";
+import {
+  FileArchive,
+  FileAudio,
+  FileCode2,
+  FileImage,
+  FileSpreadsheet,
+  FileText,
+  FileVideo,
+  Presentation,
+} from "lucide-react";
+import { inferFileVisualKind } from "@/shared/lib/utils/media/inferFileVisualKind";
+import {
+  Attachment,
+  AttachmentContent,
+  AttachmentDescription,
+  AttachmentMedia,
+  AttachmentTitle,
+  AttachmentTrigger,
+} from "@/shared/ui/components/Attachment";
+import VideoPlayer from "@/features/landing/ui/components/VideoPlayer";
+
+export interface InlineAttachmentPreviewItem {
+  attachmentRef: string;
+  fileName: string;
+  displayName: string;
+  mimeType: string;
+  mediaKind: "image" | "gif" | "video" | "file";
+  size: number;
+  uploadedAt: number;
+  mediaUrl: string;
+}
+
+function getAttachmentIcon(attachment: InlineAttachmentPreviewItem) {
+  const visualKind = inferFileVisualKind({
+    fileName: attachment.fileName,
+    mimeType: attachment.mimeType,
+    url: attachment.mediaUrl,
+  });
+
+  switch (visualKind) {
+    case "archive":
+      return <FileArchive className="size-4" />;
+    case "audio":
+      return <FileAudio className="size-4" />;
+    case "code":
+      return <FileCode2 className="size-4" />;
+    case "image":
+      return <FileImage className="size-4" />;
+    case "presentation":
+      return <Presentation className="size-4" />;
+    case "spreadsheet":
+      return <FileSpreadsheet className="size-4" />;
+    case "video":
+      return <FileVideo className="size-4" />;
+    case "document":
+    case "pdf":
+    default:
+      return <FileText className="size-4" />;
+  }
+}
+
+function InlineAttachmentCard({
+  attachment,
+}: {
+  attachment: InlineAttachmentPreviewItem;
+}) {
+  const visualKind = inferFileVisualKind({
+    fileName: attachment.fileName,
+    mimeType: attachment.mimeType,
+    url: attachment.mediaUrl,
+  });
+  const showsImage = visualKind === "image";
+
+  return (
+    <div className="max-w-md space-y-2">
+      {showsImage ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={attachment.mediaUrl}
+          alt={attachment.displayName}
+          loading="lazy"
+          decoding="async"
+          className="border-border bg-muted/30 max-h-96 w-auto max-w-full rounded-xl border object-contain"
+        />
+      ) : null}
+      {visualKind === "video" ? (
+        <div className="border-border bg-muted/30 aspect-video max-h-96 w-full overflow-hidden rounded-xl border">
+          <VideoPlayer
+            mp4Url={attachment.mediaUrl}
+            ariaLabel={attachment.displayName}
+          />
+        </div>
+      ) : null}
+
+      <Attachment
+        state="done"
+        size="sm"
+        orientation="horizontal"
+        className="border-border bg-card text-card-foreground max-w-sm min-w-0 overflow-hidden rounded-xl shadow-none"
+      >
+        <AttachmentMedia
+          variant={showsImage ? "image" : "icon"}
+          className="bg-muted text-foreground rounded-lg"
+        >
+          {showsImage ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={attachment.mediaUrl} alt="" loading="lazy" />
+          ) : (
+            getAttachmentIcon(attachment)
+          )}
+        </AttachmentMedia>
+        <AttachmentContent>
+          <AttachmentTitle title={attachment.displayName}>
+            {attachment.displayName}
+          </AttachmentTitle>
+          <AttachmentDescription>Workspace attachment</AttachmentDescription>
+        </AttachmentContent>
+        <AttachmentTrigger asChild>
+          <a
+            href={attachment.mediaUrl}
+            target="_blank"
+            rel="noreferrer"
+            aria-label={`Open ${attachment.displayName}`}
+          />
+        </AttachmentTrigger>
+      </Attachment>
+    </div>
+  );
+}
+
+export function InlineAttachmentPreview({
+  attachments,
+}: {
+  attachments: InlineAttachmentPreviewItem[];
+}) {
+  return (
+    <div className="space-y-3">
+      {attachments.map((attachment) => (
+        <InlineAttachmentCard
+          key={attachment.attachmentRef}
+          attachment={attachment}
+        />
+      ))}
+    </div>
+  );
+}

--- a/features/agent/ui/components/InlineReplyApprovalCard.tsx
+++ b/features/agent/ui/components/InlineReplyApprovalCard.tsx
@@ -39,7 +39,7 @@ const FALLBACK_CURRENT_USER: ComposerIdentityUser = {
 
 const EMPTY_MEDIA_URLS: string[] = [];
 const EMPTY_MEDIA_DESCRIPTIONS: string[] = [];
-const EMPTY_MEDIA_KINDS: Array<"image" | "gif" | "video"> = [];
+const EMPTY_MEDIA_KINDS: ComposerMediaKind[] = [];
 
 function isVideoUrl(url: string): boolean {
   return /\.(mp4|mov|m4v|webm)$/i.test(url);
@@ -73,7 +73,7 @@ export interface InlineReplyApprovalCardProps {
   draftContent?: string | null;
   mediaUrls?: string[];
   mediaDescriptions?: string[];
-  mediaKinds?: Array<"image" | "gif" | "video">;
+  mediaKinds?: ComposerMediaKind[];
   sourcePostRef?: TwitterPostRef | null;
   sourcePostSummary?: TwitterPostSummary | null;
   targetTweetId?: string | null;

--- a/features/composer/lib/entityMentions.ts
+++ b/features/composer/lib/entityMentions.ts
@@ -92,8 +92,12 @@ export function buildInitialMediaUploadFromMentionEntity(
     url: entity.attachmentUrl,
     serverUrl: entity.attachmentUrl,
     uploadId: entity.entityId,
-    type: mediaKind === "video" ? "video" : "image",
+    type:
+      mediaKind === "video" ? "video" : mediaKind === "file" ? "file" : "image",
     mediaKind,
+    fileName: entity.label,
+    mimeType: entity.attachmentMimeType ?? undefined,
+    size: entity.attachmentSize ?? undefined,
     description: undefined,
   };
 }

--- a/features/composer/types.ts
+++ b/features/composer/types.ts
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { SerializedEditorState } from "lexical";
+import type { Id } from "@/convex/_generated/dataModel";
 import { Tweet } from "@/features/threads/types";
 import type { InlineAutocompleteContext } from "@/shared/lib/autocomplete/inlineAutocomplete";
 import type {
@@ -10,7 +11,12 @@ import type {
 // Base composer types
 /** `x_post`: X/Twitter weighted length (URLs count as fixed width). `raw`: JavaScript string length. */
 export type ComposerCharacterCountMode = "raw" | "x_post";
-export type ComposerMediaKind = "image" | "gif" | "video";
+export type ComposerMediaKind = "image" | "gif" | "video" | "file";
+export type ComposerUploadType = "image" | "video" | "file";
+export type ComposerAttachmentDestination = {
+  platform: "twitter" | "linkedin";
+  surface: "comment" | "dm";
+};
 
 /** Viewer row in post/reply composer: prefer X connection snapshot, then WorkOS. */
 export type ComposerIdentityUser = {
@@ -65,11 +71,16 @@ export interface ComposerBaseProps {
 }
 
 export interface ComposerEntityMentionsConfig {
+  workspaceId?: Id<"workspaces"> | null;
   remoteAllowedKinds?: MentionEntityKind[];
   localEntities?: MentionEntitySearchResult[];
   personTextMode?: "label" | "handle";
   prospectId?: string | null;
+  attachmentDestination?: ComposerAttachmentDestination;
   onSelectEntity?: (entity: MentionEntitySearchResult) => void;
+  getAttachmentDisabledReason?: (
+    entity: MentionEntitySearchResult
+  ) => string | null;
   buildInsertionText?: (entity: MentionEntitySearchResult) => string | null;
 }
 
@@ -78,8 +89,11 @@ export interface ComposerInitialMediaUpload {
   url?: string;
   serverUrl?: string;
   uploadId?: string;
-  type: "image" | "video";
+  type: ComposerUploadType;
   mediaKind?: ComposerMediaKind;
+  fileName?: string;
+  mimeType?: string;
+  size?: number;
   description?: string;
 }
 
@@ -133,8 +147,9 @@ export interface MediaUpload {
   url?: string; // Local blob URL for preview
   serverUrl?: string; // Server URL for backend access
   uploadId?: string; // Convex upload ID
-  type: "image" | "video";
+  type: ComposerUploadType;
   mediaKind: ComposerMediaKind;
+  size?: number;
   progress: number;
   status: "uploading" | "completed" | "error";
   error?: string;

--- a/features/composer/ui/components/BaseComposer.tsx
+++ b/features/composer/ui/components/BaseComposer.tsx
@@ -9,6 +9,7 @@ import {
   isLikelyToHaveOpenGraph,
 } from "@/shared/lib/utils";
 import { getCurrentUTCTimestamp } from "@/shared/lib/utils/time/timeUtils";
+import { LINKEDIN_MESSAGE_DOCUMENT_MIME_TYPES } from "@/shared/lib/utils/media/linkedinMessageAttachmentTypes";
 import CharacterCounter from "@/shared/ui/components/CharacterCounter";
 import {
   Avatar,
@@ -28,6 +29,7 @@ import { MediaRenderPlugin } from "./MediaRenderPlugin";
 import { MediaPastePlugin } from "./MediaPastePlugin";
 import {
   ComposerBaseProps,
+  ComposerAttachmentDestination,
   ComposerEntityMentionsConfig,
   ComposerInitialMediaUpload,
   ComposerIdentityUser,
@@ -48,6 +50,7 @@ import {
   COMPOSER_PREVIEW_PLACEHOLDER_CLASS,
 } from "@/features/composer/ui/dmComposerClasses";
 import { buildInitialMediaUploadFromMentionEntity } from "../../lib/entityMentions";
+import { useWorkspace } from "@/shared/hooks";
 
 function areMediaUploadsEqual(a: MediaUpload[], b: MediaUpload[]) {
   if (a === b) return true;
@@ -61,6 +64,7 @@ function areMediaUploadsEqual(a: MediaUpload[], b: MediaUpload[]) {
       left.id !== right.id ||
       left.type !== right.type ||
       left.mediaKind !== right.mediaKind ||
+      left.size !== right.size ||
       left.progress !== right.progress ||
       left.status !== right.status ||
       left.error !== right.error ||
@@ -87,13 +91,25 @@ function inferMediaKindFromMimeType(
   if (normalized.startsWith("video/")) {
     return "video";
   }
+  if (LINKEDIN_MESSAGE_DOCUMENT_MIME_TYPES.has(normalized)) {
+    return "file";
+  }
   return "image";
 }
 
 function getComposerSelectionError(
   currentKinds: ComposerMediaKind[],
-  nextKind: ComposerMediaKind
+  nextKind: ComposerMediaKind,
+  destination?: ComposerAttachmentDestination,
+  currentBytes = 0,
+  nextBytes = 0
 ): string | null {
+  if (destination?.platform === "linkedin" && destination.surface === "dm") {
+    if (currentBytes + nextBytes > 20 * 1024 * 1024) {
+      return "LinkedIn DMs allow up to 20 MB total across all attachments.";
+    }
+    return null;
+  }
   const nextKinds = [...currentKinds, nextKind];
   const gifCount = nextKinds.filter((kind) => kind === "gif").length;
   const videoCount = nextKinds.filter((kind) => kind === "video").length;
@@ -119,28 +135,37 @@ function buildInitialMediaUpload(
   attachment: ComposerInitialMediaUpload
 ): MediaUpload {
   const mediaKind =
-    attachment.mediaKind ?? (attachment.type === "video" ? "video" : "image");
+    attachment.mediaKind ??
+    (attachment.type === "video"
+      ? "video"
+      : attachment.type === "file"
+        ? "file"
+        : "image");
+  const fallbackFileName =
+    attachment.type === "video"
+      ? `${attachment.id}.mp4`
+      : attachment.type === "file"
+        ? `${attachment.id}.pdf`
+        : `${attachment.id}.png`;
   return {
     id: attachment.id,
-    file: new File(
-      [],
-      attachment.type === "video"
-        ? `${attachment.id}.mp4`
-        : `${attachment.id}.png`,
-      {
-        type:
-          mediaKind === "gif"
-            ? "image/gif"
-            : attachment.type === "video"
-              ? "video/mp4"
-              : "image/png",
-      }
-    ),
+    file: new File([], attachment.fileName ?? fallbackFileName, {
+      type:
+        attachment.mimeType ??
+        (mediaKind === "gif"
+          ? "image/gif"
+          : attachment.type === "video"
+            ? "video/mp4"
+            : attachment.type === "file"
+              ? "application/pdf"
+              : "image/png"),
+    }),
     url: attachment.url ?? attachment.serverUrl,
     serverUrl: attachment.serverUrl ?? attachment.url,
     uploadId: attachment.uploadId,
     type: attachment.type,
     mediaKind,
+    size: attachment.size,
     progress: 100,
     status: "completed",
     description: attachment.description,
@@ -219,6 +244,7 @@ export function BaseComposer({
   onEditorBlur,
   onEditorFocus,
 }: BaseComposerProps) {
+  const { workspace } = useWorkspace();
   const isPreview = previewMode;
   const interactionDisabled = disabled || isPreview;
   const resolvedContentEditableClassName =
@@ -264,6 +290,9 @@ export function BaseComposer({
     if (allowedMediaKindsSet.has("video")) {
       labels.push("videos");
     }
+    if (allowedMediaKindsSet.has("file")) {
+      labels.push("documents");
+    }
 
     if (labels.length === 0) {
       return "attachments";
@@ -297,6 +326,9 @@ export function BaseComposer({
           uploadId: attachment.uploadId ?? null,
           type: attachment.type,
           mediaKind: attachment.mediaKind ?? null,
+          fileName: attachment.fileName ?? null,
+          mimeType: attachment.mimeType ?? null,
+          size: attachment.size ?? null,
           description: attachment.description ?? null,
         }))
       ),
@@ -316,6 +348,15 @@ export function BaseComposer({
   const handleMentionEntitySelection = useCallback(
     (entity: MentionEntitySearchResult) => {
       if (entity.kind !== "attachment") {
+        return;
+      }
+
+      if (entity.attachmentDisabled) {
+        toast.error("Attachment unavailable", {
+          description:
+            entity.attachmentDisabledReason ??
+            "This attachment is not supported here.",
+        });
         return;
       }
 
@@ -359,7 +400,13 @@ export function BaseComposer({
 
       const selectionError = getComposerSelectionError(
         currentActiveUploads.map((upload) => upload.mediaKind),
-        nextMediaKind
+        nextMediaKind,
+        entityMentions?.attachmentDestination,
+        currentActiveUploads.reduce(
+          (total, upload) => total + (upload.size ?? upload.file.size),
+          0
+        ),
+        initialUpload.size ?? 0
       );
       if (selectionError) {
         toast.error(selectionError);
@@ -371,7 +418,61 @@ export function BaseComposer({
         buildInitialMediaUpload(initialUpload),
       ]);
     },
-    [allowedMediaKindsLabel, allowedMediaKindsSet, maxAttachments, mediaUploads]
+    [
+      allowedMediaKindsLabel,
+      allowedMediaKindsSet,
+      entityMentions?.attachmentDestination,
+      maxAttachments,
+      mediaUploads,
+    ]
+  );
+
+  const getAttachmentDisabledReason = useCallback(
+    (entity: MentionEntitySearchResult): string | null => {
+      if (entity.kind !== "attachment") {
+        return null;
+      }
+      if (entity.attachmentDisabled) {
+        return (
+          entity.attachmentDisabledReason ??
+          "This attachment is not supported here."
+        );
+      }
+
+      const initialUpload = buildInitialMediaUploadFromMentionEntity(entity);
+      const nextMediaKind = initialUpload?.mediaKind;
+      if (!initialUpload?.serverUrl || !nextMediaKind) {
+        return "Attachment unavailable.";
+      }
+      if (!allowedMediaKindsSet.has(nextMediaKind)) {
+        return `This composer only supports ${allowedMediaKindsLabel}.`;
+      }
+
+      const currentActiveUploads = mediaUploads.filter(
+        (upload) => upload.status !== "error"
+      );
+      if (currentActiveUploads.length >= maxAttachments) {
+        return `Maximum ${maxAttachments} attachments are allowed.`;
+      }
+
+      return getComposerSelectionError(
+        currentActiveUploads.map((upload) => upload.mediaKind),
+        nextMediaKind,
+        entityMentions?.attachmentDestination,
+        currentActiveUploads.reduce(
+          (total, upload) => total + (upload.size ?? upload.file.size),
+          0
+        ),
+        initialUpload.size ?? 0
+      );
+    },
+    [
+      allowedMediaKindsLabel,
+      allowedMediaKindsSet,
+      entityMentions?.attachmentDestination,
+      maxAttachments,
+      mediaUploads,
+    ]
   );
 
   const resolvedEntityMentions = useMemo<
@@ -381,13 +482,14 @@ export function BaseComposer({
       entityMentions
         ? {
             ...entityMentions,
+            getAttachmentDisabledReason,
             onSelectEntity: (entity: MentionEntitySearchResult) => {
               handleMentionEntitySelection(entity);
               entityMentions.onSelectEntity?.(entity);
             },
           }
         : undefined,
-    [entityMentions, handleMentionEntitySelection]
+    [entityMentions, getAttachmentDisabledReason, handleMentionEntitySelection]
   );
 
   const handleContentChange = useCallback(
@@ -465,7 +567,7 @@ export function BaseComposer({
     setEditorAPI(api);
   }, []);
 
-  // Frontend media validation config aligned with X (Twitter) limits
+  // Frontend validation mirrors destination capability checks.
   const ALLOWED_IMAGE_TYPES = useMemo(
     () =>
       new Set([
@@ -481,17 +583,24 @@ export function BaseComposer({
     () => new Set(["video/mp4", "video/quicktime"]),
     []
   );
+  const ALLOWED_FILE_TYPES = LINKEDIN_MESSAGE_DOCUMENT_MIME_TYPES;
   const MAX_IMAGE_BYTES = 5 * 1024 * 1024; // 5 MB
   const MAX_GIF_BYTES = 15 * 1024 * 1024; // 15 MB
   const MAX_VIDEO_BYTES = 512 * 1024 * 1024; // 512 MB
+  const MAX_FILE_BYTES = 15 * 1024 * 1024; // 15 MB
   const MAX_ATTACHMENTS = maxAttachments;
 
   const validateFile = useCallback(
     (
       file: File
-    ): { ok: true; kind: "image" | "video" } | { ok: false; error: string } => {
+    ):
+      | { ok: true; kind: "image" | "video" | "file" }
+      | { ok: false; error: string } => {
       const type = (file.type || "").toLowerCase();
       const mediaKind = inferMediaKindFromMimeType(type);
+      const isLinkedInDm =
+        entityMentions?.attachmentDestination?.platform === "linkedin" &&
+        entityMentions.attachmentDestination.surface === "dm";
 
       if (!allowedMediaKindsSet.has(mediaKind)) {
         return {
@@ -511,10 +620,10 @@ export function BaseComposer({
             } as const;
           }
         } else {
-          if (file.size > MAX_IMAGE_BYTES) {
+          if (file.size > (isLinkedInDm ? MAX_FILE_BYTES : MAX_IMAGE_BYTES)) {
             return {
               ok: false,
-              error: "Image exceeds 5 MB.",
+              error: `Image exceeds ${isLinkedInDm ? "15 MB" : "5 MB"}.`,
             } as const;
           }
         }
@@ -522,33 +631,53 @@ export function BaseComposer({
       }
 
       if (ALLOWED_VIDEO_TYPES.has(type)) {
-        if (file.size > MAX_VIDEO_BYTES) {
+        if (file.size > (isLinkedInDm ? MAX_FILE_BYTES : MAX_VIDEO_BYTES)) {
           return {
             ok: false,
-            error: "Video exceeds 512 MB.",
+            error: `Video exceeds ${isLinkedInDm ? "15 MB" : "512 MB"}.`,
           } as const;
         }
         return { ok: true, kind: "video" } as const;
       }
 
+      if (ALLOWED_FILE_TYPES.has(type)) {
+        if (file.size > MAX_FILE_BYTES) {
+          return {
+            ok: false,
+            error: "Document exceeds 15 MB.",
+          } as const;
+        }
+        return { ok: true, kind: "file" } as const;
+      }
+
       return {
         ok: false,
-        error: "Invalid format. Allowed: JPG, PNG, WEBP, GIF; MP4, MOV.",
+        error:
+          "Invalid format. Allowed: JPG, PNG, WEBP, GIF; MP4, MOV; CSV, XLS, XLSX, DOC, DOCX, PPT, PPTX, PDF, TXT.",
       } as const;
     },
     [
       ALLOWED_IMAGE_TYPES,
       ALLOWED_VIDEO_TYPES,
+      MAX_FILE_BYTES,
       MAX_GIF_BYTES,
       MAX_IMAGE_BYTES,
       MAX_VIDEO_BYTES,
       allowedMediaKindsLabel,
       allowedMediaKindsSet,
+      entityMentions?.attachmentDestination,
     ]
   );
 
   const handleMediaUpload = useCallback(
     async (files: FileList | File[]) => {
+      if (!workspace?._id) {
+        toast.error("Attachment unavailable", {
+          description: "Select a workspace before uploading an attachment.",
+        });
+        return;
+      }
+
       const fileArray = Array.isArray(files) ? files : Array.from(files);
 
       // Count current active (non-error) attachments for the 4-item cap
@@ -569,8 +698,14 @@ export function BaseComposer({
           prepared.push({
             id,
             file,
-            type: mediaKind === "video" ? "video" : "image",
+            type:
+              mediaKind === "video"
+                ? "video"
+                : mediaKind === "file"
+                  ? "file"
+                  : "image",
             mediaKind,
+            size: file.size,
             progress: 0,
             status: "error",
             error: validation.error,
@@ -587,9 +722,19 @@ export function BaseComposer({
             .filter((upload) => upload.status !== "error")
             .map((upload) => upload.mediaKind),
         ];
+        const activeBytes = [
+          ...mediaUploads.filter((upload) => upload.status !== "error"),
+          ...prepared.filter((upload) => upload.status !== "error"),
+        ].reduce(
+          (total, upload) => total + (upload.size ?? upload.file.size),
+          0
+        );
         const selectionError = getComposerSelectionError(
           activeKinds,
-          mediaKind
+          mediaKind,
+          entityMentions?.attachmentDestination,
+          activeBytes,
+          file.size
         );
         if (selectionError) {
           prepared.push({
@@ -623,6 +768,7 @@ export function BaseComposer({
           file,
           type: validation.kind,
           mediaKind,
+          size: file.size,
           progress: 0,
           status: "uploading",
           url: URL.createObjectURL(file),
@@ -641,7 +787,9 @@ export function BaseComposer({
 
         try {
           // Step 1: Generate upload URL
-          const uploadUrl = await generateUploadUrl();
+          const uploadUrl = await generateUploadUrl({
+            workspaceId: workspace._id,
+          });
 
           // Step 2: Upload file with XHR to get real progress events
           const storageIdString = await new Promise<string>(
@@ -726,6 +874,7 @@ export function BaseComposer({
             fileName: upload.file.name,
             mimeType: upload.file.type,
             size: upload.file.size,
+            workspaceId: workspace._id,
           });
 
           if (processingTimer) clearInterval(processingTimer);
@@ -767,6 +916,8 @@ export function BaseComposer({
       processUploadedMedia,
       mediaUploads,
       validateFile,
+      workspace?._id,
+      entityMentions?.attachmentDestination,
     ]
   );
 

--- a/features/composer/ui/components/MediaUploadSection.tsx
+++ b/features/composer/ui/components/MediaUploadSection.tsx
@@ -15,7 +15,18 @@ import {
   AutorenewIcon,
   CloseIcon,
   EditIcon,
+  PictureAsPdfIcon,
 } from "@/shared/ui/components/icons";
+import { FileText } from "lucide-react";
+import {
+  Attachment,
+  AttachmentAction,
+  AttachmentActions,
+  AttachmentContent,
+  AttachmentDescription,
+  AttachmentMedia,
+  AttachmentTitle,
+} from "@/shared/ui/components/Attachment";
 
 interface MediaUploadSectionProps {
   uploads: MediaUpload[];
@@ -114,6 +125,10 @@ export function MediaUploadSection({
 
       const file = upload.file;
       if (!file) return;
+      if (upload.type === "file") {
+        measuredAspectIds.add(upload.id);
+        return;
+      }
 
       try {
         pendingAspectIds.add(upload.id);
@@ -203,66 +218,97 @@ export function MediaUploadSection({
         <div key={upload.id}>
           {upload.status !== "error" && (
             <>
-              {/* Media Preview */}
-              <div
-                className="border-border relative w-full overflow-hidden rounded-md border"
-                style={{ aspectRatio: aspectById[upload.id] ?? "16 / 9" }}
-              >
-                {upload.type === "image" && upload.url ? (
-                  upload.url.startsWith("blob:") ? (
-                    <Image
+              {upload.type === "file" ? (
+                <Attachment
+                  className="w-full"
+                  state={upload.status === "uploading" ? "uploading" : "done"}
+                >
+                  <AttachmentMedia>
+                    {upload.file.type.toLowerCase() === "application/pdf" ? (
+                      <PictureAsPdfIcon className="fill-current" />
+                    ) : (
+                      <FileText className="size-4" />
+                    )}
+                  </AttachmentMedia>
+                  <AttachmentContent>
+                    <AttachmentTitle>{upload.file.name}</AttachmentTitle>
+                    <AttachmentDescription>
+                      {upload.file.type.toLowerCase() === "application/pdf"
+                        ? "PDF"
+                        : "Document"}
+                    </AttachmentDescription>
+                  </AttachmentContent>
+                  <AttachmentActions>
+                    <AttachmentAction
+                      type="button"
+                      onClick={() => onRemove?.(upload.id)}
+                      aria-label={`Remove ${upload.file.name}`}
+                    >
+                      <CloseIcon className="fill-current" />
+                    </AttachmentAction>
+                  </AttachmentActions>
+                </Attachment>
+              ) : (
+                <div
+                  className="border-border relative w-full overflow-hidden rounded-md border"
+                  style={{ aspectRatio: aspectById[upload.id] ?? "16 / 9" }}
+                >
+                  {upload.type === "image" && upload.url ? (
+                    upload.url.startsWith("blob:") ? (
+                      <Image
+                        src={upload.url}
+                        alt="Uploaded media"
+                        fill
+                        className="object-cover"
+                        sizes="100vw"
+                        onLoad={() => {
+                          // next/image doesn't expose natural size in event target; precomputed aspect used
+                        }}
+                      />
+                    ) : (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={upload.url}
+                        alt="Uploaded media"
+                        className="h-full w-full object-cover"
+                      />
+                    )
+                  ) : null}
+                  {upload.type === "video" && upload.url && (
+                    <video
                       src={upload.url}
-                      alt="Uploaded media"
-                      fill
-                      className="object-cover"
-                      sizes="100vw"
-                      onLoad={() => {
-                        // next/image doesn't expose natural size in event target; precomputed aspect used
+                      className="h-full w-full object-cover"
+                      controls
+                      aria-label="Uploaded video preview"
+                      onLoadedMetadata={(e) => {
+                        const video = e.currentTarget as HTMLVideoElement;
+                        setAspectById((prev) => ({
+                          ...prev,
+                          [upload.id]: chooseNearestAspect(
+                            video.videoWidth,
+                            video.videoHeight
+                          ),
+                        }));
                       }}
                     />
-                  ) : (
-                    // eslint-disable-next-line @next/next/no-img-element
-                    <img
-                      src={upload.url}
-                      alt="Uploaded media"
-                      className="h-full w-full object-cover"
-                    />
-                  )
-                ) : null}
-                {upload.type === "video" && upload.url && (
-                  <video
-                    src={upload.url}
-                    className="h-full w-full object-cover"
-                    controls
-                    aria-label="Uploaded video preview"
-                    onLoadedMetadata={(e) => {
-                      const video = e.currentTarget as HTMLVideoElement;
-                      setAspectById((prev) => ({
-                        ...prev,
-                        [upload.id]: chooseNearestAspect(
-                          video.videoWidth,
-                          video.videoHeight
-                        ),
-                      }));
-                    }}
-                  />
-                )}
-                {!upload.url && (
-                  <Skeleton className="absolute inset-0 h-full w-full" />
-                )}
+                  )}
+                  {!upload.url && (
+                    <Skeleton className="absolute inset-0 h-full w-full" />
+                  )}
 
-                {/* Remove Button */}
-                <Button
-                  variant="outline"
-                  size="xsIcon"
-                  type="button"
-                  onClick={() => onRemove?.(upload.id)}
-                  className="absolute top-2 right-2"
-                  aria-label="Remove media"
-                >
-                  <CloseIcon className="fill-current" />
-                </Button>
-              </div>
+                  {/* Remove Button */}
+                  <Button
+                    variant="outline"
+                    size="xsIcon"
+                    type="button"
+                    onClick={() => onRemove?.(upload.id)}
+                    className="absolute top-2 right-2"
+                    aria-label="Remove media"
+                  >
+                    <CloseIcon className="fill-current" />
+                  </Button>
+                </div>
+              )}
 
               {/* Status + optional description (posts/replies); DMs omit description */}
               {(upload.status === "uploading" || showDescription) && (

--- a/features/composer/ui/components/ReplyComposer.tsx
+++ b/features/composer/ui/components/ReplyComposer.tsx
@@ -13,7 +13,7 @@ import { SerializedEditorState } from "lexical";
 import Link from "next/link";
 import { toast } from "sonner";
 import { BaseComposer } from "./BaseComposer";
-import { ReplyComposerProps } from "../../types";
+import type { ComposerMediaKind, ReplyComposerProps } from "../../types";
 import { logger } from "@/shared/lib/logger";
 import type { MentionEntitySearchResult } from "@/shared/lib/mentions/mentionEntities";
 import { buildPostMentionEntity } from "@/shared/lib/mentions/postMentions";
@@ -131,7 +131,7 @@ export function ReplyComposer({
     content: SerializedEditorState,
     mediaUrls?: string[],
     mediaDescriptions?: string[],
-    mediaKinds?: ("image" | "gif" | "video")[]
+    mediaKinds?: ComposerMediaKind[]
   ) => {
     try {
       await onSubmit?.(content, mediaUrls, mediaDescriptions, mediaKinds);
@@ -189,6 +189,10 @@ export function ReplyComposer({
       }}
       entityMentions={{
         prospectId,
+        attachmentDestination: {
+          platform: "twitter",
+          surface: "comment",
+        },
         remoteAllowedKinds: prospectId
           ? ["post", "attachment"]
           : ["attachment"],

--- a/features/composer/ui/components/mentions/MentionsPlugin.tsx
+++ b/features/composer/ui/components/mentions/MentionsPlugin.tsx
@@ -180,19 +180,37 @@ export function MentionsPlugin({
   const { results, loading } = useMentionEntitySearch({
     enabled: queryString !== null,
     query: queryString,
-    workspaceId: workspace?._id ?? null,
+    workspaceId: entityMentions?.workspaceId ?? workspace?._id ?? null,
     prospectId,
     limit: SUGGESTION_LIST_LENGTH_LIMIT,
     remoteAllowedKinds: activeRemoteAllowedKinds,
     localEntities: activeLocalEntities,
+    attachmentDestination: entityMentions?.attachmentDestination,
   });
-  const visibleResults = React.useMemo(
-    () =>
+  const visibleResults = React.useMemo(() => {
+    const filteredResults =
       activeFilter === "all"
         ? results
-        : results.filter((result) => result.kind === activeFilter),
-    [activeFilter, results]
-  );
+        : results.filter((result) => result.kind === activeFilter);
+
+    return filteredResults.map((result) => {
+      if (result.kind !== "attachment") {
+        return result;
+      }
+
+      const localDisabledReason =
+        entityMentions?.getAttachmentDisabledReason?.(result) ?? null;
+      if (!localDisabledReason) {
+        return result;
+      }
+
+      return {
+        ...result,
+        attachmentDisabled: true,
+        attachmentDisabledReason: localDisabledReason,
+      };
+    });
+  }, [activeFilter, entityMentions, results]);
 
   React.useEffect(
     () => () => {
@@ -245,6 +263,10 @@ export function MentionsPlugin({
       nodeToReplace: TextNode | null,
       closeMenu: () => void
     ) => {
+      if (selectedOption.entity.attachmentDisabled) {
+        return;
+      }
+
       const replacementText =
         entityMentions?.buildInsertionText?.(selectedOption.entity) ??
         buildComposerMentionInsertionText({

--- a/features/prospects/ui/components/LinkedInConversationPanel.tsx
+++ b/features/prospects/ui/components/LinkedInConversationPanel.tsx
@@ -185,17 +185,22 @@ export function LinkedInConversationPanel({
 
   const initialMediaUploads = React.useMemo<ComposerInitialMediaUpload[]>(
     () =>
-      (taskDraft?.mediaUrls ?? []).map((url, index) => ({
-        id: `linkedin-task-dm-media-${index}`,
-        url,
-        serverUrl: url,
-        type:
-          (taskDraft?.mediaKinds?.[index] ?? "image") === "video"
-            ? "video"
-            : "image",
-        mediaKind: taskDraft?.mediaKinds?.[index] ?? "image",
-        description: taskDraft?.mediaDescriptions?.[index] ?? undefined,
-      })),
+      (taskDraft?.mediaUrls ?? []).map((url, index) => {
+        const mediaKind = taskDraft?.mediaKinds?.[index] ?? "image";
+        return {
+          id: `linkedin-task-dm-media-${index}`,
+          url,
+          serverUrl: url,
+          type:
+            mediaKind === "video"
+              ? "video"
+              : mediaKind === "file"
+                ? "file"
+                : "image",
+          mediaKind,
+          description: taskDraft?.mediaDescriptions?.[index] ?? undefined,
+        };
+      }),
     [taskDraft?.mediaDescriptions, taskDraft?.mediaKinds, taskDraft?.mediaUrls]
   );
 
@@ -728,6 +733,7 @@ export function LinkedInConversationPanel({
               showIdentityHeader={false}
               showMediaDescription={false}
               showMediaUpload
+              allowedMediaKinds={["image", "gif", "video", "file"]}
               maxAttachments={4}
               disabled={shouldDisableComposer}
               submitDisabled={shouldDisableTaskSubmit}
@@ -750,6 +756,10 @@ export function LinkedInConversationPanel({
               }}
               entityMentions={{
                 prospectId,
+                attachmentDestination: {
+                  platform: "linkedin",
+                  surface: "dm",
+                },
                 remoteAllowedKinds: ["prospect", "post", "attachment"],
                 personTextMode: "label",
               }}

--- a/features/prospects/ui/components/XConversationPanel.tsx
+++ b/features/prospects/ui/components/XConversationPanel.tsx
@@ -666,6 +666,10 @@ export function XConversationPanel({
               }}
               entityMentions={{
                 prospectId,
+                attachmentDestination: {
+                  platform: "twitter",
+                  surface: "dm",
+                },
                 remoteAllowedKinds: ["prospect", "post", "attachment"],
                 personTextMode: "handle",
               }}

--- a/features/webapp/ui/components/linkedin/LinkedInReplyComposer.tsx
+++ b/features/webapp/ui/components/linkedin/LinkedInReplyComposer.tsx
@@ -105,6 +105,10 @@ export function LinkedInReplyComposer({
         }}
         entityMentions={{
           prospectId,
+          attachmentDestination: {
+            platform: "linkedin",
+            surface: "comment",
+          },
           remoteAllowedKinds: prospectId
             ? ["prospect", "post", "attachment"]
             : ["attachment"],

--- a/shared/hooks/useMentionEntitySearch.ts
+++ b/shared/hooks/useMentionEntitySearch.ts
@@ -25,12 +25,19 @@ function buildMentionEntityCacheKey(args: {
   prospectId?: string | null;
   limit?: number;
   remoteAllowedKinds?: MentionEntityKind[];
+  attachmentDestination?: {
+    platform: "twitter" | "linkedin";
+    surface: "comment" | "dm";
+  };
 }) {
   return [
     args.workspaceId ?? "workspace:none",
     args.prospectId ?? "prospect:none",
     args.limit ?? "limit:8",
     args.remoteAllowedKinds?.join(",") ?? "kinds:all",
+    args.attachmentDestination
+      ? `${args.attachmentDestination.platform}:${args.attachmentDestination.surface}`
+      : "destination:none",
     args.query ?? "",
   ].join("::");
 }
@@ -65,17 +72,30 @@ export function useMentionEntitySearch(args: {
   limit?: number;
   remoteAllowedKinds?: MentionEntityKind[];
   localEntities?: MentionEntitySearchResult[];
+  attachmentDestination?: {
+    platform: "twitter" | "linkedin";
+    surface: "comment" | "dm";
+  };
 }) {
+  const {
+    enabled,
+    query,
+    workspaceId,
+    prospectId,
+    limit,
+    remoteAllowedKinds,
+    localEntities,
+    attachmentDestination,
+  } = args;
   const convex = useConvex();
   const [results, setResults] = useState<MentionEntitySearchResult[]>([]);
   const [loading, setLoading] = useState(false);
-  const localEntitySignature = buildMentionEntityContentSignature(
-    args.localEntities
-  );
-  const remoteAllowedKindsSignature = args.remoteAllowedKinds?.join(",") ?? "";
+  const localEntitySignature =
+    buildMentionEntityContentSignature(localEntities);
+  const remoteAllowedKindsSignature = remoteAllowedKinds?.join(",") ?? "";
 
   useEffect(() => {
-    if (!args.enabled || args.query === null) {
+    if (!enabled || query === null) {
       const timeoutId = window.setTimeout(() => {
         setResults([]);
         setLoading(false);
@@ -84,14 +104,13 @@ export function useMentionEntitySearch(args: {
     }
 
     const localResults = getLocalMentionResults({
-      query: args.query,
-      limit: args.limit,
-      localEntities: args.localEntities,
+      query,
+      limit,
+      localEntities,
     });
-    const resultLimit = Math.max(1, Math.min(12, args.limit ?? 8));
+    const resultLimit = Math.max(1, Math.min(12, limit ?? 8));
     const shouldQueryRemote =
-      args.remoteAllowedKinds === undefined ||
-      args.remoteAllowedKinds.length > 0;
+      remoteAllowedKinds === undefined || remoteAllowedKinds.length > 0;
 
     if (!shouldQueryRemote) {
       const timeoutId = window.setTimeout(() => {
@@ -101,7 +120,14 @@ export function useMentionEntitySearch(args: {
       return () => window.clearTimeout(timeoutId);
     }
 
-    const cacheKey = buildMentionEntityCacheKey(args);
+    const cacheKey = buildMentionEntityCacheKey({
+      query,
+      workspaceId,
+      prospectId,
+      limit,
+      remoteAllowedKinds,
+      attachmentDestination,
+    });
     const cachedResults = mentionEntityCache.get(cacheKey);
 
     if (cachedResults === null) {
@@ -137,15 +163,14 @@ export function useMentionEntitySearch(args: {
 
     void convex
       .query(api.mediaMentions.searchMentionEntities, {
-        query: args.query,
-        workspaceId: args.workspaceId
-          ? (args.workspaceId as Id<"workspaces">)
+        query,
+        workspaceId: workspaceId
+          ? (workspaceId as Id<"workspaces">)
           : undefined,
-        prospectId: args.prospectId
-          ? (args.prospectId as Id<"prospects">)
-          : undefined,
-        limit: args.limit,
-        allowedKinds: args.remoteAllowedKinds,
+        prospectId: prospectId ? (prospectId as Id<"prospects">) : undefined,
+        limit,
+        allowedKinds: remoteAllowedKinds,
+        attachmentDestination,
       })
       .then((nextResults) => {
         if (cancelled) {
@@ -184,13 +209,16 @@ export function useMentionEntitySearch(args: {
       window.clearTimeout(loadingTimeoutId);
     };
   }, [
-    args.enabled,
-    args.limit,
-    args.prospectId,
-    args.query,
-    args.workspaceId,
+    enabled,
+    limit,
+    prospectId,
+    query,
+    workspaceId,
+    attachmentDestination,
     convex,
+    localEntities,
     localEntitySignature,
+    remoteAllowedKinds,
     remoteAllowedKindsSignature,
   ]);
 

--- a/shared/lib/json-render/agentArtifacts.ts
+++ b/shared/lib/json-render/agentArtifacts.ts
@@ -227,6 +227,24 @@ export const agentArtifactCatalog = defineCatalog(schema, {
       description:
         "Displays an inline DM preview card for a staged X message draft with send/cancel/open actions.",
     },
+    AttachmentPreview: {
+      props: z.object({
+        attachments: z.array(
+          z.object({
+            attachmentRef: z.string(),
+            fileName: z.string(),
+            displayName: z.string(),
+            mimeType: z.string(),
+            mediaKind: z.enum(["image", "gif", "video", "file"]),
+            size: z.number(),
+            uploadedAt: z.number(),
+            mediaUrl: z.string(),
+          })
+        ),
+      }),
+      description:
+        "Displays workspace attachments inline using the existing attachment presentation.",
+    },
   },
   actions: {},
 });
@@ -369,6 +387,21 @@ export function getAgentArtifactSemanticKey(
   if (type === "WorkspaceProfileChangeCard") {
     const requestId = getStringProperty(props, "requestId");
     return requestId ? `${type}:${requestId}` : null;
+  }
+
+  if (type === "AttachmentPreview") {
+    const attachments = props.attachments;
+    if (!Array.isArray(attachments)) return null;
+    const attachmentRefs = attachments
+      .map((attachment) =>
+        isRecord(attachment)
+          ? getStringProperty(attachment, "attachmentRef")
+          : null
+      )
+      .filter((value): value is string => value !== null);
+    return attachmentRefs.length > 0
+      ? `${type}:${attachmentRefs.join(",")}`
+      : null;
   }
 
   return null;
@@ -762,5 +795,22 @@ export function createDmDraftArtifact(input: {
     message: input.message ?? null,
     status: input.status,
     draftContent: input.draftContent ?? null,
+  });
+}
+
+export function createAttachmentPreviewArtifact(input: {
+  attachments: Array<{
+    attachmentRef: string;
+    fileName: string;
+    displayName: string;
+    mimeType: string;
+    mediaKind: "image" | "gif" | "video" | "file";
+    size: number;
+    uploadedAt: number;
+    mediaUrl: string;
+  }>;
+}) {
+  return createAgentArtifact("AttachmentPreview", {
+    attachments: input.attachments,
   });
 }

--- a/shared/lib/mentions/mentionEntities.ts
+++ b/shared/lib/mentions/mentionEntities.ts
@@ -8,7 +8,7 @@ export type MentionEntityKind =
   | "attachment"
   | "post";
 
-export type MentionAttachmentMediaKind = "image" | "gif" | "video";
+export type MentionAttachmentMediaKind = "image" | "gif" | "video" | "file";
 export type MentionPostPlatform = "twitter" | "linkedin";
 
 export interface MentionEntitySearchResult {
@@ -28,7 +28,10 @@ export interface MentionEntitySearchResult {
   taskId?: string;
   attachmentUrl?: string | null;
   attachmentMimeType?: string | null;
+  attachmentSize?: number | null;
   attachmentMediaKind?: MentionAttachmentMediaKind | null;
+  attachmentDisabled?: boolean;
+  attachmentDisabledReason?: string | null;
   postId?: string;
   postUrl?: string | null;
   postPlatform?: MentionPostPlatform | null;
@@ -280,10 +283,19 @@ export function normalizeMentionEntitySearchResult(
     taskId: coerceOptionalString(value.taskId),
     attachmentUrl: coerceOptionalString(value.attachmentUrl) ?? null,
     attachmentMimeType: coerceOptionalString(value.attachmentMimeType) ?? null,
+    attachmentSize:
+      typeof value.attachmentSize === "number" &&
+      Number.isFinite(value.attachmentSize) &&
+      value.attachmentSize >= 0
+        ? value.attachmentSize
+        : null,
     attachmentMediaKind:
       (coerceOptionalString(value.attachmentMediaKind) as
         | MentionAttachmentMediaKind
         | undefined) ?? null,
+    attachmentDisabled: value.attachmentDisabled === true,
+    attachmentDisabledReason:
+      coerceOptionalString(value.attachmentDisabledReason) ?? null,
     postId,
     postUrl,
     postPlatform,

--- a/shared/lib/utils/media/linkedinMessageAttachmentTypes.ts
+++ b/shared/lib/utils/media/linkedinMessageAttachmentTypes.ts
@@ -1,0 +1,23 @@
+export const LINKEDIN_MESSAGE_DOCUMENT_MIME_TYPES = new Set([
+  "application/msword",
+  "application/pdf",
+  "application/vnd.ms-excel",
+  "application/vnd.ms-powerpoint",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "text/csv",
+  "text/plain",
+]);
+
+export const LINKEDIN_MESSAGE_DOCUMENT_ACCEPT = [
+  ...LINKEDIN_MESSAGE_DOCUMENT_MIME_TYPES,
+].join(",");
+
+export function isLinkedInMessageDocumentMimeType(
+  mimeType: string | null | undefined
+): boolean {
+  return LINKEDIN_MESSAGE_DOCUMENT_MIME_TYPES.has(
+    mimeType?.trim().toLowerCase() ?? ""
+  );
+}

--- a/shared/ui/components/json-render/AgentArtifactRenderer.tsx
+++ b/shared/ui/components/json-render/AgentArtifactRenderer.tsx
@@ -28,6 +28,7 @@ import {
   type OutreachPlanCardTask,
 } from "@/features/prospects/ui/components/outreach-plan";
 import { InlineDmPreviewCard } from "@/features/agent/ui/components/InlineDmPreviewCard";
+import { InlineAttachmentPreview } from "@/features/agent/ui/components/InlineAttachmentPreview";
 import { cn } from "@/shared/lib/utils";
 import { Button } from "@/shared/ui/components/Button";
 import {
@@ -857,6 +858,9 @@ const { registry } = defineRegistry(agentArtifactCatalog, {
       <TwitterActionArtifactCard props={props} />
     ),
     DmDraftCard: ({ props }) => <DmDraftArtifactCard props={props} />,
+    AttachmentPreview: ({ props }) => (
+      <InlineAttachmentPreview attachments={props.attachments} />
+    ),
   },
 });
 

--- a/shared/ui/components/mentions/MentionEntityMenu.tsx
+++ b/shared/ui/components/mentions/MentionEntityMenu.tsx
@@ -179,7 +179,8 @@ function MentionEntityVisual({
             width={36}
             height={36}
             sizes="36px"
-            loading="lazy"
+            loading="eager"
+            unoptimized
           />
         ) : (
           getAttachmentIcon(entity)
@@ -297,11 +298,15 @@ export function MentionEntityMenu({
             id={getOptionId?.(item, index)}
             role="option"
             type="button"
+            disabled={item.attachmentDisabled === true}
             className={cn(
               "hover:bg-muted flex w-full items-center gap-3 rounded-lg px-2 py-2 text-left transition-colors",
-              selectedIndex === index && "bg-muted"
+              selectedIndex === index && "bg-muted",
+              item.attachmentDisabled &&
+                "cursor-not-allowed opacity-50 hover:bg-transparent"
             )}
             aria-selected={selectedIndex === index}
+            aria-disabled={item.attachmentDisabled === true}
             onMouseDown={(event) => event.preventDefault()}
             onMouseEnter={() => onHover?.(index)}
             onClick={() => onSelect(item)}
@@ -319,8 +324,11 @@ export function MentionEntityMenu({
                   />
                 ) : null}
               </div>
-              <div className="text-muted-foreground truncate text-xs">
-                {item.secondaryLabel}
+              <div
+                className="text-muted-foreground truncate text-xs"
+                title={item.attachmentDisabledReason ?? undefined}
+              >
+                {item.attachmentDisabledReason ?? item.secondaryLabel}
               </div>
             </div>
           </button>

--- a/tests/agent-artifact-deduplication.test.ts
+++ b/tests/agent-artifact-deduplication.test.ts
@@ -7,9 +7,28 @@ import {
   getToolResultArtifactSemanticKeys,
 } from "../features/agent/lib/toolArtifacts";
 import {
+  createAttachmentPreviewArtifact,
   createPlanPreviewArtifact,
   getAgentArtifactSemanticKey,
 } from "../shared/lib/json-render/agentArtifacts";
+
+function createAttachmentArtifact(...attachmentRefs: string[]) {
+  const artifact = createAttachmentPreviewArtifact({
+    attachments: attachmentRefs.map((attachmentRef, index) => ({
+      attachmentRef,
+      fileName: `file-${index + 1}.png`,
+      displayName: `File ${index + 1}`,
+      mimeType: "image/png",
+      mediaKind: "image",
+      size: 128,
+      uploadedAt: index + 1,
+      mediaUrl: `https://example.com/file-${index + 1}.png`,
+    })),
+  });
+
+  assert.ok(artifact);
+  return artifact;
+}
 
 function createPlanArtifact(planId: string, rationale: string) {
   const artifact = createPlanPreviewArtifact({
@@ -42,6 +61,16 @@ test("duplicate plan artifacts inside one tool result render once", () => {
   assert.deepEqual(getToolResultArtifactSemanticKeys({ artifact }), [
     "PlanPreviewCard:plan-1",
   ]);
+});
+
+test("attachment preview artifacts preserve ordered attachment identity", () => {
+  const artifact = createAttachmentArtifact("attachment_2", "attachment_1");
+
+  assert.equal(
+    getAgentArtifactSemanticKey(artifact),
+    "AttachmentPreview:attachment_2,attachment_1"
+  );
+  assert.equal(getAgentArtifactsFromToolResult({ artifact }).length, 1);
 });
 
 test("only the latest copy of the same plan artifact remains visible per turn", () => {

--- a/tests/agent-attachment-references.test.ts
+++ b/tests/agent-attachment-references.test.ts
@@ -41,7 +41,7 @@ test("attachment reference context distinguishes current and reusable files", ()
   const context = buildAgentAttachmentReferenceContext([demoReference]);
 
   assert.match(context ?? "", /attachment_1: demo\.mp4/);
-  assert.match(context ?? "", /selected earlier in this prospect thread/);
+  assert.match(context ?? "", /selected earlier in this thread/);
   assert.match(context ?? "", /Never put storage URLs or upload IDs/);
 });
 

--- a/tests/entity-mentions.test.ts
+++ b/tests/entity-mentions.test.ts
@@ -97,6 +97,7 @@ test("composer mention helpers use scoped handles, post URLs, and attachment upl
     attachmentUrl: "https://cdn.example.com/candidates-use-case.jpg",
     attachmentMimeType: "image/jpeg",
     attachmentMediaKind: "image",
+    attachmentSize: 2048,
   };
 
   assert.equal(
@@ -125,6 +126,49 @@ test("composer mention helpers use scoped handles, post URLs, and attachment upl
     uploadId: "file-1",
     type: "image",
     mediaKind: "image",
+    fileName: "candidates-use-case.jpg",
+    mimeType: "image/jpeg",
+    size: 2048,
+    description: undefined,
+  });
+});
+
+test("attachment mention normalization preserves disabled PDF metadata", () => {
+  const attachment = normalizeMentionEntitySearchResult({
+    id: "attachment:file-2",
+    entityId: "file-2",
+    kind: "attachment",
+    label: "results.pdf",
+    mentionText: "Attachment: results.pdf",
+    secondaryLabel: "Workspace attachment",
+    avatarUrl: null,
+    verified: false,
+    attachmentUrl: "https://cdn.example.com/results.pdf",
+    attachmentMimeType: "application/pdf",
+    attachmentMediaKind: "file",
+    attachmentSize: 4096,
+    attachmentDisabled: true,
+    attachmentDisabledReason: "results.pdf cannot be attached to X/Twitter.",
+  });
+
+  assert.ok(attachment);
+  assert.equal(attachment.attachmentMediaKind, "file");
+  assert.equal(attachment.attachmentSize, 4096);
+  assert.equal(attachment.attachmentDisabled, true);
+  assert.equal(
+    attachment.attachmentDisabledReason,
+    "results.pdf cannot be attached to X/Twitter."
+  );
+  assert.deepEqual(buildInitialMediaUploadFromMentionEntity(attachment), {
+    id: "mention-attachment:file-2",
+    url: "https://cdn.example.com/results.pdf",
+    serverUrl: "https://cdn.example.com/results.pdf",
+    uploadId: "file-2",
+    type: "file",
+    mediaKind: "file",
+    fileName: "results.pdf",
+    mimeType: "application/pdf",
+    size: 4096,
     description: undefined,
   });
 });

--- a/tests/media-capability-core.test.ts
+++ b/tests/media-capability-core.test.ts
@@ -109,6 +109,57 @@ test("LinkedIn messages use LinkedIn file types rather than X file types", () =>
   );
 });
 
+test("PDFs are allowed in LinkedIn DMs and rejected for X/Twitter", () => {
+  const pdf = media({
+    fileName: "results.pdf",
+    mimeType: "application/pdf",
+    size: 1024,
+    kind: "file",
+  });
+  assert.doesNotThrow(() =>
+    assertOutreachMediaCapability({
+      platform: "linkedin",
+      surface: "dm",
+      media: [pdf],
+    })
+  );
+  assert.throws(
+    () =>
+      assertOutreachMediaCapability({
+        platform: "twitter",
+        surface: "dm",
+        media: [pdf],
+      }),
+    /cannot be attached to X\/Twitter/
+  );
+});
+
+test("LinkedIn DMs accept supported office documents while X/Twitter rejects them", () => {
+  const document = media({
+    fileName: "case-study.docx",
+    mimeType:
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    size: 1024,
+    kind: "file",
+  });
+  assert.doesNotThrow(() =>
+    assertOutreachMediaCapability({
+      platform: "linkedin",
+      surface: "dm",
+      media: [document],
+    })
+  );
+  assert.throws(
+    () =>
+      assertOutreachMediaCapability({
+        platform: "twitter",
+        surface: "dm",
+        media: [document],
+      }),
+    /cannot be attached to X\/Twitter/
+  );
+});
+
 test("LinkedIn messages enforce the combined attachment limit", () => {
   assert.throws(
     () =>


### PR DESCRIPTION
## Summary

- Scope new uploads to an owned workspace and expose indexed attachment discovery to both the main Agent and Prospect Agent.
- Preserve verified attachment references through memory, plans, tasks, and direct social actions, with execution-time compatibility checks.
- Reuse existing attachment UI for inline previews and destination-aware disabled states; duplicate-upload behavior is unchanged.
- Add an additive backfill for workspace attachment search and exact counters.

## Verification

- TypeScript passed.
- Strict Oxlint passed with zero warnings.
- Prettier check passed.
- Full Convex and Vitest suite passed: 205/205 tests.
- Focused attachment and media suite passed: 26/26 tests.
- Attachment integration suite passed: 6/6 tests.
- Production build passed: 74/74 routes.
- Authenticated browser verification covered multi-turn uploads, exact counts, inline rendering, latest-attachment resolution, reload persistence, mentions, removal, and unchanged duplicate behavior.

## Rollout

1. Require frontend and Convex production deployments to be healthy.
2. Run: npx convex run migrations:runWorkspaceAttachmentBackfill --prod
3. Inspect the five quarantined legacy unscoped uploads.
4. Delete only those confirmed legacy rows after the migration result is verified.

No migration or legacy-row deletion is performed by this PR deployment itself.