### PR TITLE
fix: show verified XChat history in conversation panel

### DIFF
--- a/features/agent/lib/xChatBrowserSession.ts
+++ b/features/agent/lib/xChatBrowserSession.ts
@@ -112,6 +112,16 @@ function matchesSessionTarget(
 export function getXChatBrowserSession(
   target: XChatBrowserSessionTarget
 ): BrowserXChatSession | null {
+  if (
+    !target.prospectId &&
+    !target.viewerUserId &&
+    !target.participantUserId &&
+    !target.conversationId &&
+    !target.signingKeyVersion
+  ) {
+    return null;
+  }
+
   if (target.prospectId) {
     const sessionKey = sessionKeysByProspectId.get(target.prospectId);
     const session = sessionKey ? decryptedSessions.get(sessionKey) : undefined;

--- a/features/agent/lib/xChatBrowserSession.ts
+++ b/features/agent/lib/xChatBrowserSession.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { useCallback, useSyncExternalStore } from "react";
 import type { ChatWithJuicebox, SigningKeyEntry } from "@xdevplatform/chat-xdk";
 
 export type XChatDecryptBundle = {
@@ -28,6 +29,31 @@ export type BrowserDecryptedXChatMessage = {
   text: string;
 };
 
+/**
+ * Verified XChat plaintext is intentionally browser-memory-only. It is never
+ * persisted, sent to Convex, or included in Agent context without the explicit
+ * Share with Agent action.
+ */
+export type BrowserXChatSession = {
+  prospectId: string;
+  viewerUserId: string;
+  participantUserId: string;
+  conversationId: string;
+  signingKeyVersion: string;
+  messages: BrowserDecryptedXChatMessage[];
+  decryptionErrorCount: number;
+  eventPagesFetched: number;
+  hasMore: boolean;
+};
+
+export type XChatBrowserSessionTarget = {
+  prospectId?: string | null;
+  viewerUserId?: string | null;
+  participantUserId?: string | null;
+  conversationId?: string | null;
+  signingKeyVersion?: string | null;
+};
+
 type ActiveXChatSession = {
   chat: ChatWithJuicebox;
   viewerUserId: string;
@@ -35,6 +61,141 @@ type ActiveXChatSession = {
 };
 
 let activeSession: ActiveXChatSession | null = null;
+const listeners = new Set<() => void>();
+const decryptedSessions = new Map<string, BrowserXChatSession>();
+const sessionKeysByProspectId = new Map<string, string>();
+
+function emitChange() {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function makeBrowserSessionKey(args: {
+  prospectId: string;
+  bundle: XChatDecryptBundle;
+}): string {
+  // JSON encoding keeps the key unambiguous even if an upstream identifier
+  // contains a separator character.
+  return JSON.stringify([
+    args.prospectId,
+    args.bundle.viewerUserId,
+    args.bundle.signingKeyVersion,
+    args.bundle.participantUserId,
+    args.bundle.conversationId,
+  ]);
+}
+
+function matchesSessionTarget(
+  session: BrowserXChatSession,
+  target: XChatBrowserSessionTarget
+): boolean {
+  return (
+    (target.prospectId == null || session.prospectId === target.prospectId) &&
+    (target.viewerUserId == null ||
+      session.viewerUserId === target.viewerUserId) &&
+    (target.participantUserId == null ||
+      session.participantUserId === target.participantUserId) &&
+    (target.conversationId == null ||
+      session.conversationId === target.conversationId) &&
+    (target.signingKeyVersion == null ||
+      session.signingKeyVersion === target.signingKeyVersion)
+  );
+}
+
+/** Returns the current verified plaintext snapshot without persisting it. */
+export function getXChatBrowserSession(
+  target: XChatBrowserSessionTarget
+): BrowserXChatSession | null {
+  if (target.prospectId) {
+    const sessionKey = sessionKeysByProspectId.get(target.prospectId);
+    const session = sessionKey ? decryptedSessions.get(sessionKey) : undefined;
+    if (session && matchesSessionTarget(session, target)) {
+      return session;
+    }
+  }
+
+  for (const session of decryptedSessions.values()) {
+    if (matchesSessionTarget(session, target)) {
+      return session;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Subscribe to one browser-only XChat session. The snapshot is stable until a
+ * successful decrypt or explicit lock changes it.
+ */
+export function useXChatBrowserSession(
+  target: XChatBrowserSessionTarget
+): BrowserXChatSession | null {
+  const {
+    conversationId,
+    participantUserId,
+    prospectId,
+    signingKeyVersion,
+    viewerUserId,
+  } = target;
+  const getSnapshot = useCallback(
+    () =>
+      getXChatBrowserSession({
+        conversationId,
+        participantUserId,
+        prospectId,
+        signingKeyVersion,
+        viewerUserId,
+      }),
+    [
+      conversationId,
+      participantUserId,
+      prospectId,
+      signingKeyVersion,
+      viewerUserId,
+    ]
+  );
+
+  return useSyncExternalStore(subscribe, getSnapshot, () => null);
+}
+
+/**
+ * Stores only already-verified plaintext and provider coverage metadata in
+ * process memory. Callers must decrypt with rejectUnverified enabled first.
+ */
+export function cacheVerifiedXChatBrowserSession(args: {
+  prospectId: string;
+  bundle: XChatDecryptBundle;
+  messages: BrowserDecryptedXChatMessage[];
+  decryptionErrorCount: number;
+}): BrowserXChatSession {
+  const session: BrowserXChatSession = {
+    prospectId: args.prospectId,
+    viewerUserId: args.bundle.viewerUserId,
+    participantUserId: args.bundle.participantUserId,
+    conversationId: args.bundle.conversationId,
+    signingKeyVersion: args.bundle.signingKeyVersion,
+    messages: args.messages,
+    decryptionErrorCount: args.decryptionErrorCount,
+    eventPagesFetched: args.bundle.eventPagesFetched,
+    hasMore: args.bundle.hasMore,
+  };
+  const sessionKey = makeBrowserSessionKey(args);
+  const previousSessionKey = sessionKeysByProspectId.get(args.prospectId);
+
+  if (previousSessionKey && previousSessionKey !== sessionKey) {
+    decryptedSessions.delete(previousSessionKey);
+  }
+  decryptedSessions.set(sessionKey, session);
+  sessionKeysByProspectId.set(args.prospectId, sessionKey);
+  emitChange();
+  return session;
+}
 
 function isMatchingUnlockedSession(bundle: XChatDecryptBundle): boolean {
   return Boolean(
@@ -49,14 +210,58 @@ export function hasUnlockedXChatSession(bundle: XChatDecryptBundle): boolean {
 }
 
 function releaseActiveSession() {
-  if (!activeSession) {
+  const session = activeSession;
+  activeSession = null;
+  if (!session) {
     return;
   }
-  activeSession.chat.free();
-  activeSession = null;
+  try {
+    session.chat.free();
+  } catch {
+    // Key material is no longer reachable from this browser session even if
+    // the XDK's best-effort cleanup reports an error.
+  }
+}
+
+/** Frees local XChat key material and forgets all decrypted plaintext. */
+export function lockXChatInBrowser(): void {
+  releaseActiveSession();
+  decryptedSessions.clear();
+  sessionKeysByProspectId.clear();
+  emitChange();
+}
+
+/**
+ * Deduplicates only concurrent token requests. Settled entries are evicted so
+ * an expired token is never retained and a rejected request can be retried.
+ */
+export function createInFlightRealmAuthTokenProvider(
+  getRealmAuthToken: (realmId: string) => Promise<string>
+): (realmId: string) => Promise<string> {
+  const inFlightByRealmId = new Map<string, Promise<string>>();
+
+  return (realmId) => {
+    const existingRequest = inFlightByRealmId.get(realmId);
+    if (existingRequest) {
+      return existingRequest;
+    }
+
+    // Defer invocation until after the promise is cached so even a synchronous
+    // throw from an implementation follows the same retry-safe cleanup path.
+    const request = Promise.resolve().then(() => getRealmAuthToken(realmId));
+    inFlightByRealmId.set(realmId, request);
+    const clearIfCurrent = () => {
+      if (inFlightByRealmId.get(realmId) === request) {
+        inFlightByRealmId.delete(realmId);
+      }
+    };
+    void request.then(clearIfCurrent, clearIfCurrent);
+    return request;
+  };
 }
 
 export async function decryptXChatInBrowser(args: {
+  prospectId: string;
   bundle: XChatDecryptBundle;
   pin: string;
   getRealmAuthToken: (realmId: string) => Promise<string>;
@@ -77,7 +282,9 @@ export async function decryptXChatInBrowser(args: {
     const { createChat } = await import("@xdevplatform/chat-xdk");
     chat = await createChat({
       juiceboxConfig: bundle.juiceboxConfig,
-      getAuthToken: args.getRealmAuthToken,
+      getAuthToken: createInFlightRealmAuthTokenProvider(
+        args.getRealmAuthToken
+      ),
     });
     const pinBytes = new TextEncoder().encode(args.pin);
     try {
@@ -135,10 +342,16 @@ export async function decryptXChatInBrowser(args: {
     ];
   });
 
-  return {
-    messages: messages.sort(
-      (left, right) => left.occurredAt - right.occurredAt
-    ),
-    decryptionErrorCount: Object.keys(result.errors).length,
-  };
+  const decryptedMessages = messages.sort(
+    (left, right) => left.occurredAt - right.occurredAt
+  );
+  const decryptionErrorCount = Object.keys(result.errors).length;
+  cacheVerifiedXChatBrowserSession({
+    prospectId: args.prospectId,
+    bundle,
+    messages: decryptedMessages,
+    decryptionErrorCount,
+  });
+
+  return { messages: decryptedMessages, decryptionErrorCount };
 }

--- a/features/agent/ui/components/xchat-history/XChatUnlockCard.tsx
+++ b/features/agent/ui/components/xchat-history/XChatUnlockCard.tsx
@@ -21,7 +21,8 @@ import { Input } from "@/shared/ui/components/Input";
 import {
   decryptXChatInBrowser,
   hasUnlockedXChatSession,
-  type BrowserDecryptedXChatMessage,
+  lockXChatInBrowser,
+  useXChatBrowserSession,
   type XChatDecryptBundle,
 } from "@/features/agent/lib/xChatBrowserSession";
 import type { LockedXChatToolEvidence } from "@/features/agent/lib/xChatToolEvidence";
@@ -44,14 +45,15 @@ export function XChatUnlockCard({
   const streamAnalysis = useAction(api.chat.streamSharedXChatResponse);
   const [open, setOpen] = useState(false);
   const [pin, setPin] = useState("");
-  const [messages, setMessages] = useState<BrowserDecryptedXChatMessage[]>([]);
   const [bundle, setBundle] = useState<XChatDecryptBundle | null>(null);
-  const [decryptionErrorCount, setDecryptionErrorCount] = useState(0);
   const [isUnlocking, setIsUnlocking] = useState(false);
   const [isSharing, setIsSharing] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const prospectId = selectedContext?.prospectId ?? null;
+  const browserSession = useXChatBrowserSession({ prospectId });
+  const messages = browserSession?.messages ?? [];
+  const decryptionErrorCount = browserSession?.decryptionErrorCount ?? 0;
   const handleOpenChange = (nextOpen: boolean) => {
     setOpen(nextOpen);
     if (!nextOpen) {
@@ -64,7 +66,13 @@ export function XChatUnlockCard({
     nextBundle: XChatDecryptBundle,
     nextPin: string
   ) => {
+    if (!prospectId) {
+      throw new Error(
+        "The selected prospect could not be resolved for this task."
+      );
+    }
     const decrypted = await decryptXChatInBrowser({
+      prospectId,
       bundle: nextBundle,
       pin: nextPin,
       getRealmAuthToken: async (realmId) =>
@@ -72,8 +80,6 @@ export function XChatUnlockCard({
     });
     setPin("");
     setBundle(nextBundle);
-    setMessages(decrypted.messages);
-    setDecryptionErrorCount(decrypted.decryptionErrorCount);
     if (decrypted.messages.length === 0) {
       setError(
         "XChat unlocked, but no verified text messages could be decrypted from this history window."
@@ -85,6 +91,9 @@ export function XChatUnlockCard({
     setOpen(true);
     setError(null);
     if (!prospectId) {
+      return;
+    }
+    if (browserSession) {
       return;
     }
     setIsUnlocking(true);
@@ -132,14 +141,14 @@ export function XChatUnlockCard({
   };
 
   const handleShare = async () => {
-    if (!prospectId || !bundle || messages.length === 0) {
+    if (!prospectId || !browserSession || messages.length === 0) {
       return;
     }
     setIsSharing(true);
     setError(null);
     const sharedMessages = messages.slice(-MAX_SHARED_XCHAT_MESSAGES);
     const coverageComplete =
-      !bundle.hasMore &&
+      !browserSession.hasMore &&
       messages.length <= MAX_SHARED_XCHAT_MESSAGES &&
       decryptionErrorCount === 0;
     try {
@@ -149,7 +158,6 @@ export function XChatUnlockCard({
         prospectId: prospectId as Id<"prospects">,
         prompt,
       });
-      setMessages([]);
       setBundle(null);
       setOpen(false);
       toast.success("XChat shared for this Agent response");
@@ -158,7 +166,7 @@ export function XChatUnlockCard({
         promptMessageId: saved.messageId,
         context: {
           prospectId: prospectId as Id<"prospects">,
-          conversationId: bundle.conversationId,
+          conversationId: browserSession.conversationId,
           decryptedAt: getCurrentUTCTimestamp(),
           coverageComplete,
           messages: sharedMessages,
@@ -181,6 +189,13 @@ export function XChatUnlockCard({
           : "XChat could not be shared with the Agent."
       );
     }
+  };
+
+  const handleLock = () => {
+    lockXChatInBrowser();
+    setBundle(null);
+    setPin("");
+    setError(null);
   };
 
   return (
@@ -208,7 +223,7 @@ export function XChatUnlockCard({
           onClick={() => void handleOpen()}
           disabled={!prospectId && selectedContext !== undefined}
         >
-          Unlock and analyze
+          {browserSession ? "Review unlocked XChat" : "Unlock and analyze"}
         </Button>
       </div>
 
@@ -223,7 +238,7 @@ export function XChatUnlockCard({
             </DialogDescription>
           </DialogHeader>
 
-          {messages.length === 0 ? (
+          {!browserSession ? (
             <form
               className="space-y-3"
               onSubmit={(event) => {
@@ -292,6 +307,12 @@ export function XChatUnlockCard({
                 telemetry, although the Agent&apos;s resulting answer remains in
                 this task.
               </p>
+              {browserSession?.hasMore ? (
+                <p className="text-muted-foreground text-xs leading-5">
+                  This XChat window is partial; additional encrypted events
+                  remain available on X.
+                </p>
+              ) : null}
               {error ? (
                 <p className="text-destructive text-sm" role="alert">
                   {error}
@@ -308,8 +329,16 @@ export function XChatUnlockCard({
                 </Button>
                 <Button
                   type="button"
-                  onClick={() => void handleShare()}
+                  variant="outline"
+                  onClick={handleLock}
                   disabled={isSharing}
+                >
+                  Lock XChat
+                </Button>
+                <Button
+                  type="button"
+                  onClick={() => void handleShare()}
+                  disabled={isSharing || messages.length === 0}
                 >
                   {isSharing ? "Sharing…" : "Share with Agent"}
                 </Button>

--- a/features/agent/ui/components/xchat-history/XChatUnlockCard.tsx
+++ b/features/agent/ui/components/xchat-history/XChatUnlockCard.tsx
@@ -1,13 +1,11 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useAction, useMutation, useQuery } from "convex/react";
-import { LockKeyhole, ShieldCheck } from "lucide-react";
 import { toast } from "sonner";
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
 import { getCurrentUTCTimestamp } from "@/shared/lib/utils/time/timeUtils";
-import { Badge } from "@/shared/ui/components/Badge";
 import { Button } from "@/shared/ui/components/Button";
 import {
   Dialog,
@@ -18,6 +16,8 @@ import {
   DialogTitle,
 } from "@/shared/ui/components/Dialog";
 import { Input } from "@/shared/ui/components/Input";
+import { InlineFeatureStrip } from "@/shared/ui/components/InlineFeatureStrip";
+import { LockIcon, LockOpenRightIcon } from "@/shared/ui/components/icons";
 import {
   decryptXChatInBrowser,
   hasUnlockedXChatSession,
@@ -45,7 +45,7 @@ export function XChatUnlockCard({
   const streamAnalysis = useAction(api.chat.streamSharedXChatResponse);
   const [open, setOpen] = useState(false);
   const [pin, setPin] = useState("");
-  const [bundle, setBundle] = useState<XChatDecryptBundle | null>(null);
+  const bundleRef = useRef<XChatDecryptBundle | null>(null);
   const [isUnlocking, setIsUnlocking] = useState(false);
   const [isSharing, setIsSharing] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -54,6 +54,11 @@ export function XChatUnlockCard({
   const browserSession = useXChatBrowserSession({ prospectId });
   const messages = browserSession?.messages ?? [];
   const decryptionErrorCount = browserSession?.decryptionErrorCount ?? 0;
+
+  useEffect(() => {
+    bundleRef.current = null;
+  }, [prospectId]);
+
   const handleOpenChange = (nextOpen: boolean) => {
     setOpen(nextOpen);
     if (!nextOpen) {
@@ -79,12 +84,9 @@ export function XChatUnlockCard({
         await getRealmAuthToken({ realmId }),
     });
     setPin("");
-    setBundle(nextBundle);
-    if (decrypted.messages.length === 0) {
-      setError(
-        "XChat unlocked, but no verified text messages could be decrypted from this history window."
-      );
-    }
+    bundleRef.current = nextBundle;
+    setError(null);
+    return decrypted.messages.length;
   };
 
   const handleOpen = async () => {
@@ -101,7 +103,7 @@ export function XChatUnlockCard({
       const nextBundle = (await getDecryptBundle({
         prospectId,
       })) as XChatDecryptBundle;
-      setBundle(nextBundle);
+      bundleRef.current = nextBundle;
       if (hasUnlockedXChatSession(nextBundle)) {
         await decryptBundle(nextBundle, "");
       }
@@ -109,7 +111,7 @@ export function XChatUnlockCard({
       setError(
         prepareError instanceof Error
           ? prepareError.message
-          : "XChat could not be prepared."
+          : "Couldn't prepare encrypted messages."
       );
     } finally {
       setIsUnlocking(false);
@@ -125,7 +127,7 @@ export function XChatUnlockCard({
     setError(null);
     try {
       const nextBundle =
-        bundle ??
+        bundleRef.current ??
         ((await getDecryptBundle({ prospectId })) as XChatDecryptBundle);
       await decryptBundle(nextBundle, pin);
     } catch (unlockError) {
@@ -133,7 +135,7 @@ export function XChatUnlockCard({
       setError(
         unlockError instanceof Error
           ? unlockError.message
-          : "XChat could not be unlocked."
+          : "Couldn't unlock messages."
       );
     } finally {
       setIsUnlocking(false);
@@ -158,9 +160,9 @@ export function XChatUnlockCard({
         prospectId: prospectId as Id<"prospects">,
         prompt,
       });
-      setBundle(null);
+      bundleRef.current = null;
       setOpen(false);
-      toast.success("XChat shared for this Agent response");
+      toast.success("Messages shared with the Agent");
       void streamAnalysis({
         threadId,
         promptMessageId: saved.messageId,
@@ -173,7 +175,7 @@ export function XChatUnlockCard({
         },
       })
         .catch((streamError) => {
-          toast.error("The Agent could not analyze XChat", {
+          toast.error("The Agent couldn't analyze these messages", {
             description:
               streamError instanceof Error
                 ? streamError.message
@@ -186,68 +188,91 @@ export function XChatUnlockCard({
       setError(
         shareError instanceof Error
           ? shareError.message
-          : "XChat could not be shared with the Agent."
+          : "Couldn't share messages with the Agent."
       );
     }
   };
 
   const handleLock = () => {
     lockXChatInBrowser();
-    setBundle(null);
+    bundleRef.current = null;
     setPin("");
     setError(null);
+    setOpen(false);
   };
 
+  const hasReadableMessages = messages.length > 0;
+  const statusLabel = browserSession
+    ? hasReadableMessages
+      ? `XChat unlocked · ${messages.length} ready to share`
+      : "XChat unlocked"
+    : `Encrypted messages · ${evidence.eventCount} found · ${evidence.inboundEventCount} received · ${evidence.outboundEventCount} sent`;
+
   return (
-    <section className="border-border bg-card rounded-lg border p-3">
-      <header className="flex items-start justify-between gap-3">
-        <div className="flex min-w-0 items-start gap-2">
-          <span className="bg-primary/10 text-primary mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-md">
-            <LockKeyhole className="size-4" aria-hidden="true" />
-          </span>
-          <div className="min-w-0">
-            <h4 className="text-sm font-medium">Encrypted XChat found</h4>
-            <p className="text-muted-foreground mt-1 text-xs leading-5">
-              {evidence.eventCount} encrypted events:{" "}
-              {evidence.inboundEventCount} inbound and{" "}
-              {evidence.outboundEventCount} outbound.
-            </p>
-          </div>
-        </div>
-        <Badge variant="outline">XChat</Badge>
-      </header>
-      <div className="mt-3 flex justify-end">
-        <Button
-          type="button"
-          size="xs"
-          onClick={() => void handleOpen()}
-          disabled={!prospectId && selectedContext !== undefined}
-        >
-          {browserSession ? "Review unlocked XChat" : "Unlock and analyze"}
-        </Button>
-      </div>
+    <div className="space-y-2">
+      <InlineFeatureStrip
+        leading={
+          <>
+            <div className="border-border shrink-0 rounded-md border p-1">
+              {browserSession ? (
+                <LockOpenRightIcon
+                  className="text-foreground size-4 fill-current"
+                  aria-hidden="true"
+                />
+              ) : (
+                <LockIcon
+                  className="text-foreground size-4 fill-current"
+                  aria-hidden="true"
+                />
+              )}
+            </div>
+            <span className="min-w-0 truncate text-sm font-medium">
+              {statusLabel}
+            </span>
+          </>
+        }
+        trailing={
+          <Button
+            type="button"
+            size="xs"
+            onClick={() => void handleOpen()}
+            disabled={!prospectId && selectedContext !== undefined}
+          >
+            {browserSession ? "Review" : "Unlock"}
+          </Button>
+        }
+      />
 
       <Dialog open={open} onOpenChange={handleOpenChange}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Unlock XChat in this browser</DialogTitle>
+            <DialogTitle>
+              {!browserSession
+                ? "Unlock messages"
+                : hasReadableMessages
+                  ? "Share unlocked messages"
+                  : "XChat unlocked"}
+            </DialogTitle>
             <DialogDescription>
-              Your XChat PIN and private keys stay in browser memory. ReacherX
-              fetches ciphertext, then X&apos;s Chat XDK decrypts and verifies
-              it locally.
+              {!browserSession
+                ? "Enter your XChat PIN. It stays in this browser and is never sent to ReacherX."
+                : hasReadableMessages
+                  ? `Share up to the latest ${MAX_SHARED_XCHAT_MESSAGES} messages with the Agent for this response.`
+                  : "The messages already visible in the thread remain available. This unlock did not add any additional XChat rows to share for this response."}
             </DialogDescription>
           </DialogHeader>
 
           {!browserSession ? (
             <form
               className="space-y-3"
+              aria-busy={isUnlocking}
               onSubmit={(event) => {
                 event.preventDefault();
                 void handleUnlock();
               }}
             >
               <label className="space-y-1.5 text-sm font-medium">
-                <span>XChat PIN</span>
+                <span>PIN</span>
                 <Input
                   type="password"
                   value={pin}
@@ -258,16 +283,11 @@ export function XChatUnlockCard({
                   aria-describedby="xchat-pin-privacy"
                 />
               </label>
-              {isUnlocking && !bundle ? (
-                <p className="text-muted-foreground text-sm" role="status">
-                  Preparing encrypted history…
-                </p>
-              ) : null}
               <p
                 id="xchat-pin-privacy"
                 className="text-muted-foreground text-xs leading-5"
               >
-                The PIN is never sent to ReacherX, X, analytics, or the Agent.
+                Your PIN never leaves this browser.
               </p>
               {error ? (
                 <p className="text-destructive text-sm" role="alert">
@@ -277,40 +297,31 @@ export function XChatUnlockCard({
               <DialogFooter>
                 <Button
                   type="button"
+                  size="xs"
                   variant="outline"
                   onClick={() => setOpen(false)}
                   disabled={isUnlocking}
                 >
                   Cancel
                 </Button>
-                <Button type="submit" disabled={isUnlocking || !pin.trim()}>
-                  {isUnlocking ? "Unlocking…" : "Unlock XChat"}
+                <Button
+                  type="submit"
+                  size="xs"
+                  disabled={isUnlocking || !pin.trim()}
+                >
+                  Unlock
                 </Button>
               </DialogFooter>
             </form>
-          ) : (
-            <div className="space-y-4">
-              <div className="bg-muted/40 flex items-start gap-2 rounded-md border p-3">
-                <ShieldCheck
-                  className="text-primary mt-0.5 size-4 shrink-0"
-                  aria-hidden="true"
-                />
-                <p className="text-sm leading-5">
-                  {messages.length} verified text messages are ready. Sharing
-                  sends only the latest {MAX_SHARED_XCHAT_MESSAGES} messages to
-                  the Agent for this response.
-                </p>
-              </div>
-              <p className="text-muted-foreground text-xs leading-5">
-                The model provider will receive the shared text. ReacherX does
-                not store that plaintext in message context or raw-model
-                telemetry, although the Agent&apos;s resulting answer remains in
-                this task.
+          ) : !hasReadableMessages ? (
+            <div className="space-y-3">
+              <p className="text-muted-foreground text-sm" role="status">
+                The conversation is already visible above. This unlock only adds
+                encrypted XChat rows when they are available.
               </p>
-              {browserSession?.hasMore ? (
+              {browserSession.hasMore ? (
                 <p className="text-muted-foreground text-xs leading-5">
-                  This XChat window is partial; additional encrypted events
-                  remain available on X.
+                  More encrypted history is available on X.
                 </p>
               ) : null}
               {error ? (
@@ -321,6 +332,58 @@ export function XChatUnlockCard({
               <DialogFooter>
                 <Button
                   type="button"
+                  size="xs"
+                  variant="outline"
+                  onClick={() => setOpen(false)}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="button"
+                  size="xs"
+                  variant="outline"
+                  onClick={handleLock}
+                >
+                  Lock
+                </Button>
+              </DialogFooter>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <InlineFeatureStrip
+                leading={
+                  <>
+                    <div className="border-border shrink-0 rounded-md border p-1">
+                      <LockOpenRightIcon
+                        className="text-foreground size-4 fill-current"
+                        aria-hidden="true"
+                      />
+                    </div>
+                    <span className="min-w-0 truncate text-sm font-medium">
+                      {messages.length} messages ready · Latest{" "}
+                      {MAX_SHARED_XCHAT_MESSAGES} shared
+                    </span>
+                  </>
+                }
+              />
+              <p className="text-muted-foreground text-xs leading-5">
+                Shared text goes to the model for this response. ReacherX does
+                not keep that plaintext.
+              </p>
+              {browserSession?.hasMore ? (
+                <p className="text-muted-foreground text-xs leading-5">
+                  More encrypted history is available on X.
+                </p>
+              ) : null}
+              {error ? (
+                <p className="text-destructive text-sm" role="alert">
+                  {error}
+                </p>
+              ) : null}
+              <DialogFooter>
+                <Button
+                  type="button"
+                  size="xs"
                   variant="outline"
                   onClick={() => setOpen(false)}
                   disabled={isSharing}
@@ -329,14 +392,16 @@ export function XChatUnlockCard({
                 </Button>
                 <Button
                   type="button"
+                  size="xs"
                   variant="outline"
                   onClick={handleLock}
                   disabled={isSharing}
                 >
-                  Lock XChat
+                  Lock
                 </Button>
                 <Button
                   type="button"
+                  size="xs"
                   onClick={() => void handleShare()}
                   disabled={isSharing || messages.length === 0}
                 >
@@ -347,6 +412,6 @@ export function XChatUnlockCard({
           )}
         </DialogContent>
       </Dialog>
-    </section>
+    </div>
   );
 }

--- a/features/prospects/lib/xChatConversationMessages.ts
+++ b/features/prospects/lib/xChatConversationMessages.ts
@@ -1,0 +1,43 @@
+import type { BrowserXChatSession } from "@/features/agent/lib/xChatBrowserSession";
+import type { XDmMessage } from "@/shared/lib/twitter/dm";
+import { mergeConversationHistoryMessages } from "./conversationHistoryHelpers";
+
+function toIsoTimestamp(occurredAt: number): string | undefined {
+  if (!Number.isFinite(occurredAt) || occurredAt <= 0) {
+    return undefined;
+  }
+
+  const date = new Date(occurredAt);
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+}
+
+/** Converts only browser-verified XChat plaintext into panel message rows. */
+export function toXChatConversationMessages(
+  session: BrowserXChatSession | null | undefined
+): XDmMessage[] {
+  if (!session) {
+    return [];
+  }
+
+  return session.messages.map((message) => ({
+    // XChat and legacy DM identifiers use separate namespaces, so their rows
+    // cannot overwrite each other when the histories are merged.
+    id: `xchat:${session.conversationId}:${message.id}`,
+    conversationId: session.conversationId,
+    senderUserId: message.senderId,
+    text: message.text,
+    createdAt: toIsoTimestamp(message.occurredAt),
+    direction: message.direction,
+  }));
+}
+
+/** Chronologically merges browser-verified XChat with legacy X/Twitter DMs. */
+export function mergeXChatConversationMessages(
+  legacyMessages: XDmMessage[],
+  session: BrowserXChatSession | null | undefined
+): XDmMessage[] {
+  return mergeConversationHistoryMessages(
+    toXChatConversationMessages(session),
+    legacyMessages
+  );
+}

--- a/features/prospects/ui/components/XChatConversationUnlock.tsx
+++ b/features/prospects/ui/components/XChatConversationUnlock.tsx
@@ -2,7 +2,6 @@
 
 import * as React from "react";
 import { useAction } from "convex/react";
-import { LockKeyhole, ShieldCheck } from "lucide-react";
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
 import {
@@ -22,6 +21,8 @@ import {
   DialogTitle,
 } from "@/shared/ui/components/Dialog";
 import { Input } from "@/shared/ui/components/Input";
+import { InlineFeatureStrip } from "@/shared/ui/components/InlineFeatureStrip";
+import { LockIcon, LockOpenRightIcon } from "@/shared/ui/components/icons";
 
 type XChatAvailability = "checking" | "available" | "unavailable" | "failed";
 
@@ -50,7 +51,8 @@ export function XChatConversationUnlock({
   const [pin, setPin] = React.useState("");
   const [isUnlocking, setIsUnlocking] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
-  const preparedProspectIdRef = React.useRef<string | null>(null);
+  const preparedTargetKeyRef = React.useRef<string | null>(null);
+  const targetKey = JSON.stringify([prospectId, participantUserId ?? null]);
 
   const decryptBundle = React.useCallback(
     async (nextBundle: XChatDecryptBundle, nextPin: string) => {
@@ -61,29 +63,26 @@ export function XChatConversationUnlock({
         getRealmAuthToken: async (realmId) =>
           await getRealmAuthToken({ realmId }),
       });
-      if (preparedProspectIdRef.current !== prospectId) {
-        return;
+      if (preparedTargetKeyRef.current !== targetKey) {
+        return null;
       }
       setPin("");
       setBundle(nextBundle);
-      if (decrypted.messages.length === 0) {
-        setError(
-          "XChat unlocked, but no verified text messages could be decrypted from this history window."
-        );
-      }
+      setError(null);
+      return decrypted.messages.length;
     },
-    [getRealmAuthToken, prospectId]
+    [getRealmAuthToken, prospectId, targetKey]
   );
 
   const prepareBundle = React.useCallback(async () => {
-    const requestedProspectId = prospectId;
+    const requestedTargetKey = targetKey;
     setAvailability("checking");
     setError(null);
     try {
       const nextBundle = (await getDecryptBundle({
         prospectId: prospectId as Id<"prospects">,
       })) as XChatDecryptBundle;
-      if (preparedProspectIdRef.current !== requestedProspectId) {
+      if (preparedTargetKeyRef.current !== requestedTargetKey) {
         return null;
       }
       setBundle(nextBundle);
@@ -97,25 +96,25 @@ export function XChatConversationUnlock({
       }
       return nextBundle;
     } catch {
-      if (preparedProspectIdRef.current !== requestedProspectId) {
+      if (preparedTargetKeyRef.current !== requestedTargetKey) {
         return null;
       }
       setAvailability("failed");
-      setError("XChat history could not be checked. Please try again.");
+      setError("Couldn't check encrypted messages. Please try again.");
       return null;
     }
-  }, [decryptBundle, getDecryptBundle, prospectId]);
+  }, [decryptBundle, getDecryptBundle, prospectId, targetKey]);
 
   React.useEffect(() => {
-    if (preparedProspectIdRef.current === prospectId) {
+    if (preparedTargetKeyRef.current === targetKey) {
       return;
     }
-    preparedProspectIdRef.current = prospectId;
+    preparedTargetKeyRef.current = targetKey;
     setBundle(null);
     setError(null);
     setAvailability("checking");
     void prepareBundle();
-  }, [prepareBundle, prospectId]);
+  }, [prepareBundle, targetKey]);
 
   const handleOpenChange = (nextOpen: boolean) => {
     setOpen(nextOpen);
@@ -131,16 +130,19 @@ export function XChatConversationUnlock({
     try {
       const nextBundle = bundle ?? (await prepareBundle());
       if (!nextBundle || !hasEncryptedEvents(nextBundle)) {
-        setError("No encrypted XChat events are available for this prospect.");
+        setError("No encrypted messages are available for this prospect.");
         return;
       }
-      await decryptBundle(nextBundle, pin);
+      const messageCount = await decryptBundle(nextBundle, pin);
+      if (messageCount !== null) {
+        setOpen(false);
+      }
     } catch (unlockError) {
       setPin("");
       setError(
         unlockError instanceof Error
           ? unlockError.message
-          : "XChat could not be unlocked."
+          : "Couldn't unlock messages."
       );
     } finally {
       setIsUnlocking(false);
@@ -153,81 +155,81 @@ export function XChatConversationUnlock({
     setError(null);
   };
 
-  if (availability === "unavailable" && !session) {
+  if (session && !open) {
     return null;
   }
 
   const hasPartialCoverage = session?.hasMore ?? bundle?.hasMore ?? false;
+  if (availability === "unavailable" && !session) {
+    return null;
+  }
+
+  const statusLabel = session
+    ? `XChat unlocked${hasPartialCoverage ? " · More on X" : ""}`
+    : availability === "failed"
+      ? "Couldn't check encrypted messages"
+      : availability === "checking"
+        ? "Checking encrypted messages…"
+        : hasPartialCoverage
+          ? "Encrypted messages · More on X"
+          : "Encrypted messages · Enter PIN to view";
 
   return (
-    <section className="border-border bg-muted/20 rounded-lg border p-3">
-      <header className="flex items-start justify-between gap-3">
-        <div className="flex min-w-0 items-start gap-2">
-          <span className="bg-primary/10 text-primary mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-md">
-            {session ? (
-              <ShieldCheck className="size-4" aria-hidden="true" />
-            ) : (
-              <LockKeyhole className="size-4" aria-hidden="true" />
-            )}
-          </span>
-          <div className="min-w-0">
-            <h3 className="text-sm font-medium">
-              {session
-                ? "XChat unlocked in this browser"
-                : availability === "failed"
-                  ? "XChat availability unavailable"
-                  : availability === "checking"
-                    ? "Checking XChat history"
-                    : "Encrypted XChat"}
-            </h3>
-            <p className="text-muted-foreground mt-1 text-xs leading-5">
-              {session
-                ? `${session.messages.length} verified text messages are shown below.`
-                : availability === "checking"
-                  ? "Checking for encrypted XChat history…"
-                  : availability === "failed"
-                    ? "XChat history could not be checked."
-                    : "Unlock locally to view verified XChat messages in this panel."}
-            </p>
-          </div>
-        </div>
-        {session ? (
-          <Button
-            type="button"
-            size="xs"
-            variant="outline"
-            onClick={handleLock}
-          >
-            Lock XChat
-          </Button>
-        ) : availability === "failed" ? (
-          <Button
-            type="button"
-            size="xs"
-            variant="outline"
-            onClick={() => void prepareBundle()}
-          >
-            Retry
-          </Button>
-        ) : (
-          <Button
-            type="button"
-            size="xs"
-            onClick={() => setOpen(true)}
-            disabled={availability === "checking"}
-          >
-            Unlock XChat
-          </Button>
-        )}
-      </header>
-      {hasPartialCoverage ? (
-        <p className="text-muted-foreground mt-3 text-xs leading-5">
-          XChat history is partially loaded; additional encrypted events remain
-          available on X.
-        </p>
-      ) : null}
-      {availability === "failed" && error ? (
-        <p className="text-destructive mt-3 text-xs leading-5" role="alert">
+    <div className="space-y-2">
+      <InlineFeatureStrip
+        leading={
+          <>
+            <div className="border-border shrink-0 rounded-md border p-1">
+              {session ? (
+                <LockOpenRightIcon
+                  className="text-foreground size-4 fill-current"
+                  aria-hidden="true"
+                />
+              ) : (
+                <LockIcon
+                  className="text-foreground size-4 fill-current"
+                  aria-hidden="true"
+                />
+              )}
+            </div>
+            <span className="min-w-0 truncate text-sm font-medium">
+              {statusLabel}
+            </span>
+          </>
+        }
+        trailing={
+          session ? (
+            <Button
+              type="button"
+              size="xs"
+              variant="outline"
+              onClick={handleLock}
+            >
+              Lock
+            </Button>
+          ) : availability === "failed" ? (
+            <Button
+              type="button"
+              size="xs"
+              variant="outline"
+              onClick={() => void prepareBundle()}
+            >
+              Retry
+            </Button>
+          ) : (
+            <Button
+              type="button"
+              size="xs"
+              onClick={() => setOpen(true)}
+              disabled={availability === "checking" || isUnlocking}
+            >
+              Unlock
+            </Button>
+          )
+        }
+      />
+      {error && (availability === "failed" || session) ? (
+        <p className="text-destructive text-xs" role="alert">
           {error}
         </p>
       ) : null}
@@ -235,22 +237,22 @@ export function XChatConversationUnlock({
       <Dialog open={open} onOpenChange={handleOpenChange}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Unlock XChat in this browser</DialogTitle>
+            <DialogTitle>Unlock messages</DialogTitle>
             <DialogDescription>
-              Your XChat PIN and private keys stay in browser memory. ReacherX
-              fetches ciphertext, then X&apos;s Chat XDK decrypts and verifies
-              it locally.
+              Enter your XChat PIN. It stays in this browser and is never sent
+              to ReacherX.
             </DialogDescription>
           </DialogHeader>
           <form
             className="space-y-3"
+            aria-busy={isUnlocking}
             onSubmit={(event) => {
               event.preventDefault();
               void handleUnlock();
             }}
           >
             <label className="space-y-1.5 text-sm font-medium">
-              <span>XChat PIN</span>
+              <span>PIN</span>
               <Input
                 type="password"
                 value={pin}
@@ -265,7 +267,7 @@ export function XChatConversationUnlock({
               id="xchat-panel-pin-privacy"
               className="text-muted-foreground text-xs leading-5"
             >
-              The PIN is never sent to ReacherX, X, analytics, or the Agent.
+              Your PIN never leaves this browser.
             </p>
             {error ? (
               <p className="text-destructive text-sm" role="alert">
@@ -275,19 +277,24 @@ export function XChatConversationUnlock({
             <DialogFooter>
               <Button
                 type="button"
+                size="xs"
                 variant="outline"
                 onClick={() => setOpen(false)}
                 disabled={isUnlocking}
               >
                 Cancel
               </Button>
-              <Button type="submit" disabled={isUnlocking || !pin.trim()}>
-                {isUnlocking ? "Unlocking…" : "Unlock XChat"}
+              <Button
+                type="submit"
+                size="xs"
+                disabled={isUnlocking || !pin.trim()}
+              >
+                Unlock
               </Button>
             </DialogFooter>
           </form>
         </DialogContent>
       </Dialog>
-    </section>
+    </div>
   );
 }

--- a/features/prospects/ui/components/XChatConversationUnlock.tsx
+++ b/features/prospects/ui/components/XChatConversationUnlock.tsx
@@ -1,0 +1,293 @@
+"use client";
+
+import * as React from "react";
+import { useAction } from "convex/react";
+import { LockKeyhole, ShieldCheck } from "lucide-react";
+import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
+import {
+  decryptXChatInBrowser,
+  hasUnlockedXChatSession,
+  lockXChatInBrowser,
+  useXChatBrowserSession,
+  type XChatDecryptBundle,
+} from "@/features/agent/lib/xChatBrowserSession";
+import { Button } from "@/shared/ui/components/Button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/shared/ui/components/Dialog";
+import { Input } from "@/shared/ui/components/Input";
+
+type XChatAvailability = "checking" | "available" | "unavailable" | "failed";
+
+function hasEncryptedEvents(bundle: XChatDecryptBundle): boolean {
+  return bundle.events.some((event) => event.encodedEvent.trim().length > 0);
+}
+
+/**
+ * Browser-only XChat unlock control for the X conversation panel. It shares
+ * verified plaintext through xChatBrowserSession, never through Convex.
+ */
+export function XChatConversationUnlock({
+  prospectId,
+  participantUserId,
+}: {
+  prospectId: string;
+  participantUserId?: string | null;
+}) {
+  const getDecryptBundle = useAction(api.x.getXChatDecryptBundle);
+  const getRealmAuthToken = useAction(api.x.getXChatRealmAuthToken);
+  const session = useXChatBrowserSession({ prospectId, participantUserId });
+  const [availability, setAvailability] =
+    React.useState<XChatAvailability>("checking");
+  const [bundle, setBundle] = React.useState<XChatDecryptBundle | null>(null);
+  const [open, setOpen] = React.useState(false);
+  const [pin, setPin] = React.useState("");
+  const [isUnlocking, setIsUnlocking] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const preparedProspectIdRef = React.useRef<string | null>(null);
+
+  const decryptBundle = React.useCallback(
+    async (nextBundle: XChatDecryptBundle, nextPin: string) => {
+      const decrypted = await decryptXChatInBrowser({
+        prospectId,
+        bundle: nextBundle,
+        pin: nextPin,
+        getRealmAuthToken: async (realmId) =>
+          await getRealmAuthToken({ realmId }),
+      });
+      if (preparedProspectIdRef.current !== prospectId) {
+        return;
+      }
+      setPin("");
+      setBundle(nextBundle);
+      if (decrypted.messages.length === 0) {
+        setError(
+          "XChat unlocked, but no verified text messages could be decrypted from this history window."
+        );
+      }
+    },
+    [getRealmAuthToken, prospectId]
+  );
+
+  const prepareBundle = React.useCallback(async () => {
+    const requestedProspectId = prospectId;
+    setAvailability("checking");
+    setError(null);
+    try {
+      const nextBundle = (await getDecryptBundle({
+        prospectId: prospectId as Id<"prospects">,
+      })) as XChatDecryptBundle;
+      if (preparedProspectIdRef.current !== requestedProspectId) {
+        return null;
+      }
+      setBundle(nextBundle);
+      if (!hasEncryptedEvents(nextBundle)) {
+        setAvailability("unavailable");
+        return null;
+      }
+      setAvailability("available");
+      if (hasUnlockedXChatSession(nextBundle)) {
+        await decryptBundle(nextBundle, "");
+      }
+      return nextBundle;
+    } catch {
+      if (preparedProspectIdRef.current !== requestedProspectId) {
+        return null;
+      }
+      setAvailability("failed");
+      setError("XChat history could not be checked. Please try again.");
+      return null;
+    }
+  }, [decryptBundle, getDecryptBundle, prospectId]);
+
+  React.useEffect(() => {
+    if (preparedProspectIdRef.current === prospectId) {
+      return;
+    }
+    preparedProspectIdRef.current = prospectId;
+    setBundle(null);
+    setError(null);
+    setAvailability("checking");
+    void prepareBundle();
+  }, [prepareBundle, prospectId]);
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (!nextOpen) {
+      setPin("");
+      setError(null);
+    }
+  };
+
+  const handleUnlock = async () => {
+    setIsUnlocking(true);
+    setError(null);
+    try {
+      const nextBundle = bundle ?? (await prepareBundle());
+      if (!nextBundle || !hasEncryptedEvents(nextBundle)) {
+        setError("No encrypted XChat events are available for this prospect.");
+        return;
+      }
+      await decryptBundle(nextBundle, pin);
+    } catch (unlockError) {
+      setPin("");
+      setError(
+        unlockError instanceof Error
+          ? unlockError.message
+          : "XChat could not be unlocked."
+      );
+    } finally {
+      setIsUnlocking(false);
+    }
+  };
+
+  const handleLock = () => {
+    lockXChatInBrowser();
+    setPin("");
+    setError(null);
+  };
+
+  if (availability === "unavailable" && !session) {
+    return null;
+  }
+
+  const hasPartialCoverage = session?.hasMore ?? bundle?.hasMore ?? false;
+
+  return (
+    <section className="border-border bg-muted/20 rounded-lg border p-3">
+      <header className="flex items-start justify-between gap-3">
+        <div className="flex min-w-0 items-start gap-2">
+          <span className="bg-primary/10 text-primary mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-md">
+            {session ? (
+              <ShieldCheck className="size-4" aria-hidden="true" />
+            ) : (
+              <LockKeyhole className="size-4" aria-hidden="true" />
+            )}
+          </span>
+          <div className="min-w-0">
+            <h3 className="text-sm font-medium">
+              {session
+                ? "XChat unlocked in this browser"
+                : availability === "failed"
+                  ? "XChat availability unavailable"
+                  : availability === "checking"
+                    ? "Checking XChat history"
+                    : "Encrypted XChat"}
+            </h3>
+            <p className="text-muted-foreground mt-1 text-xs leading-5">
+              {session
+                ? `${session.messages.length} verified text messages are shown below.`
+                : availability === "checking"
+                  ? "Checking for encrypted XChat history…"
+                  : availability === "failed"
+                    ? "XChat history could not be checked."
+                    : "Unlock locally to view verified XChat messages in this panel."}
+            </p>
+          </div>
+        </div>
+        {session ? (
+          <Button
+            type="button"
+            size="xs"
+            variant="outline"
+            onClick={handleLock}
+          >
+            Lock XChat
+          </Button>
+        ) : availability === "failed" ? (
+          <Button
+            type="button"
+            size="xs"
+            variant="outline"
+            onClick={() => void prepareBundle()}
+          >
+            Retry
+          </Button>
+        ) : (
+          <Button
+            type="button"
+            size="xs"
+            onClick={() => setOpen(true)}
+            disabled={availability === "checking"}
+          >
+            Unlock XChat
+          </Button>
+        )}
+      </header>
+      {hasPartialCoverage ? (
+        <p className="text-muted-foreground mt-3 text-xs leading-5">
+          XChat history is partially loaded; additional encrypted events remain
+          available on X.
+        </p>
+      ) : null}
+      {availability === "failed" && error ? (
+        <p className="text-destructive mt-3 text-xs leading-5" role="alert">
+          {error}
+        </p>
+      ) : null}
+
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Unlock XChat in this browser</DialogTitle>
+            <DialogDescription>
+              Your XChat PIN and private keys stay in browser memory. ReacherX
+              fetches ciphertext, then X&apos;s Chat XDK decrypts and verifies
+              it locally.
+            </DialogDescription>
+          </DialogHeader>
+          <form
+            className="space-y-3"
+            onSubmit={(event) => {
+              event.preventDefault();
+              void handleUnlock();
+            }}
+          >
+            <label className="space-y-1.5 text-sm font-medium">
+              <span>XChat PIN</span>
+              <Input
+                type="password"
+                value={pin}
+                autoComplete="off"
+                inputMode="numeric"
+                onChange={(event) => setPin(event.target.value)}
+                disabled={isUnlocking}
+                aria-describedby="xchat-panel-pin-privacy"
+              />
+            </label>
+            <p
+              id="xchat-panel-pin-privacy"
+              className="text-muted-foreground text-xs leading-5"
+            >
+              The PIN is never sent to ReacherX, X, analytics, or the Agent.
+            </p>
+            {error ? (
+              <p className="text-destructive text-sm" role="alert">
+                {error}
+              </p>
+            ) : null}
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setOpen(false)}
+                disabled={isUnlocking}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={isUnlocking || !pin.trim()}>
+                {isUnlocking ? "Unlocking…" : "Unlock XChat"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </section>
+  );
+}

--- a/features/prospects/ui/components/XConversationPanel.tsx
+++ b/features/prospects/ui/components/XConversationPanel.tsx
@@ -16,8 +16,10 @@ import {
   DM_COMPOSER_PLACEHOLDER_CLASS,
 } from "@/features/composer/ui/dmComposerClasses";
 import { formatDmMessageTime } from "../../lib/formatDmMessageTime";
+import { mergeXChatConversationMessages } from "../../lib/xChatConversationMessages";
 import { useProspectDmPanel } from "../../hooks/useProspectDmPanel";
 import { ConversationHistoryPagination } from "./ConversationHistoryPagination";
+import { XChatConversationUnlock } from "./XChatConversationUnlock";
 import { XDmConversationMenu } from "./XDmConversationMenu";
 import { Button } from "@/shared/ui/components/Button";
 import {
@@ -49,6 +51,7 @@ import type {
   ComposerMediaKind,
 } from "@/features/composer/types";
 import { XDmAttachmentGallery } from "./XDmAttachmentGallery";
+import { useXChatBrowserSession } from "@/features/agent/lib/xChatBrowserSession";
 
 export interface XConversationPanelProps {
   prospectId: string;
@@ -115,6 +118,10 @@ export function XConversationPanel({
     actionRequestId,
     enabled: Boolean(prospectId),
   });
+  const xChatSession = useXChatBrowserSession({
+    prospectId,
+    participantUserId: data?.participantUserId,
+  });
   const updatePendingActionRequestDraft = useMutation(
     api.socialActions.updatePendingActionRequestDraft
   );
@@ -171,9 +178,14 @@ export function XConversationPanel({
     return undefined;
   }, [data]);
 
+  const messagesWithXChat = React.useMemo(
+    () => mergeXChatConversationMessages(data?.messages ?? [], xChatSession),
+    [data?.messages, xChatSession]
+  );
+
   const renderedMessages = React.useMemo(() => {
-    if (!data?.messages.length) {
-      return data?.messages ?? [];
+    if (!messagesWithXChat.length) {
+      return messagesWithXChat;
     }
 
     if (
@@ -181,12 +193,12 @@ export function XConversationPanel({
       !taskPosted?.messageId ||
       !taskPosted.mediaUrls?.length
     ) {
-      return data.messages;
+      return messagesWithXChat;
     }
 
     const taskPostedMediaUrls = taskPosted.mediaUrls;
 
-    return data.messages.map((message) => {
+    return messagesWithXChat.map((message) => {
       if (message.id !== taskPosted.messageId) {
         return message;
       }
@@ -212,7 +224,7 @@ export function XConversationPanel({
             : message.attachments,
       };
     });
-  }, [data, taskMode, taskPosted]);
+  }, [messagesWithXChat, taskMode, taskPosted]);
 
   const draftSync = useDebouncedDraftSync({
     enabled: isTaskBacked
@@ -470,10 +482,14 @@ export function XConversationPanel({
                       Refreshing conversation
                     </span>
                   ) : null}
+                  <XChatConversationUnlock
+                    prospectId={prospectId}
+                    participantUserId={data.participantUserId}
+                  />
                   {data.history?.boundary === "x_30_day_limit" &&
                   !data.history.hasMore ? (
                     <p className="text-muted-foreground text-center text-xs">
-                      X/Twitter provides conversation history from the past 30
+                      Legacy X/Twitter DM history is limited to the past 30
                       days.
                     </p>
                   ) : null}

--- a/tests/conversation-history-pagination.test.ts
+++ b/tests/conversation-history-pagination.test.ts
@@ -68,6 +68,6 @@ test("conversation panels expose upward history loading and recovery copy", () =
   );
   assert.match(
     xSource,
-    /X\/Twitter provides conversation history from the past 30/
+    /Legacy X\/Twitter DM history is limited to the past 30/
   );
 });

--- a/tests/xchat-browser-session.test.ts
+++ b/tests/xchat-browser-session.test.ts
@@ -82,6 +82,20 @@ test("lock frees the browser-only XChat view state", () => {
   assert.equal(getXChatBrowserSession({ prospectId: "prospect-1" }), null);
 });
 
+test("an unresolved session target never receives another prospect's session", () => {
+  const session = cacheVerifiedXChatBrowserSession({
+    prospectId: "prospect-1",
+    bundle: bundle(),
+    messages: [],
+    decryptionErrorCount: 0,
+  });
+
+  assert.equal(getXChatBrowserSession({}), null);
+  assert.equal(getXChatBrowserSession({ prospectId: null }), null);
+  assert.equal(getXChatBrowserSession({ prospectId: "prospect-2" }), null);
+  assert.equal(getXChatBrowserSession({ prospectId: "prospect-1" }), session);
+});
+
 test("concurrent XChat token requests for the same realm share one backend call", async () => {
   let backendCallCount = 0;
   let resolveToken: ((token: string) => void) | undefined;

--- a/tests/xchat-browser-session.test.ts
+++ b/tests/xchat-browser-session.test.ts
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import test, { afterEach } from "node:test";
+import {
+  cacheVerifiedXChatBrowserSession,
+  createInFlightRealmAuthTokenProvider,
+  getXChatBrowserSession,
+  lockXChatInBrowser,
+  type XChatDecryptBundle,
+} from "../features/agent/lib/xChatBrowserSession";
+
+function bundle(
+  overrides: Partial<XChatDecryptBundle> = {}
+): XChatDecryptBundle {
+  return {
+    viewerUserId: "viewer-1",
+    participantUserId: "participant-1",
+    conversationId: "conversation-1",
+    signingKeyVersion: "key-1",
+    juiceboxConfig: "{}",
+    signingKeys: [],
+    events: [],
+    eventPagesFetched: 1,
+    hasMore: true,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  lockXChatInBrowser();
+});
+
+test("a newer XChat session replaces stale plaintext for the same prospect", () => {
+  const first = cacheVerifiedXChatBrowserSession({
+    prospectId: "prospect-1",
+    bundle: bundle(),
+    messages: [
+      {
+        id: "event-1",
+        senderId: "participant-1",
+        direction: "received",
+        occurredAt: 1_000,
+        text: "Verified XChat text",
+      },
+    ],
+    decryptionErrorCount: 0,
+  });
+  const second = cacheVerifiedXChatBrowserSession({
+    prospectId: "prospect-1",
+    bundle: bundle({ conversationId: "conversation-2" }),
+    messages: [],
+    decryptionErrorCount: 2,
+  });
+
+  assert.equal(getXChatBrowserSession({ prospectId: "prospect-1" }), second);
+  assert.equal(first.conversationId, "conversation-1");
+  assert.equal(
+    getXChatBrowserSession({
+      prospectId: "prospect-1",
+      conversationId: "conversation-1",
+    }),
+    null
+  );
+  assert.equal(
+    getXChatBrowserSession({
+      prospectId: "prospect-2",
+      conversationId: "conversation-1",
+    }),
+    null
+  );
+});
+
+test("lock frees the browser-only XChat view state", () => {
+  cacheVerifiedXChatBrowserSession({
+    prospectId: "prospect-1",
+    bundle: bundle(),
+    messages: [],
+    decryptionErrorCount: 0,
+  });
+
+  lockXChatInBrowser();
+
+  assert.equal(getXChatBrowserSession({ prospectId: "prospect-1" }), null);
+});
+
+test("concurrent XChat token requests for the same realm share one backend call", async () => {
+  let backendCallCount = 0;
+  let resolveToken: ((token: string) => void) | undefined;
+  const getRealmAuthToken = createInFlightRealmAuthTokenProvider(async () => {
+    backendCallCount += 1;
+    return await new Promise<string>((resolve) => {
+      resolveToken = resolve;
+    });
+  });
+
+  const firstRequest = getRealmAuthToken("realm-1");
+  const duplicateRequest = getRealmAuthToken("realm-1");
+  await Promise.resolve();
+
+  assert.equal(firstRequest, duplicateRequest);
+  assert.equal(backendCallCount, 1);
+  resolveToken?.("realm-token");
+  assert.deepEqual(await Promise.all([firstRequest, duplicateRequest]), [
+    "realm-token",
+    "realm-token",
+  ]);
+});
+
+test("XChat token requests for distinct realms remain independent", async () => {
+  const requestedRealmIds: string[] = [];
+  const getRealmAuthToken = createInFlightRealmAuthTokenProvider(
+    async (realmId) => {
+      requestedRealmIds.push(realmId);
+      return `token-for-${realmId}`;
+    }
+  );
+
+  assert.deepEqual(
+    await Promise.all([
+      getRealmAuthToken("realm-1"),
+      getRealmAuthToken("realm-2"),
+    ]),
+    ["token-for-realm-1", "token-for-realm-2"]
+  );
+  assert.deepEqual(requestedRealmIds, ["realm-1", "realm-2"]);
+});
+
+test("a rejected XChat realm token request is evicted for retry", async () => {
+  let backendCallCount = 0;
+  const getRealmAuthToken = createInFlightRealmAuthTokenProvider(async () => {
+    backendCallCount += 1;
+    if (backendCallCount === 1) {
+      throw new Error("Unauthorized");
+    }
+    return "fresh-realm-token";
+  });
+
+  const firstRequest = getRealmAuthToken("realm-1");
+  const duplicateRequest = getRealmAuthToken("realm-1");
+  const rejected = await Promise.allSettled([firstRequest, duplicateRequest]);
+
+  assert.equal(backendCallCount, 1);
+  assert.deepEqual(
+    rejected.map((result) => result.status),
+    ["rejected", "rejected"]
+  );
+  assert.equal(await getRealmAuthToken("realm-1"), "fresh-realm-token");
+  assert.equal(backendCallCount, 2);
+});

--- a/tests/xchat-conversation-panel.test.ts
+++ b/tests/xchat-conversation-panel.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import {
+  mergeXChatConversationMessages,
+  toXChatConversationMessages,
+} from "../features/prospects/lib/xChatConversationMessages";
+
+const session = {
+  prospectId: "prospect-1",
+  viewerUserId: "viewer-1",
+  participantUserId: "participant-1",
+  conversationId: "xchat-conversation-1",
+  signingKeyVersion: "key-1",
+  eventPagesFetched: 1,
+  hasMore: true,
+  decryptionErrorCount: 0,
+  messages: [
+    {
+      id: "event-2",
+      senderId: "viewer-1",
+      direction: "sent" as const,
+      occurredAt: 2_000,
+      text: "Verified reply",
+    },
+    {
+      id: "event-1",
+      senderId: "participant-1",
+      direction: "received" as const,
+      occurredAt: 1_000,
+      text: "Verified greeting",
+    },
+  ],
+};
+
+test("verified XChat rows merge with legacy DMs in chronological order", () => {
+  const merged = mergeXChatConversationMessages(
+    [
+      {
+        id: "legacy-1",
+        conversationId: "legacy-conversation-1",
+        text: "Legacy message",
+        direction: "received",
+        createdAt: "1970-01-01T00:00:01.500Z",
+      },
+    ],
+    session
+  );
+
+  assert.deepEqual(
+    merged.map((message) => message.id),
+    [
+      "xchat:xchat-conversation-1:event-1",
+      "legacy-1",
+      "xchat:xchat-conversation-1:event-2",
+    ]
+  );
+  assert.equal(merged[0]?.text, "Verified greeting");
+  assert.equal(merged[2]?.text, "Verified reply");
+});
+
+test("XChat message IDs are namespaced and duplicate decrypted events collapse", () => {
+  const messages = toXChatConversationMessages({
+    ...session,
+    messages: [
+      ...session.messages,
+      {
+        id: "event-1",
+        senderId: "participant-1",
+        direction: "received",
+        occurredAt: 1_000,
+        text: "Verified greeting",
+      },
+    ],
+  });
+  const merged = mergeXChatConversationMessages([], {
+    ...session,
+    messages: [...session.messages, ...session.messages],
+  });
+
+  assert.equal(messages[0]?.id, "xchat:xchat-conversation-1:event-2");
+  assert.equal(merged.length, 2);
+  assert.equal(merged[0]?.id, "xchat:xchat-conversation-1:event-1");
+});
+
+test("the X conversation panel mounts the shared XChat unlock and merge path", () => {
+  const source = readFileSync(
+    "features/prospects/ui/components/XConversationPanel.tsx",
+    "utf8"
+  );
+
+  assert.match(source, /useXChatBrowserSession/);
+  assert.match(source, /mergeXChatConversationMessages/);
+  assert.match(source, /<XChatConversationUnlock/);
+  assert.match(
+    source,
+    /Legacy X\/Twitter DM history is limited to the past 30/
+  );
+});

--- a/tests/xchat-conversation-panel.test.ts
+++ b/tests/xchat-conversation-panel.test.ts
@@ -88,6 +88,14 @@ test("the X conversation panel mounts the shared XChat unlock and merge path", (
     "features/prospects/ui/components/XConversationPanel.tsx",
     "utf8"
   );
+  const unlockSource = readFileSync(
+    "features/prospects/ui/components/XChatConversationUnlock.tsx",
+    "utf8"
+  );
+  const agentUnlockSource = readFileSync(
+    "features/agent/ui/components/xchat-history/XChatUnlockCard.tsx",
+    "utf8"
+  );
 
   assert.match(source, /useXChatBrowserSession/);
   assert.match(source, /mergeXChatConversationMessages/);
@@ -96,4 +104,9 @@ test("the X conversation panel mounts the shared XChat unlock and merge path", (
     source,
     /Legacy X\/Twitter DM history is limited to the past 30/
   );
+  assert.match(unlockSource, /session && !open/);
+  assert.doesNotMatch(unlockSource, /No readable messages/);
+  assert.doesNotMatch(unlockSource, /Unlocking…/);
+  assert.doesNotMatch(agentUnlockSource, /No readable messages/);
+  assert.doesNotMatch(agentUnlockSource, /Unlocking…/);
 });


### PR DESCRIPTION
## Summary
- share verified browser-memory XChat sessions between the Agent unlock flow and the prospect conversation panel
- merge verified XChat messages with legacy DMs chronologically without persisting plaintext
- add local panel unlock/lock UX and deduplicate concurrent same-realm auth-token calls

## Verification
- TypeScript and strict lint pass
- 18 focused regression tests pass
- full Vitest suite: 205/205 pass
- production build passes
- isolated preview E2E against production data: 16 verified XChat messages, 17 merged bubbles (12 sent / 5 received), reopen persistence, Lock returns to one legacy DM
- browser logs: zero new errors; Convex traces: three distinct realm-token requests, all successful, no duplicate 401

No production frontend or Convex deployment is included.