### PR TITLE
fix(discovery): preserve cross-type search queries

### DIFF
--- a/convex/keywords.ts
+++ b/convex/keywords.ts
@@ -638,16 +638,21 @@ export const saveKeywordInternal = internalMutation({
       value: args.value,
     });
 
-    // Check for existing keyword with same value in workspace
+    // Keyword types have different behavior: seed/discovered terms inform query
+    // generation, while social_query rows are executable. Preserve both when
+    // their normalized text is identical.
     const existing = await ctx.db
       .query("keywords")
-      .withIndex("by_workspace_value", (q) =>
-        q.eq("workspaceId", args.workspaceId).eq("value", normalized)
+      .withIndex("by_workspace_type_and_value", (q) =>
+        q
+          .eq("workspaceId", args.workspaceId)
+          .eq("type", args.type)
+          .eq("value", normalized)
       )
       .first();
 
     if (existing) {
-      // Update existing keyword if it's the same type, otherwise skip
+      // The compound index guarantees this, but keep the guard defensive.
       if (existing.type === args.type) {
         await ctx.db.patch(existing._id, {
           canonicalValue: canonical.canonicalValue,
@@ -803,7 +808,11 @@ export const saveKeywordsBatch = internalMutation({
 
     const existingMap = new Map<string, (typeof existingKeywords)[0]>();
     for (const kw of existingKeywords) {
-      existingMap.set(kw.value, kw);
+      const canonical = buildKeywordCanonicalRecord({
+        type: kw.type,
+        value: kw.value,
+      });
+      existingMap.set(canonical.canonicalKey, kw);
     }
 
     for (const keyword of args.keywords) {
@@ -812,10 +821,9 @@ export const saveKeywordsBatch = internalMutation({
         type: keyword.type,
         value: keyword.value,
       });
-      const existing = existingMap.get(normalized);
+      const existing = existingMap.get(canonical.canonicalKey);
 
       if (existing) {
-        // Update if same type, otherwise skip
         if (existing.type === keyword.type) {
           await ctx.db.patch(existing._id, {
             canonicalValue: canonical.canonicalValue,
@@ -925,7 +933,7 @@ export const saveKeywordsBatch = internalMutation({
           twitterSearchMode: keyword.twitterSearchMode,
         });
         // Add to map to prevent duplicates within batch
-        existingMap.set(normalized, {
+        existingMap.set(canonical.canonicalKey, {
           _id: newId,
           _creationTime: now,
           workspaceId: args.workspaceId,
@@ -968,12 +976,15 @@ export const updateKeywordMonitorId = internalMutation({
 
     const keyword = await ctx.db
       .query("keywords")
-      .withIndex("by_workspace_value", (q) =>
-        q.eq("workspaceId", args.workspaceId).eq("value", normalized)
+      .withIndex("by_workspace_type_and_value", (q) =>
+        q
+          .eq("workspaceId", args.workspaceId)
+          .eq("type", "social_query")
+          .eq("value", normalized)
       )
       .first();
 
-    if (keyword && keyword.type === "social_query") {
+    if (keyword) {
       await ctx.db.patch(keyword._id, { monitorId: args.monitorId });
       return { success: true };
     }

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -643,6 +643,7 @@ export default defineSchema({
     .index("by_workspace", ["workspaceId"])
     .index("by_workspace_type", ["workspaceId", "type"])
     .index("by_workspace_value", ["workspaceId", "value"])
+    .index("by_workspace_type_and_value", ["workspaceId", "type", "value"])
     .index("by_workspace_canonical_hash", ["workspaceId", "canonicalHash"])
     .index("by_workspace_canonical_key", ["workspaceId", "canonicalKey"])
     .index("by_workspace_type_status", ["workspaceId", "type", "status"])

--- a/convex/socialapiMonitors.ts
+++ b/convex/socialapiMonitors.ts
@@ -157,9 +157,10 @@ export const saveMonitor = internalMutation({
     if (existing) {
       const keyword = await ctx.db
         .query("keywords")
-        .withIndex("by_workspace_value", (q) =>
+        .withIndex("by_workspace_type_and_value", (q) =>
           q
             .eq("workspaceId", args.workspaceId)
+            .eq("type", "social_query")
             .eq("value", normalizeMemoryText(args.query))
         )
         .first();
@@ -182,9 +183,10 @@ export const saveMonitor = internalMutation({
 
     const keyword = await ctx.db
       .query("keywords")
-      .withIndex("by_workspace_value", (q) =>
+      .withIndex("by_workspace_type_and_value", (q) =>
         q
           .eq("workspaceId", args.workspaceId)
+          .eq("type", "social_query")
           .eq("value", normalizeMemoryText(args.query))
       )
       .first();

--- a/convex/twitterProspectingSearch.integration.test.ts
+++ b/convex/twitterProspectingSearch.integration.test.ts
@@ -20,14 +20,170 @@ async function seedWorkspace(t: ReturnType<typeof convexTest>) {
       isDefault: true,
       updatedAt: 1,
     });
-    return workspaceId;
+    return { userId, workspaceId };
   });
 }
 
 describe("Twitter prospecting search mode", () => {
+  test("the workflow save bridge keeps fallback queries that match their seeds", async () => {
+    const t = convexTest(schema, modules);
+    const { workspaceId } = await seedWorkspace(t);
+
+    await t.mutation(internal.workflows.prospecting.saveKeywordsInternal, {
+      workspaceId,
+      seedKeywords: ["screen recording workflow"],
+      discoveredKeywords: [],
+      socialQueries: ["screen recording workflow"],
+    });
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db
+        .query("keywords")
+        .withIndex("by_workspace_value", (q) =>
+          q
+            .eq("workspaceId", workspaceId)
+            .eq("value", "screen recording workflow")
+        )
+        .collect()
+    );
+    expect(rows.map((row) => row.type).sort()).toEqual([
+      "seed",
+      "social_query",
+    ]);
+
+    const queue = await t.query(
+      internal.keywords.getPrioritizedTwitterQueries,
+      { workspaceId, limit: 10 }
+    );
+    expect(queue.map((item) => item.value)).toEqual([
+      "screen recording workflow",
+    ]);
+  });
+
+  test("preserves an executable query when its text matches a seed keyword", async () => {
+    const t = convexTest(schema, modules);
+    const { userId, workspaceId } = await seedWorkspace(t);
+
+    const saved = await t.mutation(internal.keywords.saveKeywordsBatch, {
+      workspaceId,
+      keywords: [
+        {
+          type: "seed",
+          value: "screen recording workflow",
+          source: "agent",
+        },
+        {
+          type: "social_query",
+          value: "  Screen   Recording Workflow  ",
+          source: "agent",
+          platformTargets: ["twitter"],
+          queryStyle: "natural_phrase",
+          twitterSearchMode: "raw",
+        },
+        {
+          type: "seed",
+          value: "SCREEN RECORDING WORKFLOW",
+          source: "agent",
+        },
+      ],
+    });
+
+    expect(saved).toEqual({ inserted: 2, updated: 1, skipped: 0 });
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db
+        .query("keywords")
+        .withIndex("by_workspace_value", (q) =>
+          q
+            .eq("workspaceId", workspaceId)
+            .eq("value", "screen recording workflow")
+        )
+        .collect()
+    );
+
+    expect(rows).toHaveLength(2);
+    expect(rows.map((row) => row.type).sort()).toEqual([
+      "seed",
+      "social_query",
+    ]);
+    expect(new Set(rows.map((row) => row.canonicalKey)).size).toBe(2);
+
+    const seed = rows.find((row) => row.type === "seed");
+    const socialQuery = rows.find((row) => row.type === "social_query");
+    expect(seed).toBeDefined();
+    expect(socialQuery).toBeDefined();
+
+    await t.mutation(internal.keywords.updateKeywordMonitorId, {
+      workspaceId,
+      query: "screen recording workflow",
+      monitorId: "keyword-monitor",
+    });
+    const updatedSeed = await t.run((ctx) => ctx.db.get(seed!._id));
+    const updatedSocialQuery = await t.run((ctx) =>
+      ctx.db.get(socialQuery!._id)
+    );
+    expect(updatedSeed?.monitorId).toBeUndefined();
+    expect(updatedSocialQuery?.monitorId).toBe("keyword-monitor");
+
+    const monitorId = await t.mutation(internal.socialapiMonitors.saveMonitor, {
+      workspaceId,
+      userId,
+      monitorId: "external-monitor",
+      query: "screen recording workflow",
+      refreshFrequency: 60,
+      purpose: "workspace_query",
+    });
+    const monitor = await t.run((ctx) => ctx.db.get(monitorId));
+    expect(monitor?.keywordId).toBe(socialQuery!._id);
+    expect(monitor?.queryCandidateId).toBe(
+      updatedSocialQuery?.activatedQueryCandidateId
+    );
+
+    const queue = await t.query(
+      internal.keywords.getPrioritizedTwitterQueries,
+      { workspaceId, limit: 10 }
+    );
+
+    expect(queue).toEqual([
+      expect.objectContaining({
+        value: "Screen   Recording Workflow",
+        searchMode: "raw",
+      }),
+    ]);
+  });
+
+  test("the single-keyword save path keeps matching seed and query rows distinct", async () => {
+    const t = convexTest(schema, modules);
+    const { workspaceId } = await seedWorkspace(t);
+
+    const seedId = await t.mutation(internal.keywords.saveKeywordInternal, {
+      workspaceId,
+      type: "seed",
+      value: "founder hiring",
+      source: "agent",
+    });
+    const queryId = await t.mutation(internal.keywords.saveKeywordInternal, {
+      workspaceId,
+      type: "social_query",
+      value: "FOUNDER HIRING",
+      source: "agent",
+      platformTargets: ["twitter"],
+      queryStyle: "natural_phrase",
+      twitterSearchMode: "raw",
+    });
+
+    expect(queryId).not.toBe(seedId);
+
+    const queue = await t.query(
+      internal.keywords.getPrioritizedTwitterQueries,
+      { workspaceId, limit: 10 }
+    );
+    expect(queue.map((item) => item.id)).toEqual([queryId]);
+  });
+
   test("persists the LLM mode and safely defaults or demotes queries", async () => {
     const t = convexTest(schema, modules);
-    const workspaceId = await seedWorkspace(t);
+    const { workspaceId } = await seedWorkspace(t);
 
     await t.mutation(internal.keywords.saveKeywordsBatch, {
       workspaceId,


### PR DESCRIPTION
## Summary

- make keyword deduplication type-aware so seed keywords cannot suppress executable social queries with identical normalized text
- add a workspace/type/value index and keep monitor linkage scoped to social queries
- add regression coverage for the workflow fallback path, normalization, queue execution, single saves, and monitor linkage

## Verification

- focused regression tests: 4/4 passed
- full Convex suite: 467/467 passed
- strict lint passed
- TypeScript typecheck passed
- production build passed
- CodeRabbit review raised 0 issues

This PR is intentionally left unmerged pending approval.