### PR TITLE
fix: stabilize notifications and standardize infinite scrolling

### DIFF
--- a/app/(webapp)/notifications/page.tsx
+++ b/app/(webapp)/notifications/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useConvex, useMutation } from "convex/react";
+import { useConvex, useMutation, usePaginatedQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
-import { useNotificationWorkspace, useQueryWithStatus } from "@/shared/hooks";
+import { useNotificationWorkspace } from "@/shared/hooks";
 import {
   PageContent,
   PageHeader,
@@ -18,6 +18,7 @@ import { Button } from "@/shared/ui/components/Button";
 
 const NOTIFICATIONS_BODY_COLUMN_CLASS_NAME =
   "w-full min-w-0 md:w-[min(32rem,100%)] md:max-w-lg";
+const NOTIFICATIONS_PAGE_SIZE = 20;
 
 export default function NotificationsPage() {
   const router = useRouter();
@@ -30,21 +31,24 @@ export default function NotificationsPage() {
     shellStateQuery,
   } = useNotificationWorkspace();
 
-  const notificationsQuery = useQueryWithStatus(
+  const notificationsQuery = usePaginatedQuery(
     api.outreach.listNotifications,
     isNotificationWorkspaceReady && workspaceId
       ? { workspaceId: workspaceId as Id<"workspaces"> }
-      : "skip"
+      : "skip",
+    { initialNumItems: NOTIFICATIONS_PAGE_SIZE }
   );
-  const notifications = (
-    notificationsQuery.isSuccess ? notificationsQuery.data : []
-  ) as NotificationItem[];
+  const notifications = notificationsQuery.results as NotificationItem[];
   const markSeen = useMutation(api.outreach.markNotificationSeen);
   const dismissNotification = useMutation(api.outreach.dismissNotification);
 
   const isLoading =
     isNotificationWorkspaceLoading ||
-    (workspaceId !== null && notificationsQuery.isPending);
+    (workspaceId !== null && notificationsQuery.status === "LoadingFirstPage");
+  const notificationQueryError =
+    "error" in notificationsQuery && notificationsQuery.error instanceof Error
+      ? notificationsQuery.error
+      : null;
 
   const handleSelect = async (
     notification: NotificationItem,
@@ -128,13 +132,13 @@ export default function NotificationsPage() {
             <WorkspacePlanLimitAlert className="mx-4 mb-4" />
             {(notificationWorkspaceError ||
               shellStateQuery.isError ||
-              notificationsQuery.isError) && (
+              notificationQueryError) && (
               <div className="mx-4 mb-4 rounded-lg border border-dashed p-4 text-sm">
                 <p className="font-medium">Could not load notifications</p>
                 <p className="text-muted-foreground mt-1">
                   {notificationWorkspaceError?.message ||
                     shellStateQuery.error?.message ||
-                    notificationsQuery.error?.message ||
+                    notificationQueryError?.message ||
                     "Please try again."}
                 </p>
                 <Button
@@ -150,6 +154,11 @@ export default function NotificationsPage() {
             <NotificationsInbox
               notifications={notifications}
               isLoading={isLoading}
+              hasMore={notificationsQuery.status === "CanLoadMore"}
+              isLoadingMore={notificationsQuery.status === "LoadingMore"}
+              onLoadMore={() =>
+                notificationsQuery.loadMore(NOTIFICATIONS_PAGE_SIZE)
+              }
               onSelect={handleSelect}
               onDismiss={handleDismiss}
             />

--- a/convex/chatGenerationRecovery.integration.test.ts
+++ b/convex/chatGenerationRecovery.integration.test.ts
@@ -120,5 +120,5 @@ describe("agent generation recovery", () => {
     expect(
       abortedStreams.filter((stream) => stream.order === seeded.order)
     ).toEqual([]);
-  });
+  }, 30_000);
 });

--- a/convex/deleteWorkspace.integration.test.ts
+++ b/convex/deleteWorkspace.integration.test.ts
@@ -238,7 +238,7 @@ describe("durable workspace deletion", () => {
     expect(componentThread).toBeNull();
     expect(deletionsAfterWorkflow).toEqual([]);
     vi.useRealTimers();
-  });
+  }, 30_000);
 
   test("preserves ownership authorization", async () => {
     const t = convexTest(schema, modules);

--- a/convex/outreach.ts
+++ b/convex/outreach.ts
@@ -3,6 +3,7 @@
 // Following existing patterns from prospects.ts
 
 import { v } from "convex/values";
+import { paginationOptsValidator } from "convex/server";
 import type { WorkflowId } from "@convex-dev/workflow";
 import { type QueryCtx, type MutationCtx } from "./_generated/server";
 import {
@@ -123,8 +124,6 @@ import {
 type PanelMode = "approval" | "posted";
 const outreachLogger = logger.withScope("Outreach");
 
-const DEFAULT_ACTIVITY_PAGE_SIZE = 20;
-const MAX_ACTIVITY_PAGE_SIZE = 100;
 const AUTH_FAILURE_CLASSES = new Set(["reauth_required", "scope_missing"]);
 const LINKEDIN_DM_TEXT_MAX = 8_000;
 const OUTREACH_TASK_TYPES = new Set<Doc<"outreachTasks">["type"]>([
@@ -418,11 +417,6 @@ function assertExpectedTaskType(
           : "This draft belongs to a DM task, not a reply task."
     );
   }
-}
-
-function toActivityPageSize(limit?: number): number {
-  const rawLimit = limit ?? DEFAULT_ACTIVITY_PAGE_SIZE;
-  return Math.min(MAX_ACTIVITY_PAGE_SIZE, Math.max(1, Math.floor(rawLimit)));
 }
 
 function parsePlanSnapshot(snapshot: unknown): OutreachPlanSnapshot | null {
@@ -773,11 +767,11 @@ export const getPlanById = query({
 export const getActivityLog = query({
   args: {
     prospectId: v.id("prospects"),
-    limit: v.optional(v.number()),
+    paginationOpts: paginationOptsValidator,
     type: v.optional(prospectActivityTypeValidator),
     search: v.optional(v.string()),
   },
-  handler: async (ctx, { prospectId, limit, type, search }) => {
+  handler: async (ctx, { prospectId, paginationOpts, type, search }) => {
     const user = await requireViewerUser(ctx);
     await requireOwnedProspect(ctx, prospectId, {
       user,
@@ -785,54 +779,24 @@ export const getActivityLog = query({
       notAuthorizedMessage: "Not authorized to view this prospect",
     });
 
-    const pageSize = toActivityPageSize(limit);
     const searchTerm = search?.trim() ?? "";
-
-    let pageActivities: Doc<"prospectActivityLog">[] = [];
-    let hasMore = false;
-
-    if (!type && !searchTerm) {
-      // No filters: indexed page fetch
-      const activitiesWithSentinel = await getProspectActivityLog(
-        ctx,
-        prospectId,
-        {
-          limit: pageSize + 1,
-        }
-      );
-      hasMore = activitiesWithSentinel.length > pageSize;
-      pageActivities = activitiesWithSentinel.slice(0, pageSize);
-    } else if (type && !searchTerm) {
-      // Type filter only: use by_prospect_type index
-      const activitiesWithSentinel = await getProspectActivityLog(
-        ctx,
-        prospectId,
-        {
-          limit: pageSize + 1,
-          type,
-        }
-      );
-      hasMore = activitiesWithSentinel.length > pageSize;
-      pageActivities = activitiesWithSentinel.slice(0, pageSize);
-    } else {
-      // Search (with or without type): bounded batch scan
-      const batchSize = Math.max(pageSize * 5, 100);
-      const source = type
-        ? getProspectActivityLog(ctx, prospectId, {
-            limit: batchSize,
-            type,
-          })
-        : getProspectActivityLog(ctx, prospectId, {
-            limit: batchSize,
-          });
-
-      const batch = await source;
-      const filtered = batch.filter((activity) =>
-        matchesActivitySearch(activity, searchTerm)
-      );
-      hasMore = filtered.length > pageSize || batch.length === batchSize;
-      pageActivities = filtered.slice(0, pageSize);
-    }
+    const activityQuery = type
+      ? ctx.db
+          .query("prospectActivityLog")
+          .withIndex("by_prospect_type", (q) =>
+            q.eq("prospectId", prospectId).eq("type", type)
+          )
+          .order("desc")
+      : ctx.db
+          .query("prospectActivityLog")
+          .withIndex("by_prospect", (q) => q.eq("prospectId", prospectId))
+          .order("desc");
+    const paginatedActivities = await activityQuery.paginate(paginationOpts);
+    const pageActivities = searchTerm
+      ? paginatedActivities.page.filter((activity) =>
+          matchesActivitySearch(activity, searchTerm)
+        )
+      : paginatedActivities.page;
 
     const planSnapshotByActivityId = new Map<
       Id<"prospectActivityLog">,
@@ -891,7 +855,8 @@ export const getActivityLog = query({
     );
 
     return {
-      activities: pageActivities.map((activity) => {
+      ...paginatedActivities,
+      page: pageActivities.map((activity) => {
         if (activity.type !== "plan_created") {
           return {
             ...activity,
@@ -913,21 +878,69 @@ export const getActivityLog = query({
           plan: planId ? (planSnapshotByPlanId.get(planId) ?? null) : null,
         };
       }),
-      hasMore,
     };
   },
 });
 
 /**
  * List notifications for the current user (public).
- * Returns notifications grouped by day (using _creationTime).
+ * Returns a stable event-time cursor page for the notifications inbox.
  */
 export const listNotifications = query({
+  args: {
+    workspaceId: v.optional(v.id("workspaces")),
+    paginationOpts: paginationOptsValidator,
+  },
+  handler: async (ctx, { workspaceId, paginationOpts }) => {
+    const user = await requireViewerUser(ctx);
+
+    // Backward-compatible: if workspaceId isn't provided, use active default workspace.
+    let resolvedWorkspaceId = workspaceId;
+    if (!resolvedWorkspaceId) {
+      const defaultWorkspace = await getDefaultWorkspaceForUser(ctx, user._id);
+      resolvedWorkspaceId = defaultWorkspace?._id;
+    }
+
+    if (!resolvedWorkspaceId) {
+      return {
+        page: [],
+        isDone: true,
+        continueCursor: paginationOpts.cursor ?? "",
+      };
+    }
+
+    await requireOwnedWorkspace(ctx, resolvedWorkspaceId, {
+      user,
+      notFoundMessage: "Workspace not found",
+      notAuthorizedMessage: "Not authorized to view this workspace",
+    });
+
+    // Order by the latest meaningful event, not only document creation. Keyed
+    // notifications are reused, so an updated older document must re-enter the
+    // live result set for its new event version to toast.
+    return await ctx.db
+      .query("outreachNotifications")
+      .withIndex("by_user_workspace_event_updated_at", (q) =>
+        q.eq("userId", user._id).eq("workspaceId", resolvedWorkspaceId)
+      )
+      .filter((q) => q.neq(q.field("status"), "dismissed"))
+      .order("desc")
+      .paginate(paginationOpts);
+  },
+});
+
+/**
+ * List pending notifications for the live toast monitor.
+ *
+ * The inbox uses cursor pagination, while the toast monitor intentionally
+ * stays a small pending-only query so newly-created approval/reply events can
+ * be detected without loading the entire notification history into the app.
+ */
+export const listPendingNotifications = query({
   args: { workspaceId: v.optional(v.id("workspaces")) },
   handler: async (ctx, { workspaceId }) => {
     const user = await requireViewerUser(ctx);
 
-    // Backward-compatible: if workspaceId isn't provided, use active default workspace.
     let resolvedWorkspaceId = workspaceId;
     if (!resolvedWorkspaceId) {
       const defaultWorkspace = await getDefaultWorkspaceForUser(ctx, user._id);
@@ -944,51 +957,16 @@ export const listNotifications = query({
       notAuthorizedMessage: "Not authorized to view this workspace",
     });
 
-    // Order by the latest meaningful event, not only document creation. Keyed
-    // notifications are reused, so an updated older document must re-enter the
-    // live result set for its new event version to toast.
-    const notifications = await ctx.db
+    return await ctx.db
       .query("outreachNotifications")
-      .withIndex("by_user_workspace_event_updated_at", (q) =>
-        q.eq("userId", user._id).eq("workspaceId", resolvedWorkspaceId)
+      .withIndex("by_user_workspace_status_event_updated_at", (q) =>
+        q
+          .eq("userId", user._id)
+          .eq("workspaceId", resolvedWorkspaceId)
+          .eq("status", "pending")
       )
-      .filter((q) => q.neq(q.field("status"), "dismissed"))
       .order("desc")
       .take(100);
-
-    return [...notifications].sort((a, b) => {
-      const aPending = a.status === "pending" ? 0 : 1;
-      const bPending = b.status === "pending" ? 0 : 1;
-      if (aPending !== bPending) {
-        return aPending - bPending;
-      }
-
-      const getTypePriority = (type: Doc<"outreachNotifications">["type"]) => {
-        switch (type) {
-          case "prospect_replied":
-            return 0;
-          case "ask_human":
-            return 1;
-          case "social_action_request":
-            return 2;
-          case "prospects_found":
-            return 3;
-          default:
-            return 4;
-        }
-      };
-
-      const typePriorityDiff =
-        getTypePriority(a.type) - getTypePriority(b.type);
-      const eventUpdatedDiff =
-        (b.eventUpdatedAt ?? b._creationTime) -
-        (a.eventUpdatedAt ?? a._creationTime);
-      if (eventUpdatedDiff !== 0) {
-        return eventUpdatedDiff;
-      }
-
-      return typePriorityDiff;
-    });
   },
 });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2936,6 +2936,12 @@ export default defineSchema({
       "workspaceId",
       "eventUpdatedAt",
     ])
+    .index("by_user_workspace_status_event_updated_at", [
+      "userId",
+      "workspaceId",
+      "status",
+      "eventUpdatedAt",
+    ])
     .index("by_user_workspace_key", [
       "userId",
       "workspaceId",

--- a/convex/socialapi.ts
+++ b/convex/socialapi.ts
@@ -571,7 +571,7 @@ export const getDynamicThreadData = action({
   args: getDynamicThreadDataArgsValidator,
   handler: async (
     ctx,
-    { threadId }
+    { threadId, repliesCursor }
   ): Promise<{
     rootTweetId: string;
     matchedReplyTweetId?: string;
@@ -581,6 +581,7 @@ export const getDynamicThreadData = action({
   }> => {
     return await ctx.runAction(api.socialapi.getConversationContext, {
       rootTweetId: threadId,
+      repliesCursor,
     });
   },
 });

--- a/convex/validators.ts
+++ b/convex/validators.ts
@@ -837,6 +837,7 @@ export const getTwitterProfileArgsValidator = v.object({
 
 export const getDynamicThreadDataArgsValidator = v.object({
   threadId: v.string(),
+  repliesCursor: v.optional(v.string()),
 });
 
 export const getConversationContextArgsValidator = v.object({

--- a/features/agent/ui/components/HistoryPanel.tsx
+++ b/features/agent/ui/components/HistoryPanel.tsx
@@ -28,7 +28,7 @@ import {
   TooltipTrigger,
 } from "@/shared/ui/components/Tooltip";
 import { SearchIcon, AddIcon } from "@/shared/ui/components/icons";
-import { AsciiSpinnerText } from "@/shared/ui/components/AsciiSpinnerText";
+import { InfiniteScrollTrigger } from "@/shared/ui/components/InfiniteScrollTrigger";
 import { ThreadCard, type ThreadData } from "./ThreadCard";
 import { ThreadCardSkeleton } from "./ThreadCardSkeleton";
 import { WorkspacePlanLimitAlert } from "@/features/billing/ui/components/WorkspacePlanLimitAlert";
@@ -367,22 +367,16 @@ export function HistoryPanel({
                   />
                 ))}
 
-                {hasMoreThreads && (
-                  <div className="px-4 pt-3 pb-4">
-                    <Button
-                      size="xs"
-                      className="w-full"
-                      onClick={() => threadsResult.loadMore(20)}
-                      disabled={isLoadingMoreThreads}
-                    >
-                      {isLoadingMoreThreads ? (
-                        <AsciiSpinnerText text="Loading" />
-                      ) : (
-                        "Load more"
-                      )}
-                    </Button>
-                  </div>
-                )}
+                <InfiniteScrollTrigger
+                  hasMore={hasMoreThreads}
+                  isLoading={isLoadingMoreThreads}
+                  onLoadMore={() => threadsResult.loadMore(20)}
+                  resultCount={displayedThreads.length}
+                  className="mx-4 pt-3 pb-4"
+                  loadingLabel="Loading more thread history"
+                  loadMoreLabel="Load more thread history"
+                  retryLabel="Retry loading thread history"
+                />
               </div>
             )}
           </ScrollArea>

--- a/features/profile/ui/components/TwitterProfilePanel.tsx
+++ b/features/profile/ui/components/TwitterProfilePanel.tsx
@@ -12,6 +12,7 @@ import {
 } from "../../contexts/TwitterProfileContext";
 import { useTwitterTimelineEngagementMerge } from "@/shared/hooks/useTwitterTimelineEngagementMerge";
 import { Button } from "@/shared/ui/components/Button";
+import { InfiniteScrollTrigger } from "@/shared/ui/components/InfiniteScrollTrigger";
 import {
   Alert,
   AlertDescription,
@@ -144,16 +145,18 @@ function renderTimelineSection(args: {
         ) : null}
       </div>
 
-      {args.nextCursor ? (
-        <div className="p-4">
-          <Button
-            size="xs"
-            className="mx-auto block"
-            onClick={() => void args.loadMore(args.value)}
-          >
-            Load more
-          </Button>
-        </div>
+      {args.nextCursor && args.activeTab === args.value ? (
+        <InfiniteScrollTrigger
+          hasMore={Boolean(args.nextCursor)}
+          isLoading={args.loadingTab}
+          loadMoreError={Boolean(args.error && args.tweets.length > 0)}
+          onLoadMore={() => void args.loadMore(args.value)}
+          resultCount={args.tweets.length}
+          className="p-4"
+          loadingLabel={`Loading more ${title}`}
+          loadMoreLabel={`Load more ${title}`}
+          retryLabel={`Retry loading ${title}`}
+        />
       ) : null}
     </TabsContent>
   );

--- a/features/prospects/ui/components/ConversationPanel.tsx
+++ b/features/prospects/ui/components/ConversationPanel.tsx
@@ -16,6 +16,7 @@ import {
   PageContent,
 } from "@/features/webapp/ui/components";
 import { ScrollArea } from "@/shared/ui/components/ScrollArea";
+import { InfiniteScrollTrigger } from "@/shared/ui/components/InfiniteScrollTrigger";
 import { usePanelStack } from "../../contexts/PanelStackContext";
 import { Tweet, TweetSkeleton } from "@/features/webapp/ui/components/tweet";
 import type { Tweet as TweetType } from "@/features/threads/types";
@@ -112,8 +113,12 @@ export function ConversationPanel({
   const fetchConversation = useAction(api.socialapi.getDynamicThreadData);
   const fetchConversationRef = React.useRef(fetchConversation);
   const [isLoading, setIsLoading] = React.useState(true);
+  const [isLoadingMore, setIsLoadingMore] = React.useState(false);
   const [tweets, setTweets] = React.useState<TweetType[]>([]);
-  const [_error, setError] = React.useState<string | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+  const [nextRepliesCursor, setNextRepliesCursor] = React.useState<
+    string | null
+  >(null);
   const mergedTweets = useTwitterTimelineEngagementMerge(tweets);
   const normalizedReplyTweetId = React.useMemo(
     () => replyTweetId?.trim() || replyTweetSummary?.ref.postId || "",
@@ -183,22 +188,44 @@ export function ConversationPanel({
     fetchConversationRef.current = fetchConversation;
   }, [fetchConversation]);
 
-  const loadConversation = React.useCallback(async () => {
-    setIsLoading(true);
-    setError(null);
-    try {
-      const result = await fetchConversationRef.current({
-        threadId,
-      });
-      setTweets(result.tweets as TweetType[]);
-    } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Failed to load conversation"
-      );
-    } finally {
-      setIsLoading(false);
-    }
-  }, [threadId]);
+  const loadConversation = React.useCallback(
+    async (cursor?: string | null) => {
+      const isInitialLoad = !cursor;
+      if (isInitialLoad) {
+        setIsLoading(true);
+      } else {
+        setIsLoadingMore(true);
+      }
+
+      setError(null);
+      try {
+        const result = await fetchConversationRef.current({
+          threadId,
+          repliesCursor: cursor ?? undefined,
+        });
+        setTweets((currentTweets) =>
+          isInitialLoad
+            ? (result.tweets as TweetType[])
+            : dedupeAndSortConversationTweets([
+                ...currentTweets,
+                ...(result.tweets as TweetType[]),
+              ])
+        );
+        setNextRepliesCursor(result.repliesCursor ?? null);
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "Failed to load conversation"
+        );
+      } finally {
+        if (isInitialLoad) {
+          setIsLoading(false);
+        } else {
+          setIsLoadingMore(false);
+        }
+      }
+    },
+    [threadId]
+  );
 
   React.useEffect(() => {
     void loadConversation();
@@ -235,6 +262,22 @@ export function ConversationPanel({
                     />
                   </article>
                 ))}
+                <InfiniteScrollTrigger
+                  hasMore={Boolean(nextRepliesCursor)}
+                  isLoading={isLoadingMore}
+                  loadMoreError={Boolean(
+                    nextRepliesCursor && error && !isLoadingMore
+                  )}
+                  onLoadMore={() => {
+                    if (nextRepliesCursor) {
+                      void loadConversation(nextRepliesCursor);
+                    }
+                  }}
+                  resultCount={conversationTweets.length}
+                  loadingLabel="Loading more replies"
+                  loadMoreLabel="Load more replies"
+                  retryLabel="Retry loading replies"
+                />
               </section>
             )}
           </PageContent>

--- a/features/prospects/ui/components/LinkedInProfilePanel.tsx
+++ b/features/prospects/ui/components/LinkedInProfilePanel.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/shared/ui/components/Avatar";
 import { Badge } from "@/shared/ui/components/Badge";
 import { Button } from "@/shared/ui/components/Button";
+import { InfiniteScrollTrigger } from "@/shared/ui/components/InfiniteScrollTrigger";
 import { Drawer, DrawerContent } from "@/shared/ui/components/Drawer";
 import {
   DropdownMenu,
@@ -774,6 +775,7 @@ export function LinkedInProfilePanel({
 
     try {
       setLoadingMorePosts(true);
+      setPostsError(undefined);
       const result = (await (prospectId
         ? getLinkedInProfilePostsPage({
             prospectId,
@@ -1091,16 +1093,17 @@ export function LinkedInProfilePanel({
       </div>
 
       {nextPostsCursor ? (
-        <div className="p-4">
-          <Button
-            size="xs"
-            className="mx-auto block"
-            disabled={loadingMorePosts}
-            onClick={() => void handleLoadMorePosts()}
-          >
-            {loadingMorePosts ? "Loading..." : "Load more"}
-          </Button>
-        </div>
+        <InfiniteScrollTrigger
+          hasMore={Boolean(nextPostsCursor)}
+          isLoading={loadingMorePosts}
+          loadMoreError={Boolean(postsError && recentPosts.length > 0)}
+          onLoadMore={() => void handleLoadMorePosts()}
+          resultCount={mergedRecentPosts.length}
+          className="p-4"
+          loadingLabel="Loading more LinkedIn posts"
+          loadMoreLabel="Load more LinkedIn posts"
+          retryLabel="Retry loading LinkedIn posts"
+        />
       ) : null}
     </TabsContent>
   );

--- a/features/prospects/ui/components/ThreadAwareTwitterReplyBody.tsx
+++ b/features/prospects/ui/components/ThreadAwareTwitterReplyBody.tsx
@@ -8,8 +8,7 @@ import type { Tweet as TweetType } from "@/features/threads/types";
 import { useHydratedTwitterPosts } from "@/shared/hooks/useHydratedTwitterPosts";
 import { dedupeAndSortConversationTweets } from "@/features/prospects/lib/twitterConversation";
 import { mergeLocalEngagementIntoTweet } from "@/shared/lib/twitter/mergeViewerState";
-import { Button } from "@/shared/ui/components/Button";
-import { AsciiSpinnerText } from "@/shared/ui/components/AsciiSpinnerText";
+import { InfiniteScrollTrigger } from "@/shared/ui/components/InfiniteScrollTrigger";
 import { cn } from "@/shared/lib/utils";
 import { TweetSkeleton } from "@/features/webapp/ui/components/tweet";
 
@@ -297,20 +296,17 @@ export function ThreadAwareTwitterReplyBody({
       ) : null}
 
       {showLoadMoreReplies && nextRepliesCursor ? (
-        <div className={cn("px-4 pt-2", loadMoreContainerClassName)}>
-          <Button
-            size="xs"
-            className="w-full"
-            onClick={() => void loadConversation(nextRepliesCursor)}
-            disabled={isLoadingConversation}
-          >
-            {isLoadingConversation ? (
-              <AsciiSpinnerText text="Loading" />
-            ) : (
-              "Load more"
-            )}
-          </Button>
-        </div>
+        <InfiniteScrollTrigger
+          hasMore={Boolean(nextRepliesCursor)}
+          isLoading={isLoadingConversation}
+          loadMoreError={Boolean(conversationError)}
+          onLoadMore={() => void loadConversation(nextRepliesCursor)}
+          resultCount={conversationTweets.length}
+          className={cn("px-4 pt-2", loadMoreContainerClassName)}
+          loadingLabel="Loading more replies"
+          loadMoreLabel="Load more replies"
+          retryLabel="Retry loading replies"
+        />
       ) : null}
     </>
   );

--- a/features/prospects/ui/components/outreach-plan/TaskItem.tsx
+++ b/features/prospects/ui/components/outreach-plan/TaskItem.tsx
@@ -13,6 +13,7 @@ import {
   type TwitterPostRef,
   type TwitterPostSummary,
 } from "@/shared/lib/twitter/contracts";
+import { CalendarClockIcon } from "@/shared/ui/components/icons";
 
 const STATUS_LABELS: Record<string, string> = {
   pending: "Pending",
@@ -26,9 +27,8 @@ const STATUS_LABELS: Record<string, string> = {
   failed: "Failed",
 };
 
-const SPINNER_VARIANT: Record<string, "spinner" | "pulse" | "clock"> = {
+const SPINNER_VARIANT: Record<string, "spinner" | "clock"> = {
   executing: "spinner",
-  waiting_connection: "pulse",
   scheduled: "clock",
 };
 
@@ -320,7 +320,18 @@ export function TaskItem({
                 isFailed && "border-destructive/50 text-destructive"
               )}
             >
-              {spinnerVariant ? (
+              {isWaitingConnection ? (
+                <span
+                  className="inline-flex items-center gap-1 text-xs"
+                  role="status"
+                >
+                  <CalendarClockIcon
+                    className="text-muted-foreground size-3.5 shrink-0 fill-current"
+                    aria-hidden
+                  />
+                  <span>{STATUS_LABELS[status] || status}</span>
+                </span>
+              ) : spinnerVariant ? (
                 <AsciiSpinnerText
                   text={STATUS_LABELS[status] || status}
                   variant={spinnerVariant}

--- a/features/prospects/ui/components/tabs/ActivityLogTab.tsx
+++ b/features/prospects/ui/components/tabs/ActivityLogTab.tsx
@@ -8,11 +8,12 @@
  */
 
 import * as React from "react";
+import { usePaginatedQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
-import { useActiveUseCaseLabels, useQueryWithStatus } from "@/shared/hooks";
+import { useActiveUseCaseLabels } from "@/shared/hooks";
 import { Skeleton } from "@/shared/ui/components/Skeleton";
-import { Button } from "@/shared/ui/components/Button";
+import { InfiniteScrollTrigger } from "@/shared/ui/components/InfiniteScrollTrigger";
 import { Input } from "@/shared/ui/components/Input";
 import {
   Select,
@@ -174,14 +175,11 @@ export function ActivityLogTab({
 }: ActivityLogTabProps) {
   const { user } = useAuth();
   const { entitySingular, stageLabels } = useActiveUseCaseLabels();
-  const [limit, setLimit] = React.useState(ACTIVITIES_PER_PAGE);
-  const [loadingLimit, setLoadingLimit] = React.useState<number | null>(null);
   const [searchInput, setSearchInput] = React.useState("");
   const [typeFilter, setTypeFilter] = React.useState<ActivityFilterType>("all");
   const debouncedSearch = useDebouncedValue(searchInput, 300);
   const normalizedSearch = debouncedSearch.trim();
   const selectedType = typeFilter === "all" ? undefined : typeFilter;
-  const cacheKey = `${selectedType ?? "all"}:${normalizedSearch.toLowerCase()}`;
   const entitySingularLower = entitySingular.toLowerCase();
   const isPreview = Array.isArray(previewActivities);
   const actionLabels = React.useMemo<Record<ActivityType, string>>(
@@ -214,42 +212,17 @@ export function ActivityLogTab({
     [stageLabels]
   );
 
-  const dataQuery = useQueryWithStatus(
+  const dataQuery = usePaginatedQuery(
     api.outreach.getActivityLog,
     isPreview
       ? "skip"
       : {
           prospectId: prospectId as Id<"prospects">,
-          limit,
           type: selectedType,
           search: normalizedSearch || undefined,
-        }
+        },
+    { initialNumItems: ACTIVITIES_PER_PAGE }
   );
-  const data = dataQuery.data;
-
-  const [cachedActivities, setCachedActivities] = React.useState<
-    ActivityRecord[]
-  >([]);
-  const [cachedHasMore, setCachedHasMore] = React.useState(false);
-  const [activeCacheKey, setActiveCacheKey] = React.useState(cacheKey);
-  const canUseCache = activeCacheKey === cacheKey;
-  const fallbackActivities = canUseCache ? cachedActivities : [];
-  const fallbackHasMore = canUseCache ? cachedHasMore : false;
-
-  React.useEffect(() => {
-    if (activeCacheKey === cacheKey) return;
-    setActiveCacheKey(cacheKey);
-    setCachedActivities([]);
-    setCachedHasMore(false);
-    setLimit(ACTIVITIES_PER_PAGE);
-    setLoadingLimit(null);
-  }, [activeCacheKey, cacheKey]);
-
-  React.useEffect(() => {
-    if (!dataQuery.isSuccess || !data) return;
-    setCachedActivities(data.activities as ActivityRecord[]);
-    setCachedHasMore(data.hasMore);
-  }, [data, dataQuery.isSuccess]);
 
   const filteredPreviewActivities = React.useMemo(() => {
     if (!previewActivities) {
@@ -272,53 +245,21 @@ export function ActivityLogTab({
     });
   }, [normalizedSearch, previewActivities, selectedType]);
 
-  const isLoadingMore =
-    !isPreview && loadingLimit !== null && dataQuery.isPending;
+  const isLoadingMore = !isPreview && dataQuery.status === "LoadingMore";
   const isInitialLoading =
-    !isPreview && dataQuery.isPending && fallbackActivities.length === 0;
+    !isPreview && dataQuery.status === "LoadingFirstPage";
 
   if (isInitialLoading) {
     return <ActivityLogSkeleton />;
   }
 
   const activities = (
-    isPreview
-      ? filteredPreviewActivities
-      : (data?.activities ?? fallbackActivities)
+    isPreview ? filteredPreviewActivities : dataQuery.results
   ) as ActivityRecord[];
-  const hasMore = isPreview ? false : (data?.hasMore ?? fallbackHasMore);
+  const hasMore =
+    !isPreview &&
+    (dataQuery.status === "CanLoadMore" || dataQuery.status === "LoadingMore");
   const hasFilters = typeFilter !== "all" || normalizedSearch.length > 0;
-
-  if (dataQuery.isError && fallbackActivities.length === 0) {
-    return (
-      <div className="px-4 py-4">
-        <ActivityLogFilters
-          searchInput={searchInput}
-          onSearchChange={setSearchInput}
-          typeFilter={typeFilter}
-          onTypeFilterChange={setTypeFilter}
-          options={activityFilterOptions}
-        />
-        <div className="rounded-lg border border-dashed p-6 text-center">
-          <p className="text-sm font-medium">Could not load activity</p>
-          <p className="text-muted-foreground mt-1 text-sm">
-            {dataQuery.error.message || "Please try again."}
-          </p>
-          <Button
-            variant="outline"
-            size="sm"
-            className="mt-3"
-            onClick={() => {
-              setLoadingLimit(null);
-              setLimit(ACTIVITIES_PER_PAGE);
-            }}
-          >
-            Retry
-          </Button>
-        </div>
-      </div>
-    );
-  }
 
   if (activities.length === 0) {
     return (
@@ -335,6 +276,18 @@ export function ActivityLogTab({
             ? "No activity matches your filters."
             : "No activity recorded yet."}
         </div>
+        {!isPreview ? (
+          <InfiniteScrollTrigger
+            hasMore={hasMore}
+            isLoading={isLoadingMore}
+            onLoadMore={() => dataQuery.loadMore(ACTIVITIES_PER_PAGE)}
+            resultCount={activities.length}
+            className="mt-4"
+            loadingLabel="Loading more activity"
+            loadMoreLabel="Load more activity"
+            retryLabel="Retry loading activity"
+          />
+        ) : null}
       </div>
     );
   }
@@ -372,12 +325,6 @@ export function ActivityLogTab({
   // Sort descending (newest first)
   entries.sort((a, b) => b.timestamp - a.timestamp);
 
-  const handleLoadMore = () => {
-    const newLimit = limit + ACTIVITIES_PER_PAGE;
-    setLoadingLimit(newLimit);
-    setLimit(newLimit);
-  };
-
   return (
     <div className="px-4 py-4">
       <ActivityLogFilters
@@ -387,15 +334,6 @@ export function ActivityLogTab({
         onTypeFilterChange={setTypeFilter}
         options={activityFilterOptions}
       />
-      {!isPreview && dataQuery.isError && (
-        <div className="mb-4 rounded-lg border border-dashed px-4 py-3 text-sm">
-          <p className="font-medium">Showing last available activity</p>
-          <p className="text-muted-foreground mt-1">
-            {dataQuery.error.message ||
-              "Live activity updates are unavailable."}
-          </p>
-        </div>
-      )}
       <Timeline>
         {entries.map((entry, index) => {
           let avatarUrl: string | undefined;
@@ -485,18 +423,18 @@ export function ActivityLogTab({
         })}
       </Timeline>
 
-      {hasMore && (
-        <div className="pt-4">
-          <Button
-            variant="secondary"
-            className="w-full"
-            onClick={handleLoadMore}
-            disabled={isLoadingMore}
-          >
-            {isLoadingMore ? "Loading..." : "Load more"}
-          </Button>
-        </div>
-      )}
+      {!isPreview ? (
+        <InfiniteScrollTrigger
+          hasMore={hasMore}
+          isLoading={isLoadingMore}
+          onLoadMore={() => dataQuery.loadMore(ACTIVITIES_PER_PAGE)}
+          resultCount={activities.length}
+          className="mt-4"
+          loadingLabel="Loading more activity"
+          loadMoreLabel="Load more activity"
+          retryLabel="Retry loading activity"
+        />
+      ) : null}
     </div>
   );
 }

--- a/features/prospects/ui/components/tabs/RelevantActivityTab.tsx
+++ b/features/prospects/ui/components/tabs/RelevantActivityTab.tsx
@@ -7,7 +7,7 @@
 "use client";
 
 import * as React from "react";
-import { Button } from "@/shared/ui/components/Button";
+import { InfiniteScrollTrigger } from "@/shared/ui/components/InfiniteScrollTrigger";
 import { Skeleton } from "@/shared/ui/components/Skeleton";
 import { Tweet, TweetSkeleton } from "@/features/webapp/ui/components/tweet";
 import {
@@ -275,18 +275,18 @@ export function RelevantActivityTab({
         ))}
       </div>
 
-      {hasMore && !isInitialHydrationPending && (
-        <div className="p-4">
-          <Button
-            size="xs"
-            className="mx-auto block"
-            onClick={handleLoadMore}
-            disabled={isLoadingMore}
-          >
-            {isLoadingMore ? "Loading..." : "Load more"}
-          </Button>
-        </div>
-      )}
+      {!isInitialHydrationPending ? (
+        <InfiniteScrollTrigger
+          hasMore={hasMore}
+          isLoading={isLoadingMore}
+          onLoadMore={handleLoadMore}
+          resultCount={visiblePosts.length}
+          className="p-4"
+          loadingLabel="Loading more relevant activity"
+          loadMoreLabel="Load more relevant activity"
+          retryLabel="Retry loading relevant activity"
+        />
+      ) : null}
     </section>
   );
 }

--- a/features/prospects/ui/components/tabs/YourInteractionsTab.tsx
+++ b/features/prospects/ui/components/tabs/YourInteractionsTab.tsx
@@ -10,6 +10,7 @@ import { useMutation, usePaginatedQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
 import { Button } from "@/shared/ui/components/Button";
+import { InfiniteScrollTrigger } from "@/shared/ui/components/InfiniteScrollTrigger";
 import { Skeleton } from "@/shared/ui/components/Skeleton";
 import { Tweet, TweetSkeleton } from "@/features/webapp/ui/components/tweet";
 import {
@@ -169,7 +170,12 @@ export function YourInteractionsTab({
     !isPreview &&
     interactionsQuery.status === "LoadingFirstPage" &&
     interactions.length === 0;
-  const canLoadMore = !isPreview && interactionsQuery.status === "CanLoadMore";
+  const canLoadMore =
+    !isPreview &&
+    (interactionsQuery.status === "CanLoadMore" ||
+      interactionsQuery.status === "LoadingMore");
+  const isLoadingMore =
+    !isPreview && interactionsQuery.status === "LoadingMore";
 
   if (showInitialSkeleton) {
     return <YourInteractionsTabSkeleton />;
@@ -318,16 +324,17 @@ export function YourInteractionsTab({
         </div>
       )}
 
-      {canLoadMore ? (
-        <div className="px-4">
-          <Button
-            variant="secondary"
-            className="w-full"
-            onClick={() => interactionsQuery.loadMore(INITIAL_PAGE_SIZE)}
-          >
-            Load more
-          </Button>
-        </div>
+      {!isPreview ? (
+        <InfiniteScrollTrigger
+          hasMore={canLoadMore}
+          isLoading={isLoadingMore}
+          onLoadMore={() => interactionsQuery.loadMore(INITIAL_PAGE_SIZE)}
+          resultCount={interactions.length}
+          className="mx-4"
+          loadingLabel="Loading more interactions"
+          loadMoreLabel="Load more interactions"
+          retryLabel="Retry loading interactions"
+        />
       ) : null}
     </section>
   );

--- a/features/prospects/ui/pages/UseCaseProspectPage.tsx
+++ b/features/prospects/ui/pages/UseCaseProspectPage.tsx
@@ -85,6 +85,7 @@ export function UseCaseProspectPage({
         disableMobileDrawer={true}
         className={cn(
           "h-full min-h-0 w-full shrink-0 overflow-hidden",
+          "md:border-border md:border-r",
           hasSubPanel && "hidden md:block md:max-w-lg"
         )}
       />

--- a/features/webapp/ui/components/linkedin/LinkedInCommentThread.tsx
+++ b/features/webapp/ui/components/linkedin/LinkedInCommentThread.tsx
@@ -14,6 +14,7 @@ import type {
 } from "@/shared/lib/linkedin/comments";
 import type { UnifiedPost } from "@/shared/lib/platforms/types";
 import { Button } from "@/shared/ui/components/Button";
+import { InfiniteScrollTrigger } from "@/shared/ui/components/InfiniteScrollTrigger";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -222,7 +223,12 @@ export function LinkedInCommentThread({
               ...result.topLevelComments,
               items: [
                 ...previous.topLevelComments.items,
-                ...result.topLevelComments.items,
+                ...result.topLevelComments.items.filter(
+                  (comment) =>
+                    !previous.topLevelComments.items.some(
+                      (previousComment) => previousComment.id === comment.id
+                    )
+                ),
               ],
             },
           };
@@ -817,12 +823,12 @@ export function LinkedInCommentThread({
             </Alert>
           ) : null}
 
-          {loading ? (
+          {loading && !thread ? (
             <div className="space-y-3">
               <Skeleton className="h-16 w-full rounded-[20px]" />
               <Skeleton className="h-20 w-full rounded-[20px]" />
             </div>
-          ) : error ? (
+          ) : error && !thread ? (
             <Alert>
               <AlertTitle>Could not load comments</AlertTitle>
               <AlertDescription className="space-y-3">
@@ -889,14 +895,18 @@ export function LinkedInCommentThread({
                           }
                           void loadRepliesForComment(comment.id);
                         }}
-                        onLoadMoreReplies={() => {
-                          if (replyState?.page?.cursor) {
-                            void loadRepliesForComment(
-                              comment.id,
-                              replyState.page.cursor
-                            );
-                          }
-                        }}
+                        onLoadMoreReplies={
+                          previewScenario
+                            ? undefined
+                            : () => {
+                                if (replyState?.page?.cursor) {
+                                  void loadRepliesForComment(
+                                    comment.id,
+                                    replyState.page.cursor
+                                  );
+                                }
+                              }
+                        }
                         onToggleReplyComposer={() =>
                           setOpenReplyComposerId((previous) =>
                             previous === comment.id ? null : comment.id
@@ -935,18 +945,22 @@ export function LinkedInCommentThread({
                 </div>
               ) : null}
 
-              {thread?.topLevelComments.cursor ? (
-                <Button
-                  variant="ghost"
-                  size="xs"
-                  onClick={() =>
+              {thread?.topLevelComments.cursor && !previewScenario ? (
+                <InfiniteScrollTrigger
+                  hasMore={Boolean(thread.topLevelComments.cursor)}
+                  isLoading={loading}
+                  loadMoreError={Boolean(error)}
+                  onLoadMore={() =>
                     void loadThread({
                       cursor: thread.topLevelComments.cursor ?? undefined,
                     })
                   }
-                >
-                  Load more comments
-                </Button>
+                  resultCount={topLevelComments.length}
+                  className="pt-2"
+                  loadingLabel="Loading more comments"
+                  loadMoreLabel="Load more comments"
+                  retryLabel="Retry loading comments"
+                />
               ) : null}
             </>
           )}

--- a/features/webapp/ui/components/linkedin/LinkedInReplyList.tsx
+++ b/features/webapp/ui/components/linkedin/LinkedInReplyList.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import type { LinkedInCommentPage } from "@/shared/lib/linkedin/comments";
-import { Button } from "@/shared/ui/components/Button";
+import { InfiniteScrollTrigger } from "@/shared/ui/components/InfiniteScrollTrigger";
 import { Skeleton } from "@/shared/ui/components/Skeleton";
 
 export interface LinkedInReplyListProps {
@@ -24,7 +24,7 @@ export function LinkedInReplyList({
     <div className="border-border/70 ml-4 border-l pl-4">
       <div className="space-y-4">
         {children}
-        {loading ? (
+        {loading && !page ? (
           <div className="space-y-3">
             <Skeleton className="h-16 w-full" />
             <Skeleton className="h-16 w-5/6" />
@@ -36,10 +36,17 @@ export function LinkedInReplyList({
             <p className="text-muted-foreground mt-1">{error}</p>
           </div>
         ) : null}
-        {!loading && !error && page?.cursor && onLoadMore ? (
-          <Button variant="ghost" size="xs" onClick={onLoadMore}>
-            Load more replies
-          </Button>
+        {page?.cursor && onLoadMore ? (
+          <InfiniteScrollTrigger
+            hasMore={Boolean(page.cursor)}
+            isLoading={loading}
+            loadMoreError={Boolean(error)}
+            onLoadMore={onLoadMore}
+            resultCount={page.items.length}
+            loadingLabel="Loading more replies"
+            loadMoreLabel="Load more replies"
+            retryLabel="Retry loading replies"
+          />
         ) : null}
       </div>
     </div>

--- a/features/webapp/ui/components/notifications/NotificationsInbox.tsx
+++ b/features/webapp/ui/components/notifications/NotificationsInbox.tsx
@@ -13,6 +13,7 @@ import {
   AvatarImage,
 } from "@/shared/ui/components/Avatar";
 import { Button } from "@/shared/ui/components/Button";
+import { InfiniteScrollTrigger } from "@/shared/ui/components/InfiniteScrollTrigger";
 import { ProspectPlatformAvatar } from "@/shared/ui/components/ProspectPlatformAvatar";
 import { Skeleton } from "@/shared/ui/components/Skeleton";
 import {
@@ -670,6 +671,9 @@ export function NotificationsSkeleton() {
 interface NotificationsInboxProps {
   notifications: NotificationItem[];
   isLoading?: boolean;
+  hasMore?: boolean;
+  isLoadingMore?: boolean;
+  onLoadMore?: () => void;
   onSelect: (
     notification: NotificationItem,
     rowNotifications: NotificationItem[]
@@ -680,6 +684,9 @@ interface NotificationsInboxProps {
 export function NotificationsInbox({
   notifications,
   isLoading = false,
+  hasMore = false,
+  isLoadingMore = false,
+  onLoadMore,
   onSelect,
   onDismiss,
 }: NotificationsInboxProps) {
@@ -687,6 +694,24 @@ export function NotificationsInbox({
     () => groupNotificationsByDay(notifications),
     [notifications]
   );
+
+  const renderNotifications = (day: keyof NotificationGroup) => {
+    const dayNotifications = groups[day];
+
+    return (
+      <>
+        {isLoading ? (
+          <NotificationsSkeleton />
+        ) : (
+          <NotificationsList
+            notifications={dayNotifications}
+            onSelect={onSelect}
+            onDismiss={onDismiss}
+          />
+        )}
+      </>
+    );
+  };
 
   return (
     <>
@@ -704,42 +729,26 @@ export function NotificationsInbox({
           </TabsTrigger>
         </TabsList>
 
-        <TabsContent value="today">
-          {isLoading ? (
-            <NotificationsSkeleton />
-          ) : (
-            <NotificationsList
-              notifications={groups.today}
-              onSelect={onSelect}
-              onDismiss={onDismiss}
-            />
-          )}
-        </TabsContent>
+        <TabsContent value="today">{renderNotifications("today")}</TabsContent>
 
         <TabsContent value="yesterday">
-          {isLoading ? (
-            <NotificationsSkeleton />
-          ) : (
-            <NotificationsList
-              notifications={groups.yesterday}
-              onSelect={onSelect}
-              onDismiss={onDismiss}
-            />
-          )}
+          {renderNotifications("yesterday")}
         </TabsContent>
 
-        <TabsContent value="older">
-          {isLoading ? (
-            <NotificationsSkeleton />
-          ) : (
-            <NotificationsList
-              notifications={groups.older}
-              onSelect={onSelect}
-              onDismiss={onDismiss}
-            />
-          )}
-        </TabsContent>
+        <TabsContent value="older">{renderNotifications("older")}</TabsContent>
       </Tabs>
+      {!isLoading && onLoadMore ? (
+        <InfiniteScrollTrigger
+          hasMore={hasMore}
+          isLoading={isLoadingMore}
+          onLoadMore={onLoadMore}
+          resultCount={notifications.length}
+          className="mx-4"
+          loadingLabel="Loading more notifications"
+          loadMoreLabel="Load more notifications"
+          retryLabel="Retry loading notifications"
+        />
+      ) : null}
     </>
   );
 }

--- a/shared/hooks/useOutreachNotificationToast.ts
+++ b/shared/hooks/useOutreachNotificationToast.ts
@@ -7,7 +7,14 @@
  * Per AGENT_CONTEXT.txt: Mirrors existing useReplyStatus pattern for consistency.
  */
 
-import { useEffect, useMemo, useRef } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  type MouseEventHandler,
+  type ReactNode,
+} from "react";
 import { toast } from "sonner";
 import { useConvex } from "convex/react";
 import { api } from "@/convex/_generated/api";
@@ -16,6 +23,7 @@ import {
   getOutreachNotificationEventKey,
   getOutreachNotificationEventTimestamp,
 } from "@/shared/lib/notifications/outreachNotificationEvents";
+import { buildOutreachNotificationToastPlan } from "@/shared/lib/notifications/outreachNotificationToastPolicy";
 import { useAuth } from "./useAuth";
 import { useNotificationWorkspace } from "./useNotificationWorkspace";
 import { useQueryWithStatus } from "./useQueryWithStatus";
@@ -48,6 +56,20 @@ type OutreachNotificationSummary = Omit<
 };
 
 type NotificationToastVariant = "info" | "success" | "warning" | "error";
+
+type QueuedNotificationToast = {
+  key: string;
+  variant: NotificationToastVariant;
+  title: string;
+  description?: string;
+  action?: {
+    label: ReactNode;
+    onClick: MouseEventHandler<HTMLButtonElement>;
+  };
+};
+
+const OUTREACH_TOAST_DURATION_MS = 8000;
+const OUTREACH_TOAST_GAP_MS = 180;
 
 function getNotificationToastVariant(
   type: Doc<"outreachNotifications">["type"]
@@ -90,7 +112,7 @@ export function useOutreachNotificationToast() {
   );
 
   const notificationsQuery = useQueryWithStatus(
-    api.outreach.listNotifications,
+    api.outreach.listPendingNotifications,
     isAuthenticated && workspaceId
       ? { workspaceId: workspaceId as Id<"workspaces"> }
       : "skip"
@@ -104,6 +126,68 @@ export function useOutreachNotificationToast() {
   const shownNotifications = useRef<Set<string>>(new Set());
   const baselineWorkspaceRef = useRef<string | null>(null);
   const baselineInitializedRef = useRef(false);
+  const toastQueueRef = useRef<QueuedNotificationToast[]>([]);
+  const activeToastKeyRef = useRef<string | null>(null);
+  const nextToastTimerRef = useRef<number | null>(null);
+
+  const flushToastQueue = useCallback(() => {
+    if (activeToastKeyRef.current || toastQueueRef.current.length === 0) {
+      return;
+    }
+
+    const nextToast = toastQueueRef.current.shift();
+    if (!nextToast) return;
+
+    activeToastKeyRef.current = nextToast.key;
+    let hasAdvanced = false;
+
+    const advanceQueue = () => {
+      if (hasAdvanced || activeToastKeyRef.current !== nextToast.key) {
+        return;
+      }
+
+      hasAdvanced = true;
+      activeToastKeyRef.current = null;
+      nextToastTimerRef.current = window.setTimeout(() => {
+        nextToastTimerRef.current = null;
+        flushToastQueue();
+      }, OUTREACH_TOAST_GAP_MS);
+    };
+
+    toast[nextToast.variant](nextToast.title, {
+      id: nextToast.key,
+      description: nextToast.description,
+      duration: OUTREACH_TOAST_DURATION_MS,
+      action: nextToast.action,
+      onAutoClose: advanceQueue,
+      onDismiss: advanceQueue,
+    });
+  }, []);
+
+  const clearToastQueue = useCallback(() => {
+    toastQueueRef.current = [];
+
+    if (nextToastTimerRef.current !== null) {
+      window.clearTimeout(nextToastTimerRef.current);
+      nextToastTimerRef.current = null;
+    }
+
+    const activeToastKey = activeToastKeyRef.current;
+    activeToastKeyRef.current = null;
+    if (activeToastKey) {
+      toast.dismiss(activeToastKey);
+    }
+  }, []);
+
+  const enqueueToast = useCallback(
+    (queuedToast: QueuedNotificationToast) => {
+      toastQueueRef.current.push(queuedToast);
+      flushToastQueue();
+    },
+    [flushToastQueue]
+  );
+
+  useEffect(() => clearToastQueue, [clearToastQueue]);
 
   useEffect(() => {
     if (!isAuthenticated || isLoading || shellStateQuery.isPending) {
@@ -112,6 +196,7 @@ export function useOutreachNotificationToast() {
 
     const scopedWorkspaceId = workspaceId ?? null;
     if (baselineWorkspaceRef.current !== scopedWorkspaceId) {
+      clearToastQueue();
       baselineWorkspaceRef.current = scopedWorkspaceId;
       baselineInitializedRef.current = false;
       shownNotifications.current.clear();
@@ -140,11 +225,58 @@ export function useOutreachNotificationToast() {
       baselineInitializedRef.current = true;
     }
 
-    for (const notification of pending) {
+    const toastPlan = buildOutreachNotificationToastPlan(
+      pending,
+      shownNotifications.current
+    );
+
+    if (toastPlan.coalescedCount > 0) {
+      const unseenPending = pending.filter(
+        (notification) =>
+          !shownNotifications.current.has(
+            getOutreachNotificationEventKey(notification)
+          )
+      );
+
+      for (const notification of unseenPending) {
+        shownNotifications.current.add(
+          getOutreachNotificationEventKey(notification)
+        );
+      }
+
+      const firstNotification = unseenPending[0];
+      const lastNotification = unseenPending.at(-1);
+      const burstKey = [
+        "outreach-notification-burst",
+        scopedWorkspaceId,
+        firstNotification
+          ? getOutreachNotificationEventKey(firstNotification)
+          : "first",
+        lastNotification
+          ? getOutreachNotificationEventKey(lastNotification)
+          : "last",
+      ].join(":");
+
+      enqueueToast({
+        key: burstKey,
+        variant: "info",
+        title: `${toastPlan.coalescedCount} new notifications`,
+        description:
+          "Open Notifications to review the pending outreach updates.",
+        action: {
+          label: "View",
+          onClick: () => {
+            window.location.href = "/notifications";
+          },
+        },
+      });
+      return;
+    }
+
+    for (const notification of toastPlan.notifications) {
       const notificationEventKey =
         getOutreachNotificationEventKey(notification);
-      // Skip if already shown
-      if (shownNotifications.current.has(notificationEventKey)) continue;
+      shownNotifications.current.add(notificationEventKey);
 
       const targetHref =
         notification.targetHref ??
@@ -187,26 +319,22 @@ export function useOutreachNotificationToast() {
           }
         : undefined;
 
-      const commonOptions = {
-        id: notificationEventKey,
-        duration: 8000, // Auto-dismiss after 8s
-        action: toastAction,
-      };
-
       const variant = getNotificationToastVariant(notification.type);
-      toast[variant](notification.title, {
+      enqueueToast({
+        key: notificationEventKey,
+        variant,
+        title: notification.title,
         description: notification.message,
-        ...commonOptions,
+        action: toastAction,
       });
-
-      // Mark as shown
-      shownNotifications.current.add(notificationEventKey);
     }
   }, [
     isAuthenticated,
     isLoading,
     notifications,
     notificationsQuery.isSuccess,
+    clearToastQueue,
+    enqueueToast,
     shellStateQuery.isPending,
     workspaceId,
     workspaceSessionStartedAt,

--- a/shared/lib/notifications/outreachNotificationToastPolicy.ts
+++ b/shared/lib/notifications/outreachNotificationToastPolicy.ts
@@ -1,0 +1,38 @@
+import {
+  getOutreachNotificationEventKey,
+  type OutreachNotificationEvent,
+} from "./outreachNotificationEvents";
+
+/** Keep small groups useful while preventing a loaded inbox from flooding Sonner. */
+export const MAX_INDIVIDUAL_OUTREACH_TOASTS = 3;
+
+export interface OutreachNotificationToastPlan<
+  T extends OutreachNotificationEvent,
+> {
+  notifications: T[];
+  coalescedCount: number;
+}
+
+export function buildOutreachNotificationToastPlan<
+  T extends OutreachNotificationEvent,
+>(
+  notifications: readonly T[],
+  shownNotificationKeys: ReadonlySet<string>
+): OutreachNotificationToastPlan<T> {
+  const unseenNotifications = notifications.filter(
+    (notification) =>
+      !shownNotificationKeys.has(getOutreachNotificationEventKey(notification))
+  );
+
+  if (unseenNotifications.length <= MAX_INDIVIDUAL_OUTREACH_TOASTS) {
+    return {
+      notifications: unseenNotifications,
+      coalescedCount: 0,
+    };
+  }
+
+  return {
+    notifications: [],
+    coalescedCount: unseenNotifications.length,
+  };
+}

--- a/shared/ui/components/AsciiSpinnerText.tsx
+++ b/shared/ui/components/AsciiSpinnerText.tsx
@@ -2,18 +2,16 @@
 
 import { useEffect, useState } from "react";
 
-type SpinnerVariant = "spinner" | "pulse" | "clock" | "ascii";
+type SpinnerVariant = "spinner" | "clock" | "ascii";
 
 const VARIANT_FRAMES: Record<SpinnerVariant, readonly string[]> = {
   spinner: ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"],
-  pulse: ["·", "•", "●", "•", "·"],
   clock: ["◴", "◷", "◶", "◵"],
   ascii: ["|", "/", "-", "\\"],
 };
 
 const VARIANT_DEFAULT_INTERVAL: Record<SpinnerVariant, number> = {
   spinner: 40,
-  pulse: 200,
   clock: 250,
   ascii: 120,
 };

--- a/tests/outreach-notification-toast.test.ts
+++ b/tests/outreach-notification-toast.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import {
+  buildOutreachNotificationToastPlan,
+  MAX_INDIVIDUAL_OUTREACH_TOASTS,
+} from "../shared/lib/notifications/outreachNotificationToastPolicy";
+
+function createNotification(id: string, eventVersion = 1) {
+  return {
+    _creationTime: 1,
+    _id: id,
+    eventVersion,
+    eventUpdatedAt: 1,
+  };
+}
+
+test("small notification groups remain individually actionable", () => {
+  const notifications = [
+    createNotification("first"),
+    createNotification("second"),
+    createNotification("third"),
+  ];
+
+  const plan = buildOutreachNotificationToastPlan(notifications, new Set());
+
+  assert.equal(MAX_INDIVIDUAL_OUTREACH_TOASTS, 3);
+  assert.deepEqual(plan.notifications, notifications);
+  assert.equal(plan.coalescedCount, 0);
+});
+
+test("a 100-notification backlog becomes one summary toast", () => {
+  const notifications = Array.from({ length: 100 }, (_, index) =>
+    createNotification(`notification-${index}`)
+  );
+
+  const plan = buildOutreachNotificationToastPlan(notifications, new Set());
+
+  assert.deepEqual(plan.notifications, []);
+  assert.equal(plan.coalescedCount, 100);
+});
+
+test("shown event keys are not resurfaced as duplicate toasts", () => {
+  const notifications = [
+    createNotification("shown"),
+    createNotification("new"),
+  ];
+
+  const plan = buildOutreachNotificationToastPlan(
+    notifications,
+    new Set(["shown:1:1"])
+  );
+
+  assert.deepEqual(plan.notifications, [notifications[1]]);
+  assert.equal(plan.coalescedCount, 0);
+});
+
+test("the toast hook serializes individual toasts and coalesces bursts", () => {
+  const source = readFileSync(
+    "shared/hooks/useOutreachNotificationToast.ts",
+    "utf8"
+  );
+
+  assert.match(source, /onAutoClose: advanceQueue/);
+  assert.match(source, /onDismiss: advanceQueue/);
+  assert.match(source, /buildOutreachNotificationToastPlan/);
+  assert.match(source, /Open Notifications to review/);
+});
+
+test("the dedicated prospect profile owns the desktop right divider", () => {
+  const source = readFileSync(
+    "features/prospects/ui/pages/UseCaseProspectPage.tsx",
+    "utf8"
+  );
+
+  assert.match(source, /md:border-border md:border-r/);
+});
+
+test("waiting for connection uses a static calendar icon", () => {
+  const taskSource = readFileSync(
+    "features/prospects/ui/components/outreach-plan/TaskItem.tsx",
+    "utf8"
+  );
+  const spinnerSource = readFileSync(
+    "shared/ui/components/AsciiSpinnerText.tsx",
+    "utf8"
+  );
+
+  assert.match(taskSource, /CalendarClockIcon/);
+  assert.doesNotMatch(taskSource, /waiting_connection: "pulse"/);
+  assert.doesNotMatch(spinnerSource, /pulse/);
+});

--- a/tests/pagination-consistency.test.ts
+++ b/tests/pagination-consistency.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const readSource = (file: string) => readFileSync(file, "utf8");
+
+test("notifications use cursor pagination while toasts monitor pending items", () => {
+  const pageSource = readSource("app/(webapp)/notifications/page.tsx");
+  const inboxSource = readSource(
+    "features/webapp/ui/components/notifications/NotificationsInbox.tsx"
+  );
+  const outreachSource = readSource("convex/outreach.ts");
+  const toastHookSource = readSource(
+    "shared/hooks/useOutreachNotificationToast.ts"
+  );
+
+  assert.match(pageSource, /usePaginatedQuery/);
+  assert.match(pageSource, /initialNumItems: NOTIFICATIONS_PAGE_SIZE/);
+  assert.match(pageSource, /notificationsQuery\.loadMore/);
+  assert.match(inboxSource, /<InfiniteScrollTrigger/);
+  assert.match(outreachSource, /paginationOpts: paginationOptsValidator/);
+  assert.match(outreachSource, /\.paginate\(paginationOpts\)/);
+  assert.match(outreachSource, /export const listPendingNotifications/);
+  assert.match(toastHookSource, /api\.outreach\.listPendingNotifications/);
+});
+
+test("activity logs load the next cursor page from the shared trigger", () => {
+  const backendSource = readSource("convex/outreach.ts");
+  const tabSource = readSource(
+    "features/prospects/ui/components/tabs/ActivityLogTab.tsx"
+  );
+
+  assert.match(backendSource, /export const getActivityLog = query/);
+  assert.match(backendSource, /paginationOpts: paginationOptsValidator/);
+  assert.match(backendSource, /activityQuery\.paginate\(paginationOpts\)/);
+  assert.match(tabSource, /usePaginatedQuery/);
+  assert.match(tabSource, /<InfiniteScrollTrigger/);
+  assert.match(tabSource, /dataQuery\.loadMore\(ACTIVITIES_PER_PAGE\)/);
+  assert.doesNotMatch(tabSource, /setLimit|loadingLimit/);
+});
+
+test("the legacy X conversation panel forwards reply cursors", () => {
+  const validatorSource = readSource("convex/validators.ts");
+  const actionSource = readSource("convex/socialapi.ts");
+  const panelSource = readSource(
+    "features/prospects/ui/components/ConversationPanel.tsx"
+  );
+
+  assert.match(
+    validatorSource,
+    /getDynamicThreadDataArgsValidator[\s\S]*repliesCursor/
+  );
+  assert.match(actionSource, /repliesCursor[\s\S]*getConversationContext/);
+  assert.match(panelSource, /<InfiniteScrollTrigger/);
+  assert.match(panelSource, /loadConversation\(nextRepliesCursor\)/);
+});
+
+test("Agent observability remains table-based pagination", () => {
+  const dashboardSource = readSource(
+    "features/agent-ops/ui/AgentOpsDashboard.tsx"
+  );
+  const paginationSource = readSource(
+    "shared/ui/components/TablePagination.tsx"
+  );
+
+  assert.match(dashboardSource, /TablePagination/);
+  assert.doesNotMatch(dashboardSource, /InfiniteScrollTrigger/);
+  assert.match(paginationSource, /pageSize/);
+});


### PR DESCRIPTION
## Summary

- Prevent Sonner notification bursts from rendering as a glitchy stack by separating the pending notification monitor from the paginated inbox and serializing/coalescing toast delivery.
- Add cursor pagination and shared infinite scrolling to notifications, thread history, social profile feeds, conversations, comments, replies, interactions, and activity logs.
- Keep Agent observability on its existing table and numbered pagination UI.
- Add the desktop-only dedicated profile divider and replace the waiting-for-connection animation with the static calendar icon used by the product UI.

## UX impact

- Users see a bounded initial result set and new results load automatically near the scroll boundary with a circular spinner and retry fallback.
- Notification bursts are presented as one actionable summary toast instead of many simultaneous Sonners.
- The profile divider appears only on dedicated desktop profile pages and disappears on mobile and other surfaces.
- Waiting for connection is visually consistent and no longer animated.

## Verification

- `pnpm build`
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm lint:strict`
- Prettier and `git diff --check`
- Targeted tests: 21 passed
- Convex suite: 41 files, 208 tests passed
- TypeScript language-service diagnostics: 0
- Built-in browser E2E checks on desktop and mobile, plus production checks for connected accounts and the exact profile URL

## Commits

- `5dd4a045` fix(ui): stabilize outreach notifications and profile states
- `a7feb92a` feat(pagination): add cursor loading across activity surfaces
- `84ecd80a` test(convex): extend long-running integration test timeouts

Please review and merge when ready; this PR has not been merged.