### PR TITLE
Fix Twitter prospecting query matching

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -215,6 +215,7 @@ import type * as lib_triggers from "../lib/triggers.js";
 import type * as lib_twitterActionCatalog from "../lib/twitterActionCatalog.js";
 import type * as lib_twitterActionPolicy from "../lib/twitterActionPolicy.js";
 import type * as lib_twitterProfileLinkResolver from "../lib/twitterProfileLinkResolver.js";
+import type * as lib_twitterProspectingSearchCore from "../lib/twitterProspectingSearchCore.js";
 import type * as lib_twitterSearchResultCore from "../lib/twitterSearchResultCore.js";
 import type * as lib_twitterViewerStateService from "../lib/twitterViewerStateService.js";
 import type * as lib_typeGuards from "../lib/typeGuards.js";
@@ -565,6 +566,7 @@ declare const fullApi: ApiFromModules<{
   "lib/twitterActionCatalog": typeof lib_twitterActionCatalog;
   "lib/twitterActionPolicy": typeof lib_twitterActionPolicy;
   "lib/twitterProfileLinkResolver": typeof lib_twitterProfileLinkResolver;
+  "lib/twitterProspectingSearchCore": typeof lib_twitterProspectingSearchCore;
   "lib/twitterSearchResultCore": typeof lib_twitterSearchResultCore;
   "lib/twitterViewerStateService": typeof lib_twitterViewerStateService;
   "lib/typeGuards": typeof lib_typeGuards;

--- a/convex/agents/internal.ts
+++ b/convex/agents/internal.ts
@@ -21,6 +21,10 @@ import {
 import { getCurrentUTCTimestamp } from "../../shared/lib/utils/time/timeUtils";
 import { getWorkspaceUseCase } from "../../shared/lib/workspaceUseCases";
 import { getWideEventLogger } from "../lib/wideEventLogger";
+import {
+  resolveTwitterProspectingSearchMode,
+  type TwitterProspectingSearchMode,
+} from "../lib/twitterProspectingSearchCore";
 
 // ============================================================================
 // Schemas
@@ -36,8 +40,12 @@ const socialQueryItemSchema = z.object({
   sourceKeyword: z.string().optional(),
 });
 
+const twitterSocialQueryItemSchema = socialQueryItemSchema.extend({
+  searchMode: z.enum(["exact", "raw"]),
+});
+
 const socialQueriesSchema = z.object({
-  twitterQueries: z.array(socialQueryItemSchema).max(15),
+  twitterQueries: z.array(twitterSocialQueryItemSchema).max(15),
   linkedinPostQueries: z.array(socialQueryItemSchema).max(15),
   linkedinPeopleQueries: z.array(socialQueryItemSchema).max(15),
   reasoning: z.string(),
@@ -48,7 +56,9 @@ const modelRoutingValidator = v.union(
   v.literal("reasoning")
 );
 
-type GeneratedSocialQuery = z.infer<typeof socialQueryItemSchema>;
+type GeneratedSocialQuery = z.infer<typeof socialQueryItemSchema> & {
+  searchMode?: TwitterProspectingSearchMode;
+};
 type SocialQueriesObject = z.infer<typeof socialQueriesSchema>;
 type SocialQueryMetadata = {
   query: string;
@@ -57,6 +67,7 @@ type SocialQueryMetadata = {
   linkedinSurface?: "posts" | "people";
   linkedinSurfaceTargets?: Array<"posts" | "people">;
   queryStyle: "natural_phrase" | "professional_keyword" | "role_title";
+  twitterSearchMode?: TwitterProspectingSearchMode;
   legacyCompatibilitySource: boolean;
 };
 
@@ -112,42 +123,70 @@ function dedupeQueryItems(items: GeneratedSocialQuery[]) {
       sourceKeyword: item.sourceKeyword
         ? normalizeSearchText(item.sourceKeyword) || undefined
         : undefined,
+      ...(item.searchMode
+        ? {
+            searchMode: resolveTwitterProspectingSearchMode({
+              query,
+              requestedMode: item.searchMode,
+            }),
+          }
+        : {}),
     });
   }
 
   return deduped;
 }
 
-function normalizeSocialQueryItemPayload(value: unknown): unknown {
+function normalizeSocialQueryItemPayload(
+  value: unknown,
+  platform: "twitter" | "linkedin"
+): unknown {
   if (typeof value === "string") {
-    return { query: normalizeSocialQueryText(value) };
+    const query = normalizeSocialQueryText(value);
+    return platform === "twitter" ? { query, searchMode: "raw" } : { query };
   }
 
   if (!isRecord(value)) {
     return value;
   }
 
+  const query =
+    typeof value.query === "string"
+      ? normalizeSocialQueryText(value.query)
+      : value.query;
+
   return {
     ...value,
-    query:
-      typeof value.query === "string"
-        ? normalizeSocialQueryText(value.query)
-        : value.query,
+    query,
     sourceKeyword:
       typeof value.sourceKeyword === "string"
         ? normalizeSearchText(value.sourceKeyword)
         : value.sourceKeyword,
+    ...(platform === "twitter"
+      ? {
+          searchMode:
+            typeof query === "string"
+              ? resolveTwitterProspectingSearchMode({
+                  query,
+                  requestedMode: value.searchMode === "exact" ? "exact" : "raw",
+                })
+              : "raw",
+        }
+      : {}),
   };
 }
 
-function normalizeSocialQueryArrayPayload(value: unknown) {
+function normalizeSocialQueryArrayPayload(
+  value: unknown,
+  platform: "twitter" | "linkedin"
+) {
   if (!Array.isArray(value)) {
     return [];
   }
 
   return value
     .slice(0, MAX_SOCIAL_QUERY_ITEMS_PER_GROUP)
-    .map(normalizeSocialQueryItemPayload);
+    .map((item) => normalizeSocialQueryItemPayload(item, platform));
 }
 
 function normalizeSocialQueriesPayload(value: unknown): unknown {
@@ -157,12 +196,17 @@ function normalizeSocialQueriesPayload(value: unknown): unknown {
 
   return {
     ...value,
-    twitterQueries: normalizeSocialQueryArrayPayload(value.twitterQueries),
+    twitterQueries: normalizeSocialQueryArrayPayload(
+      value.twitterQueries,
+      "twitter"
+    ),
     linkedinPostQueries: normalizeSocialQueryArrayPayload(
-      value.linkedinPostQueries
+      value.linkedinPostQueries,
+      "linkedin"
     ),
     linkedinPeopleQueries: normalizeSocialQueryArrayPayload(
-      value.linkedinPeopleQueries
+      value.linkedinPeopleQueries,
+      "linkedin"
     ),
     reasoning:
       typeof value.reasoning === "string"
@@ -196,7 +240,9 @@ function buildKeywordFallbackSocialQueries(args: {
   );
 
   return {
-    twitterQueries: args.includeTwitter ? copyQueryItems(baseQueries) : [],
+    twitterQueries: args.includeTwitter
+      ? baseQueries.map((item) => ({ ...item, searchMode: "raw" as const }))
+      : [],
     linkedinPostQueries: args.includeLinkedIn
       ? copyQueryItems(baseQueries)
       : [],
@@ -278,6 +324,7 @@ function buildSocialQueryActionResult(args: {
         query: item.query,
         sourceKeyword: item.sourceKeyword,
         ...metadata,
+        twitterSearchMode: item.searchMode,
       });
     }
   };
@@ -613,14 +660,18 @@ Use this search framing: ${useCase.promptContext.searchIntent}
 
 **CRITICAL: CHARACTER LIMIT**
 Every query MUST be 40 characters or less. Count the characters before including each query.
-Queries longer than 40 characters will NOT return results on social platforms.
-Aim for 25-40 characters. Shorter is better for search matching.
+Queries are normalized to this operational limit before they are saved.
+Prefer 2-5 meaningful words. Shorter is better for search matching.
 
 Return three separate groups:
 1. twitterQueries
 - Natural first-person phrasing plus short role/profile/company/topic terms
 - Conversational pain, intent, recommendation, or help-seeking language
 - Profile-fit terms that can lead to seed accounts for expansion
+- For every Twitter query, return searchMode as either "exact" or "raw"
+- Use "exact" only for a coherent 2-5 word phrase that people plausibly write verbatim
+- Use "raw" for keyword combinations, broader intent, hashtags, operators, or sentence fragments
+- Never include quotation marks in query; the backend applies them only for validated exact searches
 
 2. linkedinPostQueries
 - Short professional or topical phrases
@@ -708,6 +759,8 @@ Return grouped queries that are net-new relative to the operational memory above
 
 When Twitter is requested:
 - generate a balanced mix of post-like first-person phrasing and short role, company, profile, or topical terms
+- set searchMode="exact" only for short phrases likely to appear verbatim
+- otherwise set searchMode="raw"; do not add quotation marks yourself
 
 When LinkedIn is requested:
 - generate linkedinPostQueries as short professional/topic phrases

--- a/convex/integrations/twitter/searchPosts.ts
+++ b/convex/integrations/twitter/searchPosts.ts
@@ -15,6 +15,7 @@ import { twitterSearchTypeValidator } from "../../validators";
 import {
   compactTwitterSearchPost,
   compactTwitterSearchResults,
+  normalizeTwitterSearchCursor,
   type TwitterPost,
 } from "../../lib/twitterSearchResultCore";
 export type {
@@ -29,7 +30,7 @@ const twitterSearchPostsLogger = logger.withScope("TwitterSearchPosts");
 
 /** socialapi.io search response */
 interface ApiResponse {
-  next_cursor?: string;
+  next_cursor?: unknown;
   tweets?: unknown[];
 }
 
@@ -226,11 +227,13 @@ export const searchInternal = internalAction({
 
     const data: ApiResponse = await response.json();
 
+    const nextCursor = normalizeTwitterSearchCursor(data.next_cursor);
+
     return {
       success: true,
       posts: compactTwitterSearchResults(data.tweets ?? []),
-      nextCursor: data.next_cursor,
-      hasMore: !!data.next_cursor,
+      nextCursor,
+      hasMore: nextCursor !== undefined,
     };
   },
 });

--- a/convex/keywords.ts
+++ b/convex/keywords.ts
@@ -15,6 +15,7 @@ import {
   keywordTypeValidator,
   linkedinSearchSurfaceValidator,
   socialQueryStyleValidator,
+  twitterProspectingSearchModeValidator,
 } from "./validators";
 import { getCurrentUTCTimestamp } from "../shared/lib/utils/time/timeUtils";
 import {
@@ -37,6 +38,10 @@ import {
   prioritizeQueries,
   type QueryPriority,
 } from "./lib/queryPrioritizationCore";
+import {
+  resolveTwitterProspectingSearchMode,
+  type TwitterProspectingSearchMode,
+} from "./lib/twitterProspectingSearchCore";
 
 // ============================================================================
 // Types
@@ -134,6 +139,7 @@ async function getPrioritizedSocialQueries(
     value: string;
     lastSearchedAt?: number;
     priority: QueryPriority;
+    searchMode?: TwitterProspectingSearchMode;
   }>
 > {
   const [keywords, performanceRows] = await Promise.all([
@@ -152,6 +158,15 @@ async function getPrioritizedSocialQueries(
   ]);
   const performanceByQueryId = new Map(
     performanceRows.map((row) => [String(row.queryId), row])
+  );
+  const twitterSearchModeByQueryId = new Map(
+    keywords.map((keyword) => [
+      String(keyword._id),
+      resolveTwitterProspectingSearchMode({
+        query: keyword.originalValue ?? keyword.value,
+        requestedMode: keyword.twitterSearchMode,
+      }),
+    ])
   );
   const candidates = keywords
     .filter((keyword) => keyword.status !== "deprecated")
@@ -194,6 +209,10 @@ async function getPrioritizedSocialQueries(
     value: candidate.value,
     lastSearchedAt: candidate.lastSearchedAt,
     priority: candidate.priority,
+    searchMode:
+      args.platform === "twitter"
+        ? twitterSearchModeByQueryId.get(String(candidate.id))
+        : undefined,
   }));
 }
 
@@ -223,6 +242,7 @@ async function syncKeywordMemoryState(
     linkedinSurface?: "posts" | "people";
     linkedinSurfaceTargets?: Array<"posts" | "people">;
     queryStyle?: "natural_phrase" | "professional_keyword" | "role_title";
+    twitterSearchMode?: TwitterProspectingSearchMode;
   }
 ) {
   const queryCandidate = await upsertQueryCandidateRecord(ctx.db, {
@@ -233,6 +253,7 @@ async function syncKeywordMemoryState(
     linkedinSurface: args.linkedinSurface,
     linkedinSurfaceTargets: args.linkedinSurfaceTargets,
     queryStyle: args.queryStyle,
+    twitterSearchMode: args.twitterSearchMode,
     status: "activated",
     activatedKeywordId: args.keywordId,
   });
@@ -608,6 +629,7 @@ export const saveKeywordInternal = internalMutation({
     linkedinSurface: v.optional(linkedinSearchSurfaceValidator),
     linkedinSurfaceTargets: v.optional(v.array(linkedinSearchSurfaceValidator)),
     queryStyle: v.optional(socialQueryStyleValidator),
+    twitterSearchMode: v.optional(twitterProspectingSearchModeValidator),
   },
   handler: async (ctx, args) => {
     const normalized = normalizeKeyword(args.value);
@@ -652,6 +674,8 @@ export const saveKeywordInternal = internalMutation({
               args.linkedinSurface ? [args.linkedinSurface] : undefined
             ) ?? existing.linkedinSurfaceTargets,
           queryStyle: args.queryStyle ?? existing.queryStyle,
+          twitterSearchMode:
+            args.twitterSearchMode ?? existing.twitterSearchMode,
         });
 
         await syncKeywordMemoryState(ctx, {
@@ -671,6 +695,8 @@ export const saveKeywordInternal = internalMutation({
               args.linkedinSurface ? [args.linkedinSurface] : undefined
             ) ?? existing.linkedinSurfaceTargets,
           queryStyle: args.queryStyle ?? existing.queryStyle,
+          twitterSearchMode:
+            args.twitterSearchMode ?? existing.twitterSearchMode,
         });
       }
       return existing._id;
@@ -704,6 +730,7 @@ export const saveKeywordInternal = internalMutation({
           args.linkedinSurface ? [args.linkedinSurface] : undefined
         ) ?? undefined,
       queryStyle: args.queryStyle,
+      twitterSearchMode: args.twitterSearchMode,
     });
 
     await syncKeywordMemoryState(ctx, {
@@ -719,6 +746,7 @@ export const saveKeywordInternal = internalMutation({
           args.linkedinSurface ? [args.linkedinSurface] : undefined
         ) ?? undefined,
       queryStyle: args.queryStyle,
+      twitterSearchMode: args.twitterSearchMode,
     });
 
     return keywordId;
@@ -757,6 +785,7 @@ export const saveKeywordsBatch = internalMutation({
           v.array(linkedinSearchSurfaceValidator)
         ),
         queryStyle: v.optional(socialQueryStyleValidator),
+        twitterSearchMode: v.optional(twitterProspectingSearchModeValidator),
       })
     ),
   },
@@ -817,6 +846,8 @@ export const saveKeywordsBatch = internalMutation({
                 keyword.linkedinSurface ? [keyword.linkedinSurface] : undefined
               ) ?? existing.linkedinSurfaceTargets,
             queryStyle: keyword.queryStyle ?? existing.queryStyle,
+            twitterSearchMode:
+              keyword.twitterSearchMode ?? existing.twitterSearchMode,
           });
           await syncKeywordMemoryState(ctx, {
             workspaceId: args.workspaceId,
@@ -838,6 +869,8 @@ export const saveKeywordsBatch = internalMutation({
                 keyword.linkedinSurface ? [keyword.linkedinSurface] : undefined
               ) ?? existing.linkedinSurfaceTargets,
             queryStyle: keyword.queryStyle ?? existing.queryStyle,
+            twitterSearchMode:
+              keyword.twitterSearchMode ?? existing.twitterSearchMode,
           });
           updated++;
         } else {
@@ -874,6 +907,7 @@ export const saveKeywordsBatch = internalMutation({
               keyword.linkedinSurface ? [keyword.linkedinSurface] : undefined
             ) ?? undefined,
           queryStyle: keyword.queryStyle,
+          twitterSearchMode: keyword.twitterSearchMode,
         });
         await syncKeywordMemoryState(ctx, {
           workspaceId: args.workspaceId,
@@ -888,6 +922,7 @@ export const saveKeywordsBatch = internalMutation({
               keyword.linkedinSurface ? [keyword.linkedinSurface] : undefined
             ) ?? undefined,
           queryStyle: keyword.queryStyle,
+          twitterSearchMode: keyword.twitterSearchMode,
         });
         // Add to map to prevent duplicates within batch
         existingMap.set(normalized, {
@@ -909,6 +944,7 @@ export const saveKeywordsBatch = internalMutation({
               keyword.linkedinSurface ? [keyword.linkedinSurface] : undefined
             ) ?? undefined,
           queryStyle: keyword.queryStyle,
+          twitterSearchMode: keyword.twitterSearchMode,
         });
         inserted++;
       }

--- a/convex/lib/memoryCore.ts
+++ b/convex/lib/memoryCore.ts
@@ -17,6 +17,7 @@ import {
   isEvaluatorRelevantEventType,
   resolveDefaultMemoryWorkflowEventStatus,
 } from "./memoryEvaluatorCore";
+import type { TwitterProspectingSearchMode } from "./twitterProspectingSearchCore";
 
 type MemoryDbWriter = GenericDatabaseWriter<DataModel>;
 
@@ -89,6 +90,7 @@ export async function upsertQueryCandidateRecord(
     linkedinSurface?: "posts" | "people";
     linkedinSurfaceTargets?: Array<"posts" | "people">;
     queryStyle?: "natural_phrase" | "professional_keyword" | "role_title";
+    twitterSearchMode?: TwitterProspectingSearchMode;
     noveltyScore?: number;
     status?: Doc<"queryCandidates">["status"];
     duplicateReason?: Doc<"queryCandidates">["duplicateReason"];
@@ -132,6 +134,7 @@ export async function upsertQueryCandidateRecord(
       linkedinSurfaceTargets:
         args.linkedinSurfaceTargets ?? existing.linkedinSurfaceTargets,
       queryStyle: args.queryStyle ?? existing.queryStyle,
+      twitterSearchMode: args.twitterSearchMode ?? existing.twitterSearchMode,
       noveltyScore: args.noveltyScore ?? existing.noveltyScore,
       status: nextStatus,
       duplicateReason: args.duplicateReason ?? existing.duplicateReason,
@@ -170,6 +173,7 @@ export async function upsertQueryCandidateRecord(
     linkedinSurface: args.linkedinSurface,
     linkedinSurfaceTargets: args.linkedinSurfaceTargets,
     queryStyle: args.queryStyle,
+    twitterSearchMode: args.twitterSearchMode,
     noveltyScore: args.noveltyScore,
     status,
     duplicateReason: args.duplicateReason,

--- a/convex/lib/twitterProspectingSearchCore.test.ts
+++ b/convex/lib/twitterProspectingSearchCore.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "vitest";
+import {
+  getTwitterExactFallbackQueries,
+  partitionTwitterProspectingQueries,
+  resolveTwitterProspectingSearchMode,
+  stripTwitterExactPhraseQuotes,
+} from "./twitterProspectingSearchCore";
+
+describe("twitter prospecting search mode", () => {
+  test("keeps a short coherent LLM-selected phrase exact", () => {
+    expect(
+      resolveTwitterProspectingSearchMode({
+        query: "looking for screen recorder",
+        requestedMode: "exact",
+      })
+    ).toBe("exact");
+  });
+
+  test("defaults legacy and LLM-omitted modes to raw", () => {
+    expect(
+      resolveTwitterProspectingSearchMode({
+        query: "screen recorder mac",
+      })
+    ).toBe("raw");
+  });
+
+  test.each([
+    "need an integrated screen recorder for",
+    "this exact phrase has far too many words",
+    "screen recorder OR loom alternative",
+    "screen recorder since_time:123",
+  ])("demotes unsafe exact phrase %s to raw", (query) => {
+    expect(
+      resolveTwitterProspectingSearchMode({
+        query,
+        requestedMode: "exact",
+      })
+    ).toBe("raw");
+  });
+
+  test("partitions validated query plans by provider mode", () => {
+    expect(
+      partitionTwitterProspectingQueries([
+        { query: "looking for screen recorder", searchMode: "exact" },
+        { query: "screen recorder mac", searchMode: "raw" },
+      ])
+    ).toEqual({
+      exact: ["looking for screen recorder"],
+      raw: ["screen recorder mac"],
+    });
+  });
+
+  test("falls back only after successful exact searches return zero", () => {
+    expect(
+      getTwitterExactFallbackQueries([
+        {
+          query: '"looking for screen recorder"',
+          postsFound: 0,
+          success: true,
+        },
+        { query: '"video export is slow"', postsFound: 2, success: true },
+        {
+          query: '"provider request failed"',
+          postsFound: 0,
+          success: false,
+        },
+      ])
+    ).toEqual(["looking for screen recorder"]);
+  });
+
+  test("removes only a complete pair of exact phrase quotes", () => {
+    expect(stripTwitterExactPhraseQuotes('"screen recorder mac"')).toBe(
+      "screen recorder mac"
+    );
+    expect(stripTwitterExactPhraseQuotes('"screen recorder mac')).toBe(
+      '"screen recorder mac'
+    );
+  });
+});

--- a/convex/lib/twitterProspectingSearchCore.test.ts
+++ b/convex/lib/twitterProspectingSearchCore.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import {
   getTwitterExactFallbackQueries,
+  mergeTwitterProspectingSearchResults,
   partitionTwitterProspectingQueries,
   resolveTwitterProspectingSearchMode,
   stripTwitterExactPhraseQuotes,
@@ -29,6 +30,8 @@ describe("twitter prospecting search mode", () => {
     "this exact phrase has far too many words",
     "screen recorder OR loom alternative",
     "screen recorder since_time:123",
+    'looking for "screen recorder"',
+    '"looking for screen recorder',
   ])("demotes unsafe exact phrase %s to raw", (query) => {
     expect(
       resolveTwitterProspectingSearchMode({
@@ -41,7 +44,7 @@ describe("twitter prospecting search mode", () => {
   test("partitions validated query plans by provider mode", () => {
     expect(
       partitionTwitterProspectingQueries([
-        { query: "looking for screen recorder", searchMode: "exact" },
+        { query: '"looking for screen recorder"', searchMode: "exact" },
         { query: "screen recorder mac", searchMode: "raw" },
       ])
     ).toEqual({
@@ -66,6 +69,62 @@ describe("twitter prospecting search mode", () => {
         },
       ])
     ).toEqual(["looking for screen recorder"]);
+  });
+
+  test("deduplicates overlapping search posts before they are saved", () => {
+    const exactPost = { id_str: "post-1", source: "exact" };
+    const rawPost = { id_str: "post-1", source: "raw" };
+    const uniquePost = { id_str: "post-2", source: "fallback" };
+
+    expect(
+      mergeTwitterProspectingSearchResults([
+        {
+          queryStats: [
+            {
+              query: "looking for screen recorder",
+              postsFound: 1,
+              success: true,
+            },
+          ],
+          posts: [exactPost],
+          matchedQueriesByPostId: {
+            "post-1": ["looking for screen recorder"],
+          },
+        },
+        {
+          queryStats: [
+            {
+              query: "screen recorder mac",
+              postsFound: 2,
+              success: true,
+            },
+          ],
+          posts: [rawPost, uniquePost],
+          matchedQueriesByPostId: {
+            "post-1": ["screen recorder mac"],
+            "post-2": ["screen recorder mac"],
+          },
+        },
+      ])
+    ).toEqual({
+      queryStats: [
+        {
+          query: "looking for screen recorder",
+          postsFound: 1,
+          success: true,
+        },
+        {
+          query: "screen recorder mac",
+          postsFound: 2,
+          success: true,
+        },
+      ],
+      posts: [exactPost, uniquePost],
+      matchedQueriesByPostId: {
+        "post-1": ["looking for screen recorder", "screen recorder mac"],
+        "post-2": ["screen recorder mac"],
+      },
+    });
   });
 
   test("removes only a complete pair of exact phrase quotes", () => {

--- a/convex/lib/twitterProspectingSearchCore.ts
+++ b/convex/lib/twitterProspectingSearchCore.ts
@@ -8,10 +8,17 @@ export type TwitterProspectingQueryPlan = {
   searchMode: TwitterProspectingSearchMode;
 };
 
-type TwitterQueryStat = {
+export type TwitterQueryStat = {
   query: string;
   postsFound: number;
   success: boolean;
+  error?: string;
+};
+
+export type UnsavedTwitterSearchResult<TPost extends { id_str: string }> = {
+  queryStats: TwitterQueryStat[];
+  posts: TPost[];
+  matchedQueriesByPostId: Record<string, string[]>;
 };
 
 const EXACT_PHRASE_MIN_WORDS = 2;
@@ -77,6 +84,7 @@ export function resolveTwitterProspectingSearchMode(args: {
     words.length > EXACT_PHRASE_MAX_WORDS ||
     !lastWord ||
     TRAILING_CONNECTORS.has(lastWord) ||
+    query.includes('"') ||
     hasSearchOperatorSyntax(query)
   ) {
     return "raw";
@@ -95,13 +103,48 @@ export function partitionTwitterProspectingQueries(
     const query = normalizeQuery(plan.query);
     if (!query) continue;
     if (plan.searchMode === "exact") {
-      exact.push(query);
+      exact.push(stripTwitterExactPhraseQuotes(query));
     } else {
       raw.push(query);
     }
   }
 
   return { exact, raw };
+}
+
+export function mergeTwitterProspectingSearchResults<
+  TPost extends { id_str: string },
+>(
+  results: UnsavedTwitterSearchResult<TPost>[]
+): UnsavedTwitterSearchResult<TPost> {
+  const postsById = new Map<string, TPost>();
+  const matchedQueriesByPostId = new Map<string, Set<string>>();
+
+  for (const result of results) {
+    for (const post of result.posts) {
+      if (!postsById.has(post.id_str)) {
+        postsById.set(post.id_str, post);
+      }
+
+      const matchedQueries =
+        matchedQueriesByPostId.get(post.id_str) ?? new Set<string>();
+      for (const query of result.matchedQueriesByPostId[post.id_str] ?? []) {
+        matchedQueries.add(query);
+      }
+      matchedQueriesByPostId.set(post.id_str, matchedQueries);
+    }
+  }
+
+  return {
+    queryStats: results.flatMap((result) => result.queryStats),
+    posts: Array.from(postsById.values()),
+    matchedQueriesByPostId: Object.fromEntries(
+      Array.from(matchedQueriesByPostId.entries()).map(([postId, queries]) => [
+        postId,
+        Array.from(queries),
+      ])
+    ),
+  };
 }
 
 export function getTwitterExactFallbackQueries(stats: TwitterQueryStat[]) {

--- a/convex/lib/twitterProspectingSearchCore.ts
+++ b/convex/lib/twitterProspectingSearchCore.ts
@@ -1,0 +1,116 @@
+export const TWITTER_PROSPECTING_SEARCH_MODES = ["exact", "raw"] as const;
+
+export type TwitterProspectingSearchMode =
+  (typeof TWITTER_PROSPECTING_SEARCH_MODES)[number];
+
+export type TwitterProspectingQueryPlan = {
+  query: string;
+  searchMode: TwitterProspectingSearchMode;
+};
+
+type TwitterQueryStat = {
+  query: string;
+  postsFound: number;
+  success: boolean;
+};
+
+const EXACT_PHRASE_MIN_WORDS = 2;
+const EXACT_PHRASE_MAX_WORDS = 5;
+const TRAILING_CONNECTORS = new Set([
+  "a",
+  "an",
+  "and",
+  "at",
+  "for",
+  "from",
+  "in",
+  "my",
+  "of",
+  "on",
+  "or",
+  "the",
+  "to",
+  "with",
+  "your",
+]);
+
+function normalizeQuery(query: string) {
+  return query.replace(/\s+/g, " ").trim();
+}
+
+function hasSearchOperatorSyntax(query: string) {
+  return (
+    /[()]/.test(query) ||
+    /(^|\s)(?:AND|OR)(?=\s|$)/i.test(query) ||
+    /(^|\s)-?[a-z_]+:/i.test(query)
+  );
+}
+
+export function stripTwitterExactPhraseQuotes(query: string) {
+  const normalized = normalizeQuery(query);
+  if (
+    normalized.length >= 2 &&
+    normalized.startsWith('"') &&
+    normalized.endsWith('"')
+  ) {
+    return normalized.slice(1, -1).trim();
+  }
+  return normalized;
+}
+
+export function resolveTwitterProspectingSearchMode(args: {
+  query: string;
+  requestedMode?: TwitterProspectingSearchMode;
+}): TwitterProspectingSearchMode {
+  if (args.requestedMode !== "exact") {
+    return "raw";
+  }
+
+  const query = stripTwitterExactPhraseQuotes(args.query);
+  const words = query.split(/\s+/).filter(Boolean);
+  const lastWord = words[words.length - 1]
+    ?.replace(/[^a-z]/gi, "")
+    .toLowerCase();
+
+  if (
+    words.length < EXACT_PHRASE_MIN_WORDS ||
+    words.length > EXACT_PHRASE_MAX_WORDS ||
+    !lastWord ||
+    TRAILING_CONNECTORS.has(lastWord) ||
+    hasSearchOperatorSyntax(query)
+  ) {
+    return "raw";
+  }
+
+  return "exact";
+}
+
+export function partitionTwitterProspectingQueries(
+  plans: TwitterProspectingQueryPlan[]
+) {
+  const exact: string[] = [];
+  const raw: string[] = [];
+
+  for (const plan of plans) {
+    const query = normalizeQuery(plan.query);
+    if (!query) continue;
+    if (plan.searchMode === "exact") {
+      exact.push(query);
+    } else {
+      raw.push(query);
+    }
+  }
+
+  return { exact, raw };
+}
+
+export function getTwitterExactFallbackQueries(stats: TwitterQueryStat[]) {
+  return Array.from(
+    new Set(
+      stats
+        .filter((stat) => stat.success && stat.postsFound === 0)
+        .map((stat) => stripTwitterExactPhraseQuotes(stat.query))
+        .filter(Boolean)
+    )
+  );
+}

--- a/convex/lib/twitterSearchResultCore.test.ts
+++ b/convex/lib/twitterSearchResultCore.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "vitest";
+import { normalizeTwitterSearchCursor } from "./twitterSearchResultCore";
+
+describe("normalizeTwitterSearchCursor", () => {
+  test.each([null, undefined, "", "   "])(
+    "normalizes an absent provider cursor (%s) to undefined",
+    (cursor) => {
+      expect(normalizeTwitterSearchCursor(cursor)).toBeUndefined();
+    }
+  );
+
+  test("preserves a valid provider cursor", () => {
+    expect(normalizeTwitterSearchCursor(" cursor-token ")).toBe("cursor-token");
+  });
+});

--- a/convex/lib/twitterSearchResultCore.ts
+++ b/convex/lib/twitterSearchResultCore.ts
@@ -21,6 +21,15 @@ export type TwitterPost = Tweet & {
   user: TwitterUser;
 };
 
+export function normalizeTwitterSearchCursor(value: unknown) {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const cursor = value.trim();
+  return cursor || undefined;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -157,6 +157,7 @@ import {
   twitterReplyDiscoveryCandidateStatusValidator,
   twitterReplyDiscoveryScoreBreakdownValidator,
   socialQueryStyleValidator,
+  twitterProspectingSearchModeValidator,
   agentUsageSnapshotValidator,
   agentMessageAttachmentReferenceValidator,
   agentMessagePromptTextSourceValidator,
@@ -619,6 +620,7 @@ export default defineSchema({
     linkedinSurface: v.optional(linkedinSearchSurfaceValidator),
     linkedinSurfaceTargets: v.optional(v.array(linkedinSearchSurfaceValidator)),
     queryStyle: v.optional(socialQueryStyleValidator),
+    twitterSearchMode: v.optional(twitterProspectingSearchModeValidator),
 
     // =========================================================================
     // Platform-specific search tracking (for social_query type)
@@ -2366,6 +2368,7 @@ export default defineSchema({
     linkedinSurface: v.optional(linkedinSearchSurfaceValidator),
     linkedinSurfaceTargets: v.optional(v.array(linkedinSearchSurfaceValidator)),
     queryStyle: v.optional(socialQueryStyleValidator),
+    twitterSearchMode: v.optional(twitterProspectingSearchModeValidator),
     noveltyScore: v.optional(v.number()),
     status: queryCandidateStatusValidator,
     duplicateReason: v.optional(queryCandidateDuplicateReasonValidator),

--- a/convex/twitterProspectingSearch.integration.test.ts
+++ b/convex/twitterProspectingSearch.integration.test.ts
@@ -1,0 +1,73 @@
+/// <reference types="vite/client" />
+
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { internal } from "./_generated/api";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+
+async function seedWorkspace(t: ReturnType<typeof convexTest>) {
+  return await t.run(async (ctx) => {
+    const userId = await ctx.db.insert("users", {
+      workosUserId: "twitter-search-mode-user",
+      email: "twitter-search-mode@example.com",
+    });
+    const workspaceId = await ctx.db.insert("workspaces", {
+      userId,
+      name: "Twitter search mode",
+      description: "Twitter prospecting search mode tests",
+      isDefault: true,
+      updatedAt: 1,
+    });
+    return workspaceId;
+  });
+}
+
+describe("Twitter prospecting search mode", () => {
+  test("persists the LLM mode and safely defaults or demotes queries", async () => {
+    const t = convexTest(schema, modules);
+    const workspaceId = await seedWorkspace(t);
+
+    await t.mutation(internal.keywords.saveKeywordsBatch, {
+      workspaceId,
+      keywords: [
+        {
+          type: "social_query",
+          value: "looking for screen recorder",
+          source: "agent",
+          platformTargets: ["twitter"],
+          queryStyle: "natural_phrase",
+          twitterSearchMode: "exact",
+        },
+        {
+          type: "social_query",
+          value: "need an integrated screen recorder for",
+          source: "agent",
+          platformTargets: ["twitter"],
+          queryStyle: "natural_phrase",
+          twitterSearchMode: "exact",
+        },
+        {
+          type: "social_query",
+          value: "screen recording workflow",
+          source: "agent",
+          platformTargets: ["twitter"],
+          queryStyle: "natural_phrase",
+        },
+      ],
+    });
+
+    const queue = await t.query(
+      internal.keywords.getPrioritizedTwitterQueries,
+      { workspaceId, limit: 10 }
+    );
+    const modes = new Map(
+      queue.map((item) => [item.value, item.searchMode] as const)
+    );
+
+    expect(modes.get("looking for screen recorder")).toBe("exact");
+    expect(modes.get("need an integrated screen recorder for")).toBe("raw");
+    expect(modes.get("screen recording workflow")).toBe("raw");
+  });
+});

--- a/convex/validators.ts
+++ b/convex/validators.ts
@@ -2288,6 +2288,11 @@ export const socialQueryStyleValidator = v.union(
   v.literal("role_title")
 );
 
+export const twitterProspectingSearchModeValidator = v.union(
+  v.literal("exact"),
+  v.literal("raw")
+);
+
 // User timeline mode (used in socialapi.ts)
 export const userTimelineModeValidator = v.union(
   v.literal("posts"),

--- a/convex/workflows/prospecting.ts
+++ b/convex/workflows/prospecting.ts
@@ -49,12 +49,13 @@ import {
 import { logger } from "../../shared/lib/logger";
 import { getCurrentUTCTimestamp } from "../../shared/lib/utils/time/timeUtils";
 import { isWorkspaceInactive } from "../lib/workspaceSystem";
-import { getTwitterPostId } from "../../shared/lib/twitter/contracts";
 import { getSystemRuntimeConfig } from "../lib/runtimeConfigHelpers";
 import {
   getTwitterExactFallbackQueries,
+  mergeTwitterProspectingSearchResults,
   partitionTwitterProspectingQueries,
   stripTwitterExactPhraseQuotes,
+  type TwitterQueryStat,
   type TwitterProspectingSearchMode,
 } from "../lib/twitterProspectingSearchCore";
 
@@ -80,18 +81,16 @@ type TwitterQueueItem = {
   searchMode: TwitterProspectingSearchMode;
 };
 
-type TwitterQueryStat = {
-  query: string;
-  postsFound: number;
-  success: boolean;
-  error?: string;
-};
-
 type TwitterSearchResult = {
   saved: number;
   queryStats: TwitterQueryStat[];
   posts: TwitterPost[];
   matchedQueriesByPostId: Record<string, string[]>;
+  exactFallbackQueries: string[];
+  primaryQueryStats: TwitterQueryStat[];
+  graphSeedQueryStats: TwitterQueryStat[];
+  primaryPostsFound: number;
+  graphSeedPostsFound: number;
 };
 
 const PREVIEW_GRAPH_SEED_LOOKBACK_MS = 2 * 365 * 24 * 60 * 60 * 1000;
@@ -119,6 +118,11 @@ function createEmptyTwitterSearchResult(): TwitterSearchResult {
     queryStats: [],
     posts: [],
     matchedQueriesByPostId: {},
+    exactFallbackQueries: [],
+    primaryQueryStats: [],
+    graphSeedQueryStats: [],
+    primaryPostsFound: 0,
+    graphSeedPostsFound: 0,
   };
 }
 
@@ -126,38 +130,6 @@ function getPreviewGraphSeedSinceTimestampSeconds() {
   return Math.floor(
     (getCurrentUTCTimestamp() - PREVIEW_GRAPH_SEED_LOOKBACK_MS) / 1000
   );
-}
-
-function mergeTwitterSearchResults(
-  results: TwitterSearchResult[]
-): TwitterSearchResult {
-  const postsById = new Map<string, TwitterPost>();
-  const matchedQueriesByPostId: Record<string, string[]> = {};
-
-  for (const result of results) {
-    for (const post of result.posts) {
-      const postId = getTwitterPostId(post);
-      if (!postId) {
-        continue;
-      }
-
-      if (!postsById.has(postId)) {
-        postsById.set(postId, post);
-      }
-
-      matchedQueriesByPostId[postId] = dedupeQueries([
-        ...(matchedQueriesByPostId[postId] ?? []),
-        ...(result.matchedQueriesByPostId[postId] ?? []),
-      ]);
-    }
-  }
-
-  return {
-    saved: results.reduce((total, result) => total + result.saved, 0),
-    queryStats: results.flatMap((result) => result.queryStats),
-    posts: Array.from(postsById.values()),
-    matchedQueriesByPostId,
-  };
 }
 
 function normalizeTwitterSearchResultQueries(
@@ -478,40 +450,15 @@ export const prospectingWorkflow = workflow.define({
                 searchMode: query.searchMode,
               }))
             );
-            const runTwitterSearch = async (
-              queries: string[],
-              searchMode: TwitterProspectingSearchMode
-            ) => {
-              if (queries.length === 0) {
-                return createEmptyTwitterSearchResult();
-              }
-
-              return await step.runAction(
-                internal.workflows.prospecting.searchTwitterInternal,
-                {
-                  workspaceId: args.workspaceId,
-                  queries,
-                  searchMode,
-                },
-                { retry: runtimeConfig.retries.provider }
-              );
-            };
-            const [exactResult, rawResult] = await Promise.all([
-              runTwitterSearch(partitionedQueries.exact, "exact"),
-              runTwitterSearch(partitionedQueries.raw, "raw"),
-            ]);
-            const exactFallbackQueries = getTwitterExactFallbackQueries(
-              exactResult.queryStats
+            const result = await step.runAction(
+              internal.workflows.prospecting.searchTwitterInternal,
+              {
+                workspaceId: args.workspaceId,
+                exactQueries: partitionedQueries.exact,
+                rawQueries: partitionedQueries.raw,
+              },
+              { retry: runtimeConfig.retries.provider }
             );
-            const exactFallbackResult = await runTwitterSearch(
-              exactFallbackQueries,
-              "raw"
-            );
-            const result = mergeTwitterSearchResults([
-              exactResult,
-              rawResult,
-              exactFallbackResult,
-            ]);
 
             // Mark queries as searched
             await step.runMutation(internal.keywords.markQueriesAsSearched, {
@@ -963,12 +910,14 @@ export const saveKeywordsInternal = internalMutation({
 // ============================================================================
 
 /**
- * Search Twitter and save prospects
+ * Search Twitter, deduplicate all search paths, and save prospects.
  */
 export const searchTwitterInternal = internalAction({
   args: {
     workspaceId: v.id("workspaces"),
-    queries: v.array(v.string()),
+    exactQueries: v.array(v.string()),
+    rawQueries: v.array(v.string()),
+    graphSeedQueries: v.optional(v.array(v.string())),
     processingMode: v.optional(
       v.union(v.literal("normal"), v.literal("preview"))
     ),
@@ -981,7 +930,6 @@ export const searchTwitterInternal = internalAction({
     ),
     setupSessionId: v.optional(v.id("workspaceSetupSessions")),
     setupRevision: v.optional(v.number()),
-    searchMode: v.optional(twitterProspectingSearchModeValidator),
   },
   handler: async (ctx, args): Promise<TwitterSearchResult> => {
     // Get workspace for userId
@@ -993,84 +941,140 @@ export const searchTwitterInternal = internalAction({
       throw new Error("Workspace not found");
     }
 
-    const searchMode: TwitterProspectingSearchMode = args.searchMode ?? "exact";
-    const providerResult =
-      searchMode === "raw"
-        ? await ctx.runAction(
-            api.integrations.twitter.searchPosts.searchRawBatch,
-            {
-              queries: args.queries,
-              type: "Latest",
-              maxQueriesPerBatch: 10,
-            }
-          )
-        : await ctx.runAction(
-            api.integrations.twitter.searchPosts.searchBatch,
-            {
-              queries: args.queries,
-              type: "Latest",
-              maxQueriesPerBatch: 10,
-            }
-          );
-    const result = normalizeTwitterSearchResultQueries(
-      {
-        saved: 0,
-        queryStats: providerResult.queryStats ?? [],
-        posts: providerResult.posts ?? [],
-        matchedQueriesByPostId: providerResult.matchedQueriesByPostId ?? {},
-      },
-      searchMode
-    );
+    const runProviderSearch = async (
+      queries: string[],
+      searchMode: TwitterProspectingSearchMode
+    ): Promise<TwitterSearchResult> => {
+      if (queries.length === 0) {
+        return createEmptyTwitterSearchResult();
+      }
 
-    if (!providerResult.success || result.posts.length === 0) {
-      return {
-        saved: 0,
-        queryStats: result.queryStats,
-        posts: [],
-        matchedQueriesByPostId: {},
-      };
+      const providerResult =
+        searchMode === "raw"
+          ? await ctx.runAction(
+              api.integrations.twitter.searchPosts.searchRawBatch,
+              {
+                queries,
+                type: "Latest",
+                maxQueriesPerBatch: 10,
+              }
+            )
+          : await ctx.runAction(
+              api.integrations.twitter.searchPosts.searchBatch,
+              {
+                queries,
+                type: "Latest",
+                maxQueriesPerBatch: 10,
+              }
+            );
+      const result = normalizeTwitterSearchResultQueries(
+        {
+          ...createEmptyTwitterSearchResult(),
+          queryStats: providerResult.queryStats ?? [],
+          posts: providerResult.posts ?? [],
+          matchedQueriesByPostId: providerResult.matchedQueriesByPostId ?? {},
+        },
+        searchMode
+      );
+
+      if (!providerResult.success) {
+        return {
+          ...result,
+          posts: [],
+          matchedQueriesByPostId: {},
+        };
+      }
+
+      return result;
+    };
+
+    const [exactResult, rawResult, graphSeedResult] = await Promise.all([
+      runProviderSearch(args.exactQueries, "exact"),
+      runProviderSearch(args.rawQueries, "raw"),
+      runProviderSearch(args.graphSeedQueries ?? [], "raw"),
+    ]);
+    const exactFallbackQueries = getTwitterExactFallbackQueries(
+      exactResult.queryStats
+    );
+    const exactFallbackResult = await runProviderSearch(
+      exactFallbackQueries,
+      "raw"
+    );
+    const primaryResult = mergeTwitterProspectingSearchResults([
+      exactResult,
+      rawResult,
+      exactFallbackResult,
+    ]);
+    const mergedResult = mergeTwitterProspectingSearchResults([
+      primaryResult,
+      graphSeedResult,
+    ]);
+    const result: TwitterSearchResult = {
+      ...mergedResult,
+      saved: 0,
+      exactFallbackQueries,
+      primaryQueryStats: primaryResult.queryStats,
+      graphSeedQueryStats: graphSeedResult.queryStats,
+      primaryPostsFound: primaryResult.posts.length,
+      graphSeedPostsFound: graphSeedResult.posts.length,
+    };
+
+    if (result.posts.length === 0) {
+      return result;
     }
 
     // Transform and save prospects
+    const fallbackQueries = dedupeQueries([
+      ...args.exactQueries.map(stripTwitterExactPhraseQuotes),
+      ...args.rawQueries,
+      ...(args.graphSeedQueries ?? []),
+    ]).slice(0, 5);
     const prospectsToSave = result.posts.map((post: TwitterPost) => ({
       platform: "twitter" as const,
       externalId: post.id_str,
       data: post,
       matchedKeywords:
         result.matchedQueriesByPostId[post.id_str]?.slice(0, 5) ??
-        args.queries.slice(0, 5),
+        fallbackQueries,
       discoverySource: "search_post" as const,
       discoveryContext: {
         matchedQueries:
           result.matchedQueriesByPostId[post.id_str]?.slice(0, 5) ??
-          args.queries.slice(0, 5),
+          fallbackQueries,
         matchedReason: "Matched on X post",
         discoverySnippet: getTwitterPostText(post).slice(0, 240),
       },
     }));
 
-    const saveResult = await ctx.runMutation(
-      internal.prospects.createProspectsBatch,
-      {
-        userId: workspace.userId,
-        workspaceId: args.workspaceId,
-        processingMode: args.processingMode,
-        prospects: prospectsToSave.map(
-          (prospect: (typeof prospectsToSave)[number]) => ({
-            ...prospect,
-            origin: args.prospectOrigin,
-            setupSessionId: args.setupSessionId,
-            setupRevision: args.setupRevision,
-          })
-        ),
-      }
-    );
+    let saved = 0;
+    const saveBatchSize = PREVIEW_BATCH_LIMITS.previewProspectWriteBatch;
+    for (
+      let index = 0;
+      index < prospectsToSave.length;
+      index += saveBatchSize
+    ) {
+      const saveResult = await ctx.runMutation(
+        internal.prospects.createProspectsBatch,
+        {
+          userId: workspace.userId,
+          workspaceId: args.workspaceId,
+          processingMode: args.processingMode,
+          prospects: prospectsToSave
+            .slice(index, index + saveBatchSize)
+            .map((prospect: (typeof prospectsToSave)[number]) => ({
+              ...prospect,
+              origin: args.prospectOrigin,
+              setupSessionId: args.setupSessionId,
+              setupRevision: args.setupRevision,
+            })),
+        }
+      );
+      saved += saveResult.created + saveResult.updated;
+    }
 
     return {
-      saved: saveResult.created + saveResult.updated,
-      queryStats: result.queryStats,
-      posts: result.posts,
-      matchedQueriesByPostId: result.matchedQueriesByPostId,
+      ...result,
+      saved,
     };
   },
 });
@@ -1740,73 +1744,29 @@ export const runPreviewDiscoveryBurstInternal = internalAction({
       .filter((query) => !twitterQueryKeys.has(query.toLowerCase()))
       .slice(0, PREVIEW_BATCH_LIMITS.twitterGraphSeedSearchBatch);
 
-    const runPreviewTwitterSearch = async (
-      queries: string[],
-      label: string,
-      searchMode: TwitterProspectingSearchMode
-    ): Promise<TwitterSearchResult> => {
-      if (queries.length === 0) {
+    const twitterResult = await ctx
+      .runAction(internal.workflows.prospecting.searchTwitterInternal, {
+        workspaceId: args.workspaceId,
+        exactQueries: partitionedTwitterQueries.exact,
+        rawQueries: partitionedTwitterQueries.raw,
+        graphSeedQueries: twitterGraphSeedQueries,
+        processingMode: "preview",
+        prospectOrigin: "setup_preview",
+        setupSessionId: args.sessionId,
+        setupRevision: args.previewRevision,
+      })
+      .catch((error) => {
+        prospectingWorkflowLogger.error(
+          "Preview Twitter search failed",
+          {
+            workspaceId: args.workspaceId,
+            workspaceName: workspace.name,
+            previewRevision: args.previewRevision,
+          },
+          error
+        );
         return createEmptyTwitterSearchResult();
-      }
-
-      return await ctx
-        .runAction(internal.workflows.prospecting.searchTwitterInternal, {
-          workspaceId: args.workspaceId,
-          queries,
-          processingMode: "preview",
-          prospectOrigin: "setup_preview",
-          setupSessionId: args.sessionId,
-          setupRevision: args.previewRevision,
-          searchMode,
-        })
-        .catch((error) => {
-          prospectingWorkflowLogger.error(
-            "Preview Twitter search failed",
-            {
-              workspaceId: String(args.workspaceId),
-              workspaceName: workspace.name,
-              previewRevision: args.previewRevision,
-              label,
-              searchMode,
-            },
-            error
-          );
-          return createEmptyTwitterSearchResult();
-        });
-    };
-
-    const [exactTwitterResult, rawTwitterResult, graphSeedTwitterResult] =
-      await Promise.all([
-        runPreviewTwitterSearch(
-          partitionedTwitterQueries.exact,
-          "Twitter exact search",
-          "exact"
-        ),
-        runPreviewTwitterSearch(
-          partitionedTwitterQueries.raw,
-          "Twitter raw search",
-          "raw"
-        ),
-        runPreviewTwitterSearch(
-          twitterGraphSeedQueries,
-          "Twitter graph seed search",
-          "raw"
-        ),
-      ]);
-    const exactFallbackTwitterResult = await runPreviewTwitterSearch(
-      getTwitterExactFallbackQueries(exactTwitterResult.queryStats),
-      "Twitter exact fallback search",
-      "raw"
-    );
-    const primaryTwitterResult = mergeTwitterSearchResults([
-      exactTwitterResult,
-      rawTwitterResult,
-      exactFallbackTwitterResult,
-    ]);
-    const twitterResult = mergeTwitterSearchResults([
-      primaryTwitterResult,
-      graphSeedTwitterResult,
-    ]);
+      });
 
     const similarExpansion =
       twitterResult.posts.length > 0
@@ -1863,19 +1823,15 @@ export const runPreviewDiscoveryBurstInternal = internalAction({
               : partitionedTwitterQueries.exact.length > 0
                 ? "exact"
                 : "raw",
-          twitterExactFallbackQueries: getTwitterExactFallbackQueries(
-            exactTwitterResult.queryStats
-          ),
+          twitterExactFallbackQueries: twitterResult.exactFallbackQueries,
           twitterGraphSeedSearchMode: "raw",
           twitterQueryStats: twitterResult.queryStats,
-          twitterPrimaryQueryStats: primaryTwitterResult.queryStats,
-          twitterGraphSeedQueryStats: graphSeedTwitterResult.queryStats,
-          twitterPrimaryPostsFound: primaryTwitterResult.posts.length,
-          twitterGraphSeedPostsFound: graphSeedTwitterResult.posts.length,
+          twitterPrimaryQueryStats: twitterResult.primaryQueryStats,
+          twitterGraphSeedQueryStats: twitterResult.graphSeedQueryStats,
+          twitterPrimaryPostsFound: twitterResult.primaryPostsFound,
+          twitterGraphSeedPostsFound: twitterResult.graphSeedPostsFound,
           twitterPostsFound: twitterResult.posts.length,
           twitterSaved: twitterResult.saved,
-          twitterPrimarySaved: primaryTwitterResult.saved,
-          twitterGraphSeedSaved: graphSeedTwitterResult.saved,
           similarProfilesSaved: similarExpansion.saved,
           similarProfileStats: similarExpansion.similarStats,
           similarProfileEvidenceStats: similarExpansion.evidenceStats,

--- a/convex/workflows/prospecting.ts
+++ b/convex/workflows/prospecting.ts
@@ -43,6 +43,7 @@ import {
   prospectingBootstrapCompletionReasonValidator,
   prospectingCycleStatusValidator,
   prospectingWorkflowPauseReasonValidator,
+  twitterProspectingSearchModeValidator,
   workspaceWorkflowStatusValidator,
 } from "../validators";
 import { logger } from "../../shared/lib/logger";
@@ -50,6 +51,12 @@ import { getCurrentUTCTimestamp } from "../../shared/lib/utils/time/timeUtils";
 import { isWorkspaceInactive } from "../lib/workspaceSystem";
 import { getTwitterPostId } from "../../shared/lib/twitter/contracts";
 import { getSystemRuntimeConfig } from "../lib/runtimeConfigHelpers";
+import {
+  getTwitterExactFallbackQueries,
+  partitionTwitterProspectingQueries,
+  stripTwitterExactPhraseQuotes,
+  type TwitterProspectingSearchMode,
+} from "../lib/twitterProspectingSearchCore";
 
 type QueryMetadataRecord = {
   query: string;
@@ -58,12 +65,19 @@ type QueryMetadataRecord = {
   linkedinSurface?: "posts" | "people";
   linkedinSurfaceTargets?: Array<"posts" | "people">;
   queryStyle: "natural_phrase" | "professional_keyword" | "role_title";
+  twitterSearchMode?: TwitterProspectingSearchMode;
   legacyCompatibilitySource: boolean;
 };
 
 type LinkedInQueueItem = {
   id: Id<"keywords">;
   value: string;
+};
+
+type TwitterQueueItem = {
+  id: Id<"keywords">;
+  value: string;
+  searchMode: TwitterProspectingSearchMode;
 };
 
 type TwitterQueryStat = {
@@ -79,8 +93,6 @@ type TwitterSearchResult = {
   posts: TwitterPost[];
   matchedQueriesByPostId: Record<string, string[]>;
 };
-
-type TwitterSearchMode = "exact" | "raw";
 
 const PREVIEW_GRAPH_SEED_LOOKBACK_MS = 2 * 365 * 24 * 60 * 60 * 1000;
 const prospectingWorkflowLogger = logger.withScope("ProspectingWorkflow");
@@ -145,6 +157,29 @@ function mergeTwitterSearchResults(
     queryStats: results.flatMap((result) => result.queryStats),
     posts: Array.from(postsById.values()),
     matchedQueriesByPostId,
+  };
+}
+
+function normalizeTwitterSearchResultQueries(
+  result: TwitterSearchResult,
+  searchMode: TwitterProspectingSearchMode
+): TwitterSearchResult {
+  if (searchMode !== "exact") {
+    return result;
+  }
+
+  return {
+    ...result,
+    queryStats: result.queryStats.map((stat) => ({
+      ...stat,
+      query: stripTwitterExactPhraseQuotes(stat.query),
+    })),
+    matchedQueriesByPostId: Object.fromEntries(
+      Object.entries(result.matchedQueriesByPostId).map(([postId, queries]) => [
+        postId,
+        dedupeQueries(queries.map(stripTwitterExactPhraseQuotes)),
+      ])
+    ),
   };
 }
 
@@ -430,18 +465,57 @@ export const prospectingWorkflow = workflow.define({
           );
 
           if (twitterQueue.length > 0) {
-            const result = await step.runAction(
-              internal.workflows.prospecting.searchTwitterInternal,
-              {
-                workspaceId: args.workspaceId,
-                queries: twitterQueue.map((query: any) => query.value),
-              },
-              { retry: runtimeConfig.retries.provider }
+            const typedTwitterQueue: TwitterQueueItem[] = twitterQueue.map(
+              (query) => ({
+                id: query.id,
+                value: query.value,
+                searchMode: query.searchMode ?? "raw",
+              })
             );
+            const partitionedQueries = partitionTwitterProspectingQueries(
+              typedTwitterQueue.map((query) => ({
+                query: query.value,
+                searchMode: query.searchMode,
+              }))
+            );
+            const runTwitterSearch = async (
+              queries: string[],
+              searchMode: TwitterProspectingSearchMode
+            ) => {
+              if (queries.length === 0) {
+                return createEmptyTwitterSearchResult();
+              }
+
+              return await step.runAction(
+                internal.workflows.prospecting.searchTwitterInternal,
+                {
+                  workspaceId: args.workspaceId,
+                  queries,
+                  searchMode,
+                },
+                { retry: runtimeConfig.retries.provider }
+              );
+            };
+            const [exactResult, rawResult] = await Promise.all([
+              runTwitterSearch(partitionedQueries.exact, "exact"),
+              runTwitterSearch(partitionedQueries.raw, "raw"),
+            ]);
+            const exactFallbackQueries = getTwitterExactFallbackQueries(
+              exactResult.queryStats
+            );
+            const exactFallbackResult = await runTwitterSearch(
+              exactFallbackQueries,
+              "raw"
+            );
+            const result = mergeTwitterSearchResults([
+              exactResult,
+              rawResult,
+              exactFallbackResult,
+            ]);
 
             // Mark queries as searched
             await step.runMutation(internal.keywords.markQueriesAsSearched, {
-              queryIds: twitterQueue.map((query: any) => query.id),
+              queryIds: typedTwitterQueue.map((query) => query.id),
               platform: "twitter",
               resultsCount: result.saved,
               queryStats: result.queryStats,
@@ -833,6 +907,7 @@ export const saveKeywordsInternal = internalMutation({
             v.literal("professional_keyword"),
             v.literal("role_title")
           ),
+          twitterSearchMode: v.optional(twitterProspectingSearchModeValidator),
           legacyCompatibilitySource: v.boolean(),
         })
       )
@@ -847,6 +922,7 @@ export const saveKeywordsInternal = internalMutation({
       linkedinSurface?: "posts" | "people";
       linkedinSurfaceTargets?: Array<"posts" | "people">;
       queryStyle?: "natural_phrase" | "professional_keyword" | "role_title";
+      twitterSearchMode?: TwitterProspectingSearchMode;
     }> = [];
     const metadataByQuery = new Map(
       (args.queryMetadata ?? []).map((item) => [item.query, item])
@@ -870,6 +946,7 @@ export const saveKeywordsInternal = internalMutation({
         linkedinSurface: metadata?.linkedinSurface,
         linkedinSurfaceTargets: metadata?.linkedinSurfaceTargets,
         queryStyle: metadata?.queryStyle,
+        twitterSearchMode: metadata?.twitterSearchMode,
       });
     }
 
@@ -904,7 +981,7 @@ export const searchTwitterInternal = internalAction({
     ),
     setupSessionId: v.optional(v.id("workspaceSetupSessions")),
     setupRevision: v.optional(v.number()),
-    searchMode: v.optional(v.union(v.literal("exact"), v.literal("raw"))),
+    searchMode: v.optional(twitterProspectingSearchModeValidator),
   },
   handler: async (ctx, args): Promise<TwitterSearchResult> => {
     // Get workspace for userId
@@ -916,8 +993,8 @@ export const searchTwitterInternal = internalAction({
       throw new Error("Workspace not found");
     }
 
-    const searchMode: TwitterSearchMode = args.searchMode ?? "exact";
-    const result =
+    const searchMode: TwitterProspectingSearchMode = args.searchMode ?? "exact";
+    const providerResult =
       searchMode === "raw"
         ? await ctx.runAction(
             api.integrations.twitter.searchPosts.searchRawBatch,
@@ -935,11 +1012,20 @@ export const searchTwitterInternal = internalAction({
               maxQueriesPerBatch: 10,
             }
           );
+    const result = normalizeTwitterSearchResultQueries(
+      {
+        saved: 0,
+        queryStats: providerResult.queryStats ?? [],
+        posts: providerResult.posts ?? [],
+        matchedQueriesByPostId: providerResult.matchedQueriesByPostId ?? {},
+      },
+      searchMode
+    );
 
-    if (!result.success || !result.posts?.length) {
+    if (!providerResult.success || result.posts.length === 0) {
       return {
         saved: 0,
-        queryStats: result.queryStats ?? [],
+        queryStats: result.queryStats,
         posts: [],
         matchedQueriesByPostId: {},
       };
@@ -1585,7 +1671,7 @@ export const runPreviewDiscoveryBurstInternal = internalAction({
       0,
       BATCH_LIMITS.socialQueriesPerCycle
     );
-    const queryMetadata =
+    const queryMetadata: QueryMetadataRecord[] =
       socialQueriesResult.queryMetadata?.filter((item: QueryMetadataRecord) =>
         socialQueries.includes(item.query)
       ) ??
@@ -1630,6 +1716,18 @@ export const runPreviewDiscoveryBurstInternal = internalAction({
         )
         .map((item: QueryMetadataRecord) => item.query),
     ]).slice(0, PREVIEW_BATCH_LIMITS.twitterSearchBatch);
+    const twitterSearchModeByQuery = new Map(
+      fallbackMetadata.map((item) => [
+        item.query.toLowerCase(),
+        item.twitterSearchMode ?? ("raw" as const),
+      ])
+    );
+    const partitionedTwitterQueries = partitionTwitterProspectingQueries(
+      twitterQueries.map((query) => ({
+        query,
+        searchMode: twitterSearchModeByQuery.get(query.toLowerCase()) ?? "raw",
+      }))
+    );
     const twitterQueryKeys = new Set(
       twitterQueries.map((query) => query.toLowerCase())
     );
@@ -1645,7 +1743,7 @@ export const runPreviewDiscoveryBurstInternal = internalAction({
     const runPreviewTwitterSearch = async (
       queries: string[],
       label: string,
-      searchMode: TwitterSearchMode = "exact"
+      searchMode: TwitterProspectingSearchMode
     ): Promise<TwitterSearchResult> => {
       if (queries.length === 0) {
         return createEmptyTwitterSearchResult();
@@ -1677,13 +1775,33 @@ export const runPreviewDiscoveryBurstInternal = internalAction({
         });
     };
 
-    const [primaryTwitterResult, graphSeedTwitterResult] = await Promise.all([
-      runPreviewTwitterSearch(twitterQueries, "Twitter search"),
-      runPreviewTwitterSearch(
-        twitterGraphSeedQueries,
-        "Twitter graph seed search",
-        "raw"
-      ),
+    const [exactTwitterResult, rawTwitterResult, graphSeedTwitterResult] =
+      await Promise.all([
+        runPreviewTwitterSearch(
+          partitionedTwitterQueries.exact,
+          "Twitter exact search",
+          "exact"
+        ),
+        runPreviewTwitterSearch(
+          partitionedTwitterQueries.raw,
+          "Twitter raw search",
+          "raw"
+        ),
+        runPreviewTwitterSearch(
+          twitterGraphSeedQueries,
+          "Twitter graph seed search",
+          "raw"
+        ),
+      ]);
+    const exactFallbackTwitterResult = await runPreviewTwitterSearch(
+      getTwitterExactFallbackQueries(exactTwitterResult.queryStats),
+      "Twitter exact fallback search",
+      "raw"
+    );
+    const primaryTwitterResult = mergeTwitterSearchResults([
+      exactTwitterResult,
+      rawTwitterResult,
+      exactFallbackTwitterResult,
     ]);
     const twitterResult = mergeTwitterSearchResults([
       primaryTwitterResult,
@@ -1738,7 +1856,16 @@ export const runPreviewDiscoveryBurstInternal = internalAction({
           acceptedQueries: acceptedQueries.length,
           twitterQueries,
           twitterGraphSeedQueries,
-          twitterPrimarySearchMode: "exact",
+          twitterPrimarySearchMode:
+            partitionedTwitterQueries.exact.length > 0 &&
+            partitionedTwitterQueries.raw.length > 0
+              ? "mixed"
+              : partitionedTwitterQueries.exact.length > 0
+                ? "exact"
+                : "raw",
+          twitterExactFallbackQueries: getTwitterExactFallbackQueries(
+            exactTwitterResult.queryStats
+          ),
           twitterGraphSeedSearchMode: "raw",
           twitterQueryStats: twitterResult.queryStats,
           twitterPrimaryQueryStats: primaryTwitterResult.queryStats,


### PR DESCRIPTION
## Summary

- let query generation classify Twitter queries as exact or raw while preserving the existing LinkedIn query contract
- validate exact-phrase eligibility and retry zero-result exact searches as raw queries
- persist Twitter search mode with query metadata for normal and setup-preview discovery
- normalize malformed SocialAPI cursors so provider response types cannot fail Convex validation
- add unit and Convex integration coverage for classification, fallback, persistence, and cursor handling

## Scope

This PR contains only the isolated Twitter prospecting changes. It does not include the separate LinkedIn searchMode validator or oversized LinkedIn payload fixes.

## Merge

Do not merge until approved by Salman.