### PR TITLE
Simplify error boundary recovery UI

### DIFF
--- a/app/(webapp)/error.tsx
+++ b/app/(webapp)/error.tsx
@@ -1,48 +1,28 @@
 "use client";
 
-import Link from "next/link";
 import { useEffect } from "react";
-import { Button } from "@/shared/ui/components/Button";
+import { AppErrorState } from "@/shared/ui/components/AppErrorState";
 import { logger } from "@/shared/lib/logger";
 
 const webAppErrorLogger = logger.withScope("WebAppError");
 
 export default function WebAppError({
   error,
-  reset,
+  unstable_retry,
 }: {
   error: Error & { digest?: string };
-  reset: () => void;
+  unstable_retry: () => void;
 }) {
   useEffect(() => {
     webAppErrorLogger.error("Unhandled webapp error boundary event", error);
   }, [error]);
 
   return (
-    <div className="flex h-full min-h-0 items-center justify-center p-6">
-      <div className="bg-background w-full max-w-lg rounded-2xl border p-6 shadow-sm">
-        <p className="text-muted-foreground text-xs font-medium tracking-[0.18em] uppercase">
-          Unexpected error
-        </p>
-        <h2 className="mt-2 text-2xl font-semibold tracking-tight">
-          This page hit an unexpected problem.
-        </h2>
-        <p className="text-muted-foreground mt-3 text-sm leading-6">
-          Try reloading this part of the app. If the issue keeps happening, you
-          can return to the dashboard and continue working from there.
-        </p>
-        {error.digest ? (
-          <p className="text-muted-foreground mt-3 font-mono text-xs">
-            Reference: {error.digest}
-          </p>
-        ) : null}
-        <div className="mt-6 flex flex-wrap gap-2">
-          <Button onClick={() => reset()}>Try again</Button>
-          <Button asChild variant="outline">
-            <Link href="/">Go to dashboard</Link>
-          </Button>
-        </div>
-      </div>
-    </div>
+    <AppErrorState
+      className="min-h-full items-center px-6 py-16"
+      title="We couldn’t load this view."
+      description="Please try again, or return to your dashboard."
+      onRetry={unstable_retry}
+    />
   );
 }

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import Link from "next/link";
 import { useEffect } from "react";
-import { Button } from "@/shared/ui/components/Button";
+import { AppErrorState } from "@/shared/ui/components/AppErrorState";
 import { logger } from "@/shared/lib/logger";
 import { geistMono, geistPixelSquare, geistSans } from "./fonts";
 import "./globals.css";
@@ -11,10 +10,10 @@ const globalErrorLogger = logger.withScope("GlobalError");
 
 export default function GlobalError({
   error,
-  reset,
+  unstable_retry,
 }: {
   error: Error & { digest?: string };
-  reset: () => void;
+  unstable_retry: () => void;
 }) {
   useEffect(() => {
     globalErrorLogger.error("Unhandled global error boundary event", error);
@@ -26,31 +25,14 @@ export default function GlobalError({
         suppressHydrationWarning
         className={`${geistSans.variable} ${geistMono.variable} ${geistPixelSquare.variable} bg-background text-foreground antialiased`}
       >
-        <title>Something went wrong | ReacherX</title>
-        <main className="flex min-h-screen items-center justify-center p-6">
-          <div className="bg-background w-full max-w-xl rounded-2xl border p-6 shadow-sm">
-            <p className="text-muted-foreground text-xs font-medium tracking-[0.18em] uppercase">
-              Global error
-            </p>
-            <h1 className="mt-2 text-3xl font-semibold tracking-tight">
-              ReacherX ran into an unexpected failure.
-            </h1>
-            <p className="text-muted-foreground mt-3 text-sm leading-6">
-              Try reloading the app. If the error persists, return to the
-              dashboard and start a fresh session.
-            </p>
-            {error.digest ? (
-              <p className="text-muted-foreground mt-3 font-mono text-xs">
-                Reference: {error.digest}
-              </p>
-            ) : null}
-            <div className="mt-6 flex flex-wrap gap-2">
-              <Button onClick={() => reset()}>Try again</Button>
-              <Button asChild variant="outline">
-                <Link href="/">Go to dashboard</Link>
-              </Button>
-            </div>
-          </div>
+        <title>Couldn’t load ReacherX | ReacherX</title>
+        <main className="flex min-h-screen items-center justify-center">
+          <AppErrorState
+            className="px-6 py-16"
+            title="We couldn’t load this page."
+            description="Please try again, or return to your dashboard."
+            onRetry={unstable_retry}
+          />
         </main>
       </body>
     </html>

--- a/shared/ui/components/AppErrorState.tsx
+++ b/shared/ui/components/AppErrorState.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Button } from "@/shared/ui/components/Button";
+import { navigateDocumentIntentionally } from "@/shared/lib/convex/intentionalDocumentNavigation";
+import { cn } from "@/shared/lib/utils";
+
+interface AppErrorStateProps {
+  title: string;
+  description: string;
+  onRetry: () => void;
+  className?: string;
+}
+
+export function AppErrorState({
+  title,
+  description,
+  onRetry,
+  className,
+}: AppErrorStateProps) {
+  return (
+    <section
+      aria-labelledby="app-error-title"
+      role="alert"
+      className={cn("flex w-full justify-center text-center", className)}
+    >
+      <div className="w-full max-w-sm">
+        <h1
+          id="app-error-title"
+          className="text-foreground text-base font-medium tracking-tight"
+        >
+          {title}
+        </h1>
+        <p className="text-muted-foreground mt-2 text-sm leading-6 text-pretty">
+          {description}
+        </p>
+        <div className="mt-5 flex items-center justify-center gap-1.5">
+          <Button type="button" variant="default" size="xs" onClick={onRetry}>
+            Try again
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="xs"
+            onClick={() => navigateDocumentIntentionally("/")}
+          >
+            Dashboard
+          </Button>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- replace reset() with unstable_retry() in the segment and global error boundaries
- centralize the fallback state in a shared component
- simplify the UI to a minimal text-only recovery state

## Validation
- pnpm exec tsc --noEmit --pretty false
- pnpm lint
- pnpm build
- npx react-doctor@latest . --verbose --diff (100/100)
- browser visual preview verified
