### PR TITLE
Fix sent DM payloads appearing in composers

### DIFF
--- a/convex/outreach.ts
+++ b/convex/outreach.ts
@@ -104,6 +104,7 @@ import {
   hasDmBody,
   hasPostBody,
 } from "../shared/lib/twitter/xPostTextLimit";
+import { resolveTaskDmComposerState } from "../shared/lib/outreach/taskDmComposerHelpers";
 import { getEffectivePostTextLimitForUser } from "./lib/xPostLimits";
 import { resumeOutreachPlansAfterUnarchiveCore } from "./lib/resumeOutreachAfterUnarchive";
 import {
@@ -1574,6 +1575,21 @@ export const getAgentPanelContext = query({
       getStringProperty(resultData, "text") ||
       task.content ||
       "";
+    const taskDraft = {
+      content: task.content || "",
+      mediaUrls: task.mediaUrls || [],
+      mediaDescriptions: task.mediaDescriptions || [],
+      mediaKinds: normalizeMediaKinds(task.mediaKinds, task.mediaUrls || []),
+    };
+    const draft =
+      task.type === "dm"
+        ? (resolveTaskDmComposerState({
+            taskId: task._id,
+            taskMode: mode,
+            taskStatus: task.status,
+            taskDraft,
+          }).draft ?? null)
+        : taskDraft;
 
     return {
       kind: task.type === "dm" ? "dm" : "post",
@@ -1585,12 +1601,7 @@ export const getAgentPanelContext = query({
       approvalReady: Boolean(task.approvalEventId),
       resolvedTaskId: task._id,
       targetTweetId: task.targetTweetId,
-      draft: {
-        content: task.content || "",
-        mediaUrls: task.mediaUrls || [],
-        mediaDescriptions: task.mediaDescriptions || [],
-        mediaKinds: normalizeMediaKinds(task.mediaKinds, task.mediaUrls || []),
-      },
+      draft,
       originalPost:
         task.type === "comment" &&
         (sourcePostSummary || fallbackSource?.sourcePostData)

--- a/convex/outreachPanelContext.integration.test.ts
+++ b/convex/outreachPanelContext.integration.test.ts
@@ -1,0 +1,179 @@
+/// <reference types="vite/client" />
+
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { api } from "./_generated/api";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+
+async function seedDmPanelContexts(
+  t: ReturnType<typeof convexTest>,
+  platform: "twitter" | "linkedin"
+) {
+  return await t.run(async (ctx) => {
+    const workosUserId = `panel-context-${platform}`;
+    const userId = await ctx.db.insert("users", {
+      workosUserId,
+      email: `${platform}@example.com`,
+    });
+    const workspaceId = await ctx.db.insert("workspaces", {
+      userId,
+      name: `${platform} panel workspace`,
+      description: "DM panel regression workspace",
+      isDefault: true,
+      entitlementSlot: 1,
+      updatedAt: 1,
+    });
+    const prospectId = await ctx.db.insert("prospects", {
+      workspaceId,
+      userId,
+      platform,
+      origin: "workspace_discovery",
+      externalId: `${platform}-panel-prospect`,
+      data: {},
+      status: "contacted",
+      qualificationStatus: "qualified",
+      displayName: `${platform} panel prospect`,
+      updatedAt: 1,
+    });
+    const planId = await ctx.db.insert("outreachPlans", {
+      prospectId,
+      workspaceId,
+      userId,
+      status: "executing",
+      strategy: {
+        rationale: "Test task panel state.",
+        valueProposition: "Regression coverage.",
+        tone: "peer",
+      },
+      version: 1,
+      updatedAt: 1,
+    });
+    const draft = {
+      content: `${platform} pending DM text`,
+      mediaUrls: [`https://cdn.example.com/${platform}-pending.png`],
+      mediaDescriptions: [`${platform} pending caption`],
+      mediaKinds: ["image" as const],
+    };
+    const pendingTaskId = await ctx.db.insert("outreachTasks", {
+      planId,
+      order: 1,
+      type: "dm",
+      description: "Pending DM",
+      ...draft,
+      status: "pending",
+      timing: { type: "immediate" },
+      approvalContext: { platform, panelMode: "approval" },
+    });
+    const completedTaskId = await ctx.db.insert("outreachTasks", {
+      planId,
+      order: 2,
+      type: "dm",
+      description: "Completed DM",
+      ...draft,
+      status: "completed",
+      timing: { type: "immediate" },
+      executedAt: 2,
+      approvalContext: { platform, panelMode: "posted" },
+      resultData: {
+        conversationId: `${platform}-conversation`,
+        messageId: `${platform}-message`,
+        postedAt: 2,
+        postedText: draft.content,
+        postedMediaUrls: draft.mediaUrls,
+        postedMediaDescriptions: draft.mediaDescriptions,
+        postedMediaKinds: draft.mediaKinds,
+      },
+    });
+
+    return { completedTaskId, draft, pendingTaskId, prospectId, workosUserId };
+  });
+}
+
+describe("outreach DM panel context", () => {
+  for (const platform of ["twitter", "linkedin"] as const) {
+    test(`${platform} exposes payload for approval but not after send`, async () => {
+      const t = convexTest(schema, modules);
+      const seeded = await seedDmPanelContexts(t, platform);
+      const authenticated = t.withIdentity({ subject: seeded.workosUserId });
+
+      const pending = await authenticated.query(
+        api.outreach.getAgentPanelContext,
+        {
+          prospectId: seeded.prospectId,
+          taskId: seeded.pendingTaskId,
+        }
+      );
+      const completed = await authenticated.query(
+        api.outreach.getAgentPanelContext,
+        {
+          prospectId: seeded.prospectId,
+          taskId: seeded.completedTaskId,
+        }
+      );
+
+      expect(pending).toMatchObject({
+        kind: "dm",
+        mode: "approval",
+        platform,
+        draft: seeded.draft,
+        posted: null,
+      });
+      expect(completed).toMatchObject({
+        kind: "dm",
+        mode: "posted",
+        platform,
+        draft: null,
+        posted: {
+          conversationId: `${platform}-conversation`,
+          messageId: `${platform}-message`,
+          text: seeded.draft.content,
+          mediaUrls: seeded.draft.mediaUrls,
+          mediaDescriptions: seeded.draft.mediaDescriptions,
+          mediaKinds: seeded.draft.mediaKinds,
+        },
+      });
+    });
+  }
+
+  test("completed comment panels retain their existing draft context", async () => {
+    const t = convexTest(schema, modules);
+    const seeded = await seedDmPanelContexts(t, "twitter");
+    const commentTaskId = await t.run(async (ctx) => {
+      const dmTask = await ctx.db.get(seeded.pendingTaskId);
+      if (!dmTask) throw new Error("Seeded task not found");
+      return await ctx.db.insert("outreachTasks", {
+        planId: dmTask.planId,
+        order: 3,
+        type: "comment",
+        description: "Completed reply",
+        content: "Previously posted reply",
+        status: "completed",
+        timing: { type: "immediate" },
+        targetTweetId: "source-post",
+        executedAt: 2,
+        approvalContext: { platform: "twitter", panelMode: "posted" },
+        resultData: {
+          postedTweetId: "posted-reply",
+          postedText: "Previously posted reply",
+          postedAt: 2,
+        },
+      });
+    });
+
+    const context = await t
+      .withIdentity({ subject: seeded.workosUserId })
+      .query(api.outreach.getAgentPanelContext, {
+        prospectId: seeded.prospectId,
+        taskId: commentTaskId,
+      });
+
+    expect(context?.draft).toEqual({
+      content: "Previously posted reply",
+      mediaUrls: [],
+      mediaDescriptions: [],
+      mediaKinds: [],
+    });
+  });
+});

--- a/features/agent/ui/components/AgentDynamicPanel.tsx
+++ b/features/agent/ui/components/AgentDynamicPanel.tsx
@@ -458,6 +458,8 @@ export function AgentDynamicPanel({
   const taskReplySubmitButtonText =
     taskApprovalUi?.submitButtonText ?? "Approve reply";
   const isTaskBackedDmContext = taskPanelKind === "dm";
+  const isTaskBackedDmApprovalContext =
+    isTaskBackedDmContext && mode === "approval";
   const isLinkedInDmAction =
     actionPanelData?.actionKey === "linkedin_send_message" ||
     actionPanelData?.actionKey ===
@@ -920,15 +922,21 @@ export function AgentDynamicPanel({
             isTaskBackedDmContext ? taskPanelData?.taskStatus : undefined
           }
           taskMode={mode}
-          taskApprovalReady={isTaskBackedDmContext && taskPanelApprovalReady}
+          taskApprovalReady={
+            isTaskBackedDmApprovalContext && taskPanelApprovalReady
+          }
           taskPlanId={
-            isTaskBackedDmContext ? (taskPanelData?.planId ?? null) : null
+            isTaskBackedDmApprovalContext
+              ? (taskPanelData?.planId ?? null)
+              : null
           }
           taskPlanStatus={
-            isTaskBackedDmContext ? taskPanelData?.planStatus : undefined
+            isTaskBackedDmApprovalContext
+              ? taskPanelData?.planStatus
+              : undefined
           }
           taskDraft={
-            isTaskBackedDmContext
+            isTaskBackedDmApprovalContext
               ? (taskPanelData?.draft ?? undefined)
               : undefined
           }
@@ -950,15 +958,17 @@ export function AgentDynamicPanel({
           isTaskBackedDmContext ? taskPanelData?.taskStatus : undefined
         }
         taskMode={mode}
-        taskApprovalReady={isTaskBackedDmContext && taskPanelApprovalReady}
+        taskApprovalReady={
+          isTaskBackedDmApprovalContext && taskPanelApprovalReady
+        }
         taskPlanId={
-          isTaskBackedDmContext ? (taskPanelData?.planId ?? null) : null
+          isTaskBackedDmApprovalContext ? (taskPanelData?.planId ?? null) : null
         }
         taskPlanStatus={
-          isTaskBackedDmContext ? taskPanelData?.planStatus : undefined
+          isTaskBackedDmApprovalContext ? taskPanelData?.planStatus : undefined
         }
         taskDraft={
-          isTaskBackedDmContext
+          isTaskBackedDmApprovalContext
             ? (taskPanelData?.draft ?? undefined)
             : undefined
         }

--- a/features/prospects/ui/components/LinkedInConversationPanel.tsx
+++ b/features/prospects/ui/components/LinkedInConversationPanel.tsx
@@ -44,6 +44,7 @@ import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
 import { useDebouncedDraftSync } from "@/features/agent/hooks/useDebouncedDraftSync";
 import { resolveOutreachTaskApprovalUiState } from "@/shared/lib/outreach/taskApprovalHelpers";
+import { resolveTaskDmComposerState } from "@/shared/lib/outreach/taskDmComposerHelpers";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -155,17 +156,39 @@ export function LinkedInConversationPanel({
   );
   const approveTaskWithEdits = useMutation(api.outreach.approveTaskWithEdits);
   const approvePlan = useMutation(api.outreach.approvePlan);
-  const [currentDraftText, setCurrentDraftText] = React.useState("");
-  const lastServerDraftRef = React.useRef<string | undefined>(undefined);
-
-  React.useEffect(() => {
-    lastServerDraftRef.current = undefined;
-  }, [prospectId, actionRequestId]);
 
   const resolvedData = previewData ?? data;
   const resolvedLoading = isPreview ? false : loading;
   const resolvedError = isPreview ? null : error;
   const profileUrl = resolvedData?.prospect.profileUrl;
+  const taskComposerState = React.useMemo(
+    () =>
+      resolveTaskDmComposerState({
+        taskId,
+        taskMode,
+        taskStatus,
+        taskDraft,
+      }),
+    [taskDraft, taskId, taskMode, taskStatus]
+  );
+  const taskDraftForComposer = taskComposerState.draft;
+  const isTaskApprovalComposer = taskComposerState.behavior === "task-approval";
+  const serverDraft =
+    (isTaskBacked ? taskDraftForComposer?.content : resolvedData?.draftText) ??
+    "";
+  const draftSourceKey = isTaskBacked
+    ? taskComposerState.resetKey
+    : `${prospectId}:${actionRequestId ?? "live"}`;
+  const [localDraftState, setLocalDraftState] = React.useState<{
+    sourceKey: string;
+    serverValue: string;
+    text: string;
+  } | null>(null);
+  const currentDraftText =
+    localDraftState?.sourceKey === draftSourceKey &&
+    localDraftState.serverValue === serverDraft
+      ? localDraftState.text
+      : serverDraft;
   const messagingRecoveryAction = resolveLinkedInRecoveryAction(
     resolvedData?.eligibility.reasonCode
   );
@@ -173,20 +196,10 @@ export function LinkedInConversationPanel({
     resolvedData?.warning?.code
   );
 
-  React.useEffect(() => {
-    const serverDraft =
-      (isTaskBacked ? taskDraft?.content : resolvedData?.draftText) ?? "";
-    if (lastServerDraftRef.current === serverDraft) {
-      return;
-    }
-    lastServerDraftRef.current = serverDraft;
-    setCurrentDraftText(serverDraft);
-  }, [isTaskBacked, resolvedData?.draftText, taskDraft?.content]);
-
   const initialMediaUploads = React.useMemo<ComposerInitialMediaUpload[]>(
     () =>
-      (taskDraft?.mediaUrls ?? []).map((url, index) => {
-        const mediaKind = taskDraft?.mediaKinds?.[index] ?? "image";
+      (taskDraftForComposer?.mediaUrls ?? []).map((url, index) => {
+        const mediaKind = taskDraftForComposer?.mediaKinds?.[index] ?? "image";
         return {
           id: `linkedin-task-dm-media-${index}`,
           url,
@@ -198,22 +211,29 @@ export function LinkedInConversationPanel({
                 ? "file"
                 : "image",
           mediaKind,
-          description: taskDraft?.mediaDescriptions?.[index] ?? undefined,
+          description:
+            taskDraftForComposer?.mediaDescriptions?.[index] ?? undefined,
         };
       }),
-    [taskDraft?.mediaDescriptions, taskDraft?.mediaKinds, taskDraft?.mediaUrls]
+    [taskDraftForComposer]
   );
+  const visiblePanelDraftAttachments = isTaskBacked
+    ? undefined
+    : resolvedData?.draftAttachments;
+  const composerResetKey = isTaskBacked
+    ? taskComposerState.resetKey
+    : `${actionRequestId ?? "live"}:${actionRequestStatus ?? "none"}`;
 
   const draftSync = useDebouncedDraftSync({
     enabled: isTaskBacked
-      ? taskMode === "approval" &&
+      ? isTaskApprovalComposer &&
         Boolean(taskId) &&
         (taskStatus === "pending" || taskStatus === "executing")
       : Boolean(actionRequestId && data && isPendingApproval),
     value: currentDraftText,
-    persistedValue: (isTaskBacked ? taskDraft?.content : data?.draftText) ?? "",
+    persistedValue: serverDraft,
     onSave: async (nextValue) => {
-      if (isTaskBacked) {
+      if (isTaskApprovalComposer) {
         if (!taskId) {
           return;
         }
@@ -221,10 +241,13 @@ export function LinkedInConversationPanel({
           taskId: taskId as Id<"outreachTasks">,
           expectedType: "dm",
           content: nextValue,
-          mediaUrls: taskDraft?.mediaUrls,
-          mediaDescriptions: taskDraft?.mediaDescriptions,
-          mediaKinds: taskDraft?.mediaKinds,
+          mediaUrls: taskDraftForComposer?.mediaUrls,
+          mediaDescriptions: taskDraftForComposer?.mediaDescriptions,
+          mediaKinds: taskDraftForComposer?.mediaKinds,
         });
+        return;
+      }
+      if (isTaskBacked) {
         return;
       }
       if (!actionRequestId || !isPendingApproval) {
@@ -274,9 +297,8 @@ export function LinkedInConversationPanel({
     planStatus: taskPlanStatus,
   });
   const shouldDisableTaskSubmit =
-    isTaskBacked &&
-    (taskMode !== "approval" ||
-      (taskStatus !== "pending" && taskStatus !== "executing") ||
+    isTaskApprovalComposer &&
+    ((taskStatus !== "pending" && taskStatus !== "executing") ||
       (taskApprovalUi.submitBlockedByPlan &&
         !taskApprovalUi.planCanBeApproved));
 
@@ -291,37 +313,43 @@ export function LinkedInConversationPanel({
         const nextText = extractTextFromEditorState(content).trim();
         const resolvedMediaUrls = mediaUrls?.length
           ? mediaUrls
-          : isTaskBacked
-            ? taskDraft?.mediaUrls
-            : resolvedData?.draftAttachments
-                ?.map(
-                  (attachment: LinkedInConversationAttachmentSummary) =>
-                    attachment.url
-                )
-                .filter((url: string | undefined): url is string =>
-                  Boolean(url)
-                );
+          : isTaskApprovalComposer
+            ? taskDraftForComposer?.mediaUrls
+            : isTaskBacked
+              ? undefined
+              : resolvedData?.draftAttachments
+                  ?.map(
+                    (attachment: LinkedInConversationAttachmentSummary) =>
+                      attachment.url
+                  )
+                  .filter((url: string | undefined): url is string =>
+                    Boolean(url)
+                  );
         const resolvedDescriptions = mediaDescriptions?.length
           ? mediaDescriptions
-          : isTaskBacked
-            ? taskDraft?.mediaDescriptions
-            : resolvedData?.draftAttachments?.map(
-                (attachment: LinkedInConversationAttachmentSummary) =>
-                  attachment.altText ?? ""
-              );
+          : isTaskApprovalComposer
+            ? taskDraftForComposer?.mediaDescriptions
+            : isTaskBacked
+              ? undefined
+              : resolvedData?.draftAttachments?.map(
+                  (attachment: LinkedInConversationAttachmentSummary) =>
+                    attachment.altText ?? ""
+                );
         const resolvedMediaKinds = mediaKinds?.length
           ? mediaKinds
-          : isTaskBacked
-            ? taskDraft?.mediaKinds
+          : isTaskApprovalComposer
+            ? taskDraftForComposer?.mediaKinds
             : undefined;
 
         if (!nextText && !(resolvedMediaUrls && resolvedMediaUrls.length > 0)) {
           return;
         }
 
-        if (isTaskBacked) {
+        if (isTaskApprovalComposer) {
+          if (!taskId) {
+            return;
+          }
           if (
-            taskMode === "approval" &&
             taskApprovalUi.submitBlockedByPlan &&
             taskApprovalUi.planCanBeApproved
           ) {
@@ -356,7 +384,11 @@ export function LinkedInConversationPanel({
         }
 
         await send(nextText, resolvedMediaUrls, resolvedDescriptions);
-        setCurrentDraftText("");
+        setLocalDraftState({
+          sourceKey: draftSourceKey,
+          serverValue: serverDraft,
+          text: "",
+        });
       } catch (err) {
         toast.error("Failed to send LinkedIn message", {
           description: err instanceof Error ? err.message : "Please try again.",
@@ -366,14 +398,16 @@ export function LinkedInConversationPanel({
     [
       approvePlan,
       approveTaskWithEdits,
+      draftSourceKey,
+      isTaskApprovalComposer,
       isTaskBacked,
       resolvedData,
       send,
+      serverDraft,
       taskApprovalUi.planCanBeApproved,
       taskApprovalUi.submitBlockedByPlan,
-      taskDraft,
+      taskDraftForComposer,
       taskId,
-      taskMode,
       taskPlanId,
       updatePendingTaskDraft,
     ]
@@ -389,12 +423,11 @@ export function LinkedInConversationPanel({
 
   const shouldDisableComposer =
     isPreview ||
-    (!isTaskBacked &&
+    (!isTaskApprovalComposer &&
       (!resolvedData ||
         !resolvedData.eligibility.enabled ||
         isSendingActionRequest ||
-        isSendingMessage)) ||
-    Boolean(taskMode === "posted");
+        isSendingMessage));
   const inlineDraftStatus =
     draftSync.status === "saving" ? (
       <span className="text-muted-foreground text-xs">Saving</span>
@@ -408,7 +441,8 @@ export function LinkedInConversationPanel({
     ) : !isTaskBacked && isPendingApproval && isSendingActionRequest ? (
       <span className="text-muted-foreground text-xs">Sending</span>
     ) : null;
-  const shouldRenderDraftStatusSlot = isTaskBacked || isPendingApproval;
+  const shouldRenderDraftStatusSlot =
+    isTaskApprovalComposer || isPendingApproval;
   const draftStatusSlot =
     shouldRenderDraftStatusSlot && inlineDraftStatus
       ? inlineDraftStatus
@@ -688,9 +722,9 @@ export function LinkedInConversationPanel({
           </ScrollArea>
 
           <div className="bg-background shrink-0 px-4 pt-2 pb-4 backdrop-blur-xl">
-            {resolvedData?.draftAttachments?.length ? (
+            {visiblePanelDraftAttachments?.length ? (
               <div className="mb-3 grid gap-2">
-                {resolvedData.draftAttachments.map(
+                {visiblePanelDraftAttachments.map(
                   (
                     attachment: LinkedInConversationAttachmentSummary,
                     index: number
@@ -718,7 +752,7 @@ export function LinkedInConversationPanel({
               </div>
             ) : null}
             <BaseComposer
-              key={`linkedin-dm-composer:${prospectId}:${actionRequestId ?? "live"}:${actionRequestStatus ?? "none"}`}
+              key={`linkedin-dm-composer:${prospectId}:${composerResetKey}`}
               currentUser={currentUser}
               initialContent={buildSerializedTextState(currentDraftText)}
               initialMediaUploads={initialMediaUploads}
@@ -726,9 +760,11 @@ export function LinkedInConversationPanel({
               maxLength={LINKEDIN_DM_TEXT_MAX}
               characterCountMode="raw"
               submitButtonText={
-                isTaskBacked ? taskApprovalUi.submitButtonText : "Send"
+                isTaskApprovalComposer
+                  ? taskApprovalUi.submitButtonText
+                  : "Send"
               }
-              submitButtonVariant={isTaskBacked ? "text" : "icon"}
+              submitButtonVariant={isTaskApprovalComposer ? "text" : "icon"}
               toolbarPlacement="bottom"
               showIdentityHeader={false}
               showMediaDescription={false}
@@ -765,7 +801,11 @@ export function LinkedInConversationPanel({
               }}
               className="rounded-xl border p-2"
               onContentChange={(content) => {
-                setCurrentDraftText(extractTextFromEditorState(content).trim());
+                setLocalDraftState({
+                  sourceKey: draftSourceKey,
+                  serverValue: serverDraft,
+                  text: extractTextFromEditorState(content).trim(),
+                });
               }}
               onEditorBlur={() => {
                 void draftSync.flushNow();

--- a/features/prospects/ui/components/XConversationPanel.tsx
+++ b/features/prospects/ui/components/XConversationPanel.tsx
@@ -44,6 +44,7 @@ import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
 import { useDebouncedDraftSync } from "@/features/agent/hooks/useDebouncedDraftSync";
 import { resolveOutreachTaskApprovalUiState } from "@/shared/lib/outreach/taskApprovalHelpers";
+import { resolveTaskDmComposerState } from "@/shared/lib/outreach/taskDmComposerHelpers";
 import { X_DM_TEXT_MAX } from "@/shared/lib/twitter/xPostTextLimit";
 import type { XDmAttachmentSummary, XDmMessage } from "@/shared/lib/twitter/dm";
 import type {
@@ -130,41 +131,57 @@ export function XConversationPanel({
   );
   const approveTaskWithEdits = useMutation(api.outreach.approveTaskWithEdits);
   const approvePlan = useMutation(api.outreach.approvePlan);
-  const [currentDraftText, setCurrentDraftText] = React.useState("");
   const profileUrl = data?.prospect.profileUrl;
-  const lastServerDraftRef = React.useRef<string | undefined>(undefined);
-
-  React.useEffect(() => {
-    lastServerDraftRef.current = undefined;
-  }, [prospectId, actionRequestId]);
-
-  // Sync local draft only when the server/Convex draft value changes — never when the editor
-  // blurs (e.g. emoji popover), or we wipe typed text and the composer resets to stale draft.
-  React.useEffect(() => {
-    const serverDraft =
-      (isTaskBacked ? taskDraft?.content : data?.draftText) ?? "";
-    if (lastServerDraftRef.current === serverDraft) {
-      return;
-    }
-    lastServerDraftRef.current = serverDraft;
-    setCurrentDraftText(serverDraft);
-  }, [data?.draftText, isTaskBacked, taskDraft?.content]);
+  const taskComposerState = React.useMemo(
+    () =>
+      resolveTaskDmComposerState({
+        taskId,
+        taskMode,
+        taskStatus,
+        taskDraft,
+      }),
+    [taskDraft, taskId, taskMode, taskStatus]
+  );
+  const taskDraftForComposer = taskComposerState.draft;
+  const isTaskApprovalComposer = taskComposerState.behavior === "task-approval";
+  const serverDraft =
+    (isTaskBacked ? taskDraftForComposer?.content : data?.draftText) ?? "";
+  const draftSourceKey = isTaskBacked
+    ? taskComposerState.resetKey
+    : `${prospectId}:${actionRequestId ?? "live"}`;
+  const [localDraftState, setLocalDraftState] = React.useState<{
+    sourceKey: string;
+    serverValue: string;
+    text: string;
+  } | null>(null);
+  const currentDraftText =
+    localDraftState?.sourceKey === draftSourceKey &&
+    localDraftState.serverValue === serverDraft
+      ? localDraftState.text
+      : serverDraft;
 
   const initialMediaUploads = React.useMemo<ComposerInitialMediaUpload[]>(
     () =>
-      (taskDraft?.mediaUrls ?? []).map((url, index) => ({
+      (taskDraftForComposer?.mediaUrls ?? []).map((url, index) => ({
         id: `task-dm-media-${index}`,
         url,
         serverUrl: url,
         type:
-          (taskDraft?.mediaKinds?.[index] ?? "image") === "video"
+          (taskDraftForComposer?.mediaKinds?.[index] ?? "image") === "video"
             ? "video"
             : "image",
-        mediaKind: taskDraft?.mediaKinds?.[index] ?? "image",
-        description: taskDraft?.mediaDescriptions?.[index] ?? undefined,
+        mediaKind: taskDraftForComposer?.mediaKinds?.[index] ?? "image",
+        description:
+          taskDraftForComposer?.mediaDescriptions?.[index] ?? undefined,
       })),
-    [taskDraft?.mediaDescriptions, taskDraft?.mediaKinds, taskDraft?.mediaUrls]
+    [taskDraftForComposer]
   );
+  const visiblePanelDraftAttachments = isTaskBacked
+    ? undefined
+    : data?.draftAttachments;
+  const composerResetKey = isTaskBacked
+    ? taskComposerState.resetKey
+    : `${actionRequestId ?? "live"}:${actionRequestStatus ?? "none"}`;
 
   const resolvedTwitterUsername = React.useMemo(() => {
     const p = data?.prospect;
@@ -228,14 +245,14 @@ export function XConversationPanel({
 
   const draftSync = useDebouncedDraftSync({
     enabled: isTaskBacked
-      ? taskMode === "approval" &&
+      ? isTaskApprovalComposer &&
         Boolean(taskId) &&
         (taskStatus === "pending" || taskStatus === "executing")
       : Boolean(actionRequestId && data && isPendingApproval),
     value: currentDraftText,
-    persistedValue: (isTaskBacked ? taskDraft?.content : data?.draftText) ?? "",
+    persistedValue: serverDraft,
     onSave: async (nextValue) => {
-      if (isTaskBacked) {
+      if (isTaskApprovalComposer) {
         if (!taskId) {
           return;
         }
@@ -243,10 +260,13 @@ export function XConversationPanel({
           taskId: taskId as Id<"outreachTasks">,
           expectedType: "dm",
           content: nextValue,
-          mediaUrls: taskDraft?.mediaUrls,
-          mediaDescriptions: taskDraft?.mediaDescriptions,
-          mediaKinds: taskDraft?.mediaKinds,
+          mediaUrls: taskDraftForComposer?.mediaUrls,
+          mediaDescriptions: taskDraftForComposer?.mediaDescriptions,
+          mediaKinds: taskDraftForComposer?.mediaKinds,
         });
+        return;
+      }
+      if (isTaskBacked) {
         return;
       }
       if (!actionRequestId || !isPendingApproval) {
@@ -274,9 +294,8 @@ export function XConversationPanel({
     planStatus: taskPlanStatus,
   });
   const shouldDisableTaskSubmit =
-    isTaskBacked &&
-    (taskMode !== "approval" ||
-      (taskStatus !== "pending" && taskStatus !== "executing") ||
+    isTaskApprovalComposer &&
+    ((taskStatus !== "pending" && taskStatus !== "executing") ||
       (taskApprovalUi.submitBlockedByPlan &&
         !taskApprovalUi.planCanBeApproved));
 
@@ -291,31 +310,37 @@ export function XConversationPanel({
         const nextText = extractTextFromEditorState(content).trim();
         const resolvedMediaUrls = mediaUrls?.length
           ? mediaUrls
-          : isTaskBacked
-            ? taskDraft?.mediaUrls
-            : data?.draftAttachments
-                ?.map((attachment: XDmAttachmentSummary) => attachment.url)
-                .filter((url: string | undefined): url is string =>
-                  Boolean(url)
-                );
+          : isTaskApprovalComposer
+            ? taskDraftForComposer?.mediaUrls
+            : isTaskBacked
+              ? undefined
+              : data?.draftAttachments
+                  ?.map((attachment: XDmAttachmentSummary) => attachment.url)
+                  .filter((url: string | undefined): url is string =>
+                    Boolean(url)
+                  );
         const resolvedDescriptions = mediaDescriptions?.length
           ? mediaDescriptions
-          : isTaskBacked
-            ? taskDraft?.mediaDescriptions
-            : data?.draftAttachments?.map(
-                (attachment: XDmAttachmentSummary) => attachment.altText ?? ""
-              );
+          : isTaskApprovalComposer
+            ? taskDraftForComposer?.mediaDescriptions
+            : isTaskBacked
+              ? undefined
+              : data?.draftAttachments?.map(
+                  (attachment: XDmAttachmentSummary) => attachment.altText ?? ""
+                );
         const resolvedMediaKinds = mediaKinds?.length
           ? mediaKinds
-          : isTaskBacked
-            ? taskDraft?.mediaKinds
+          : isTaskApprovalComposer
+            ? taskDraftForComposer?.mediaKinds
             : undefined;
         if (!nextText && !(resolvedMediaUrls && resolvedMediaUrls.length > 0)) {
           return;
         }
-        if (isTaskBacked) {
+        if (isTaskApprovalComposer) {
+          if (!taskId) {
+            return;
+          }
           if (
-            taskMode === "approval" &&
             taskApprovalUi.submitBlockedByPlan &&
             taskApprovalUi.planCanBeApproved
           ) {
@@ -349,7 +374,11 @@ export function XConversationPanel({
           return;
         }
         await send(nextText, resolvedMediaUrls, resolvedDescriptions);
-        setCurrentDraftText("");
+        setLocalDraftState({
+          sourceKey: draftSourceKey,
+          serverValue: serverDraft,
+          text: "",
+        });
         toast.success("DM sent on X/Twitter");
       } catch (err) {
         toast.error("Failed to send DM", {
@@ -361,13 +390,15 @@ export function XConversationPanel({
       approvePlan,
       approveTaskWithEdits,
       data,
+      draftSourceKey,
+      isTaskApprovalComposer,
       isTaskBacked,
       send,
+      serverDraft,
       taskApprovalUi.planCanBeApproved,
       taskApprovalUi.submitBlockedByPlan,
-      taskDraft,
+      taskDraftForComposer,
       taskId,
-      taskMode,
       taskPlanId,
       updatePendingTaskDraft,
     ]
@@ -382,9 +413,8 @@ export function XConversationPanel({
   }, [cancel, isTaskBacked]);
 
   const shouldDisableComposer =
-    (!isTaskBacked &&
-      (!data || !data.eligibility.enabled || isSendingActionRequest)) ||
-    Boolean(taskMode === "posted");
+    !isTaskApprovalComposer &&
+    (!data || !data.eligibility.enabled || isSendingActionRequest);
   const inlineDraftStatus =
     draftSync.status === "saving" ? (
       <span className="text-muted-foreground text-xs">Saving</span>
@@ -398,7 +428,8 @@ export function XConversationPanel({
     ) : !isTaskBacked && isPendingApproval && isSendingActionRequest ? (
       <span className="text-muted-foreground text-xs">Sending</span>
     ) : null;
-  const shouldRenderDraftStatusSlot = isTaskBacked || isPendingApproval;
+  const shouldRenderDraftStatusSlot =
+    isTaskApprovalComposer || isPendingApproval;
   const draftStatusSlot =
     shouldRenderDraftStatusSlot && inlineDraftStatus
       ? inlineDraftStatus
@@ -623,9 +654,9 @@ export function XConversationPanel({
           </ScrollArea>
 
           <div className="bg-background shrink-0 px-4 pt-2 pb-4 backdrop-blur-xl">
-            {data?.draftAttachments?.length ? (
+            {visiblePanelDraftAttachments?.length ? (
               <div className="mb-3 grid gap-2">
-                {data.draftAttachments.map(
+                {visiblePanelDraftAttachments.map(
                   (attachment: XDmAttachmentSummary, index: number) => (
                     <div
                       key={`${attachment.url ?? "draft-attachment"}-${index}`}
@@ -645,7 +676,7 @@ export function XConversationPanel({
               </div>
             ) : null}
             <BaseComposer
-              key={`x-dm-composer:${prospectId}:${actionRequestId ?? "live"}:${actionRequestStatus ?? "none"}`}
+              key={`x-dm-composer:${prospectId}:${composerResetKey}`}
               currentUser={currentUser}
               initialContent={buildSerializedTextState(currentDraftText)}
               initialMediaUploads={initialMediaUploads}
@@ -653,9 +684,11 @@ export function XConversationPanel({
               maxLength={X_DM_TEXT_MAX}
               characterCountMode="raw"
               submitButtonText={
-                isTaskBacked ? taskApprovalUi.submitButtonText : "Send"
+                isTaskApprovalComposer
+                  ? taskApprovalUi.submitButtonText
+                  : "Send"
               }
-              submitButtonVariant={isTaskBacked ? "text" : "icon"}
+              submitButtonVariant={isTaskApprovalComposer ? "text" : "icon"}
               toolbarPlacement="bottom"
               showIdentityHeader={false}
               showMediaDescription={false}
@@ -691,7 +724,11 @@ export function XConversationPanel({
               }}
               className="rounded-xl border p-2"
               onContentChange={(content) => {
-                setCurrentDraftText(extractTextFromEditorState(content).trim());
+                setLocalDraftState({
+                  sourceKey: draftSourceKey,
+                  serverValue: serverDraft,
+                  text: extractTextFromEditorState(content).trim(),
+                });
               }}
               onEditorBlur={() => {
                 void draftSync.flushNow();

--- a/shared/lib/outreach/taskDmComposerHelpers.ts
+++ b/shared/lib/outreach/taskDmComposerHelpers.ts
@@ -1,0 +1,38 @@
+export type TaskDmComposerBehavior = "task-approval" | "fresh-send";
+
+export interface ResolveTaskDmComposerStateArgs<TDraft> {
+  taskId?: string | null;
+  taskMode?: "approval" | "posted" | null;
+  taskStatus?: string;
+  taskDraft?: TDraft;
+}
+
+export interface TaskDmComposerState<TDraft> {
+  behavior: TaskDmComposerBehavior;
+  draft?: TDraft;
+  resetKey: string;
+}
+
+const SENT_TASK_STATUSES = new Set(["waiting_response", "completed"]);
+
+/**
+ * Keeps an outreach task's persisted payload isolated to its approval composer.
+ * Once the task is posted or has a sent status, the conversation panel becomes
+ * a fresh send surface and must not inherit any part of the sent payload.
+ */
+export function resolveTaskDmComposerState<TDraft>(
+  args: ResolveTaskDmComposerStateArgs<TDraft>
+): TaskDmComposerState<TDraft> {
+  const behavior: TaskDmComposerBehavior =
+    args.taskId &&
+    args.taskMode === "approval" &&
+    !SENT_TASK_STATUSES.has(args.taskStatus ?? "")
+      ? "task-approval"
+      : "fresh-send";
+
+  return {
+    behavior,
+    draft: behavior === "task-approval" ? args.taskDraft : undefined,
+    resetKey: `${args.taskId ?? "live"}:${behavior}`,
+  };
+}

--- a/tests/task-dm-composer-state.test.ts
+++ b/tests/task-dm-composer-state.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolveTaskDmComposerState } from "../shared/lib/outreach/taskDmComposerHelpers";
+
+const sentPayload = {
+  content: "Previously sent text",
+  mediaUrls: ["https://cdn.example.com/sent-image.png"],
+  mediaDescriptions: ["Previously sent caption"],
+  mediaKinds: ["image" as const],
+  mediaMetadata: [{ previewUrl: "blob:previous-preview", width: 1200 }],
+};
+
+test("pending approval tasks retain their complete draft payload", () => {
+  const state = resolveTaskDmComposerState({
+    taskId: "task-1",
+    taskMode: "approval",
+    taskStatus: "pending",
+    taskDraft: sentPayload,
+  });
+
+  assert.equal(state.behavior, "task-approval");
+  assert.strictEqual(state.draft, sentPayload);
+});
+
+test("posted tasks expose a blank fresh-send state with no sent payload", () => {
+  const state = resolveTaskDmComposerState({
+    taskId: "task-1",
+    taskMode: "posted",
+    taskStatus: "completed",
+    taskDraft: sentPayload,
+  });
+
+  assert.equal(state.behavior, "fresh-send");
+  assert.equal(state.draft, undefined);
+});
+
+test("sent task status blocks hydration even with a stale approval mode", () => {
+  for (const taskStatus of ["waiting_response", "completed"]) {
+    const state = resolveTaskDmComposerState({
+      taskId: "task-1",
+      taskMode: "approval",
+      taskStatus,
+      taskDraft: sentPayload,
+    });
+
+    assert.equal(state.behavior, "fresh-send");
+    assert.equal(state.draft, undefined);
+  }
+});
+
+test("unsent failed and skipped tasks keep their editable approval payload", () => {
+  for (const taskStatus of ["failed", "skipped"]) {
+    const state = resolveTaskDmComposerState({
+      taskId: "task-1",
+      taskMode: "approval",
+      taskStatus,
+      taskDraft: sentPayload,
+    });
+
+    assert.equal(state.behavior, "task-approval");
+    assert.strictEqual(state.draft, sentPayload);
+  }
+});
+
+test("approval-to-posted transitions and task changes produce reset keys", () => {
+  const approval = resolveTaskDmComposerState({
+    taskId: "task-1",
+    taskMode: "approval",
+    taskStatus: "pending",
+    taskDraft: sentPayload,
+  });
+  const posted = resolveTaskDmComposerState({
+    taskId: "task-1",
+    taskMode: "posted",
+    taskStatus: "completed",
+    taskDraft: sentPayload,
+  });
+  const nextTask = resolveTaskDmComposerState({
+    taskId: "task-2",
+    taskMode: "approval",
+    taskStatus: "pending",
+    taskDraft: sentPayload,
+  });
+
+  assert.notEqual(approval.resetKey, posted.resetKey);
+  assert.notEqual(approval.resetKey, nextTask.resetKey);
+  assert.equal(approval.resetKey, "task-1:task-approval");
+  assert.equal(posted.resetKey, "task-1:fresh-send");
+});


### PR DESCRIPTION
## Summary
- prevent completed LinkedIn and X DM tasks from exposing sent text or attachment data as an editable draft
- reset composer state when an approval transitions to posted while preserving conversation history
- keep pending and unsent approval drafts editable
- add frontend state and Convex integration regression coverage for both platforms

## Validation
- TypeScript: passed
- strict Oxlint: passed with zero warnings
- Prettier: passed
- TypeScript language-server diagnostics: zero
- React Doctor changed-files audit: zero issues
- Convex suite: 208/208 passed
- focused regressions: 8/8 passed
- local browser approval-to-posted transition verified for LinkedIn and X, including attachment removal and blank fresh-send composer
- browser console: zero errors or warnings

## Deployment
No schema or data migration is required. Do not merge until deployment checks and manual review pass.