### PR TITLE
fix(progress): show clear and accurate workspace metrics

### DIFF
--- a/convex/onboardingProgress.integration.test.ts
+++ b/convex/onboardingProgress.integration.test.ts
@@ -1,0 +1,50 @@
+/// <reference types="vite/client" />
+
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { api } from "./_generated/api";
+import { createEmptyWorkspaceStatsRecord } from "./lib/readModelHelpers";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+
+describe("onboarding progress", () => {
+  test("returns the represented X/Twitter and LinkedIn prospect counts", async () => {
+    const t = convexTest(schema, modules);
+    const workosUserId = "onboarding-progress-platforms";
+    const seeded = await t.run(async (ctx) => {
+      const userId = await ctx.db.insert("users", {
+        workosUserId,
+        email: "onboarding-progress-platforms@example.com",
+      });
+      const workspaceId = await ctx.db.insert("workspaces", {
+        userId,
+        name: "Onboarding progress platform regression",
+        description: "Verifies represented platform counts",
+        isDefault: true,
+        entitlementSlot: 1,
+        updatedAt: 1,
+      });
+      await ctx.db.insert("workspaceStats", {
+        ...createEmptyWorkspaceStatsRecord({ workspaceId, userId }),
+        totalProspectsCount: 60,
+        twitterProspectsCount: 37,
+        linkedInProspectsCount: 23,
+      });
+
+      return { workspaceId };
+    });
+
+    const progress = await t
+      .withIdentity({ subject: workosUserId })
+      .query(api.prospects.getOnboardingProgress, {
+        workspaceId: seeded.workspaceId,
+      });
+
+    expect(progress).toMatchObject({
+      found: 60,
+      twitterProspectsCount: 37,
+      linkedInProspectsCount: 23,
+    });
+  });
+});

--- a/convex/prospects.ts
+++ b/convex/prospects.ts
@@ -912,6 +912,8 @@ export const getOnboardingProgress = query({
     const actionableReadyCount =
       getWorkspaceStatsActionableReadyCount(workspaceStats);
     const found = workspaceStats.totalProspectsCount;
+    const twitterProspectsCount = workspaceStats.twitterProspectsCount;
+    const linkedInProspectsCount = workspaceStats.linkedInProspectsCount;
     const avgQualificationScore = workspaceStats.avgQualificationScore;
     const disqualifiedCount = analyticsRows.reduce(
       (total, row) => total + (row.qualificationDisqualifiedCount ?? 0),
@@ -945,6 +947,8 @@ export const getOnboardingProgress = query({
 
     return {
       found,
+      twitterProspectsCount,
+      linkedInProspectsCount,
       qualified,
       enriched,
       plansGenerated,

--- a/features/agent/ui/components/OnboardingProgressCard.tsx
+++ b/features/agent/ui/components/OnboardingProgressCard.tsx
@@ -30,6 +30,11 @@ import {
   getCurrentUTCTimestamp,
   isSameDay,
 } from "@/shared/lib/utils";
+import { formatProspectPlatformSummary } from "@/shared/lib/platforms/prospectPlatformSummary";
+import {
+  formatAverageFitScoreDetail,
+  formatEnrichedProfilesDetail,
+} from "@/shared/lib/workspaceProgressDetails";
 
 const STAGES = [
   { id: "searching", label: "Search", step: 1 },
@@ -40,6 +45,8 @@ const STAGES = [
 
 type OnboardingProgressData = {
   found: number;
+  twitterProspectsCount: number;
+  linkedInProspectsCount: number;
   qualified: number;
   enriched: number;
   plansGenerated: number;
@@ -63,6 +70,8 @@ type OnboardingProgressData = {
 
 export type OnboardingProgressPreviewData = {
   found: number;
+  twitterProspectsCount: number;
+  linkedInProspectsCount: number;
   qualified: number;
   enriched: number;
   plansGenerated?: number;
@@ -95,6 +104,8 @@ interface OnboardingProgressCardProps {
 
 const DEFAULT_PROGRESS_DATA: OnboardingProgressData = {
   found: 0,
+  twitterProspectsCount: 0,
+  linkedInProspectsCount: 0,
   qualified: 0,
   enriched: 0,
   plansGenerated: 0,
@@ -186,6 +197,8 @@ export function OnboardingProgressCard({
     ? {
         ...DEFAULT_PROGRESS_DATA,
         found: previewData.found,
+        twitterProspectsCount: previewData.twitterProspectsCount,
+        linkedInProspectsCount: previewData.linkedInProspectsCount,
         qualified: previewData.qualified,
         enriched: previewData.enriched,
         plansGenerated: previewData.plansGenerated ?? 0,
@@ -337,21 +350,24 @@ export function OnboardingProgressCard({
         <StatCell
           label="Found"
           value={data.found}
-          detail={`${platformCount(data.found)} platf.`}
+          detail={
+            formatProspectPlatformSummary({
+              twitterProspectsCount: data.twitterProspectsCount,
+              linkedInProspectsCount: data.linkedInProspectsCount,
+            }) ?? "\u00A0"
+          }
         />
         <StatCell
           label="Qualified"
           value={data.qualified}
           detail={
-            data.avgQualificationScore > 0
-              ? `avg: ${data.avgQualificationScore}`
-              : "\u00A0"
+            formatAverageFitScoreDetail(data.avgQualificationScore) ?? "\u00A0"
           }
         />
         <StatCell
           label="Enriched"
           value={data.enriched}
-          detail={data.enriched > 0 ? `${data.enriched} prof.` : "\u00A0"}
+          detail={formatEnrichedProfilesDetail(data.enriched)}
         />
       </CardContent>
 
@@ -443,8 +459,4 @@ function StatCell({
       <p className="text-muted-foreground mt-0.5 text-[11px]">{detail}</p>
     </article>
   );
-}
-
-function platformCount(found: number): number {
-  return found > 0 ? 1 : 0;
 }

--- a/features/landing/ui/components/use-case-demo/DemoAgentStatusDialog.tsx
+++ b/features/landing/ui/components/use-case-demo/DemoAgentStatusDialog.tsx
@@ -40,6 +40,11 @@ import {
   TooltipTrigger,
 } from "@/shared/ui/components/Tooltip";
 import { getCurrentUTCTimestamp } from "@/shared/lib/utils/time/timeUtils";
+import { formatProspectPlatformSummary } from "@/shared/lib/platforms/prospectPlatformSummary";
+import {
+  formatAverageFitScoreDetail,
+  formatEnrichedProfilesDetail,
+} from "@/shared/lib/workspaceProgressDetails";
 import { useDemoShell } from "./demoShellContext";
 
 // Same stage list as OnboardingProgressCard.
@@ -66,6 +71,8 @@ const STATUS_DOT_CLASS_NAME = {
 
 const DEMO_PROGRESS = {
   found: 128,
+  twitterProspectsCount: 82,
+  linkedInProspectsCount: 46,
   qualified: 46,
   enriched: 24,
   plansGenerated: 8,
@@ -258,17 +265,27 @@ export function DemoAgentStatusDialog({
               <StatCell
                 label="Found"
                 value={DEMO_PROGRESS.found}
-                detail="1 platf."
+                detail={
+                  formatProspectPlatformSummary({
+                    twitterProspectsCount: DEMO_PROGRESS.twitterProspectsCount,
+                    linkedInProspectsCount:
+                      DEMO_PROGRESS.linkedInProspectsCount,
+                  }) ?? "\u00A0"
+                }
               />
               <StatCell
                 label="Qualified"
                 value={DEMO_PROGRESS.qualified}
-                detail={`avg: ${DEMO_PROGRESS.avgQualificationScore}`}
+                detail={
+                  formatAverageFitScoreDetail(
+                    DEMO_PROGRESS.avgQualificationScore
+                  ) ?? "\u00A0"
+                }
               />
               <StatCell
                 label="Enriched"
                 value={DEMO_PROGRESS.enriched}
-                detail={`${DEMO_PROGRESS.enriched} prof.`}
+                detail={formatEnrichedProfilesDetail(DEMO_PROGRESS.enriched)}
               />
             </CardContent>
 

--- a/shared/lib/platforms/prospectPlatformSummary.test.ts
+++ b/shared/lib/platforms/prospectPlatformSummary.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { formatProspectPlatformSummary } from "./prospectPlatformSummary";
+
+describe("formatProspectPlatformSummary", () => {
+  it.each([
+    [12, 8, "X/Twitter + LinkedIn"],
+    [12, 0, "X/Twitter"],
+    [0, 8, "LinkedIn"],
+    [0, 0, null],
+  ])(
+    "formats X/Twitter count %i and LinkedIn count %i as %s",
+    (twitterProspectsCount, linkedInProspectsCount, expected) => {
+      expect(
+        formatProspectPlatformSummary({
+          twitterProspectsCount,
+          linkedInProspectsCount,
+        })
+      ).toBe(expected);
+    }
+  );
+});

--- a/shared/lib/platforms/prospectPlatformSummary.ts
+++ b/shared/lib/platforms/prospectPlatformSummary.ts
@@ -1,0 +1,23 @@
+import { PLATFORM_REGISTRY } from "./registry";
+
+interface ProspectPlatformCounts {
+  twitterProspectsCount: number;
+  linkedInProspectsCount: number;
+}
+
+/** Formats the platforms represented by a workspace's discovered prospects. */
+export function formatProspectPlatformSummary({
+  twitterProspectsCount,
+  linkedInProspectsCount,
+}: ProspectPlatformCounts): string | null {
+  const platformLabels: string[] = [];
+
+  if (twitterProspectsCount > 0) {
+    platformLabels.push(PLATFORM_REGISTRY.twitter.label);
+  }
+  if (linkedInProspectsCount > 0) {
+    platformLabels.push(PLATFORM_REGISTRY.linkedin.label);
+  }
+
+  return platformLabels.length > 0 ? platformLabels.join(" + ") : null;
+}

--- a/shared/lib/workspaceProgressDetails.test.ts
+++ b/shared/lib/workspaceProgressDetails.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatAverageFitScoreDetail,
+  formatEnrichedProfilesDetail,
+} from "./workspaceProgressDetails";
+
+describe("workspace progress details", () => {
+  describe("formatAverageFitScoreDetail", () => {
+    it("identifies the average as a fit score out of 100", () => {
+      expect(formatAverageFitScoreDetail(77)).toBe("Avg. fit: 77/100");
+    });
+
+    it("hides the detail when no average is available", () => {
+      expect(formatAverageFitScoreDetail(0)).toBeNull();
+    });
+  });
+
+  describe("formatEnrichedProfilesDetail", () => {
+    it.each([
+      [0, "Profiles enriched"],
+      [1, "Profile enriched"],
+      [12, "Profiles enriched"],
+    ])("formats %i enriched profiles as %s", (enrichedCount, expected) => {
+      expect(formatEnrichedProfilesDetail(enrichedCount)).toBe(expected);
+    });
+  });
+});

--- a/shared/lib/workspaceProgressDetails.ts
+++ b/shared/lib/workspaceProgressDetails.ts
@@ -1,0 +1,9 @@
+export function formatAverageFitScoreDetail(
+  averageFitScore: number
+): string | null {
+  return averageFitScore > 0 ? `Avg. fit: ${averageFitScore}/100` : null;
+}
+
+export function formatEnrichedProfilesDetail(enrichedCount: number): string {
+  return `${enrichedCount === 1 ? "Profile" : "Profiles"} enriched`;
+}


### PR DESCRIPTION
## Summary

- replace the fake platform count with the actual platforms represented by workspace prospects
- display X/Twitter + LinkedIn using canonical product naming
- clarify qualification and enrichment details as Avg. fit: N/100 and Profiles enriched
- keep the landing demo aligned with the live workspace dialog
- add formatter unit tests and a Convex integration regression test

## Type Of Change

- [x] Bug fix
- [ ] Documentation update
- [x] UI or UX improvement
- [ ] Refactor
- [ ] New feature
- [ ] Infrastructure or tooling

## Why This Change

The workspace progress dialog reported 1 platf. whenever any prospects existed, even when prospects came from both X/Twitter and LinkedIn. Its avg and prof. abbreviations were also unclear. The dialog now uses real per-platform counts and short, explicit metric labels.

## Screenshots Or Recordings

Verified locally in the production build. X/Twitter + LinkedIn, Avg. fit: 86/100, and Profiles enriched each render on one line without clipping. The verification screenshot is attached to the originating Codex task.

## Testing

- [x] pnpm lint:strict
- [x] pnpm exec tsc --noEmit
- [x] pnpm build
- [x] pnpm test:convex — 477 tests across 93 files
- [x] Focused regression suite — 10 tests
- [x] Manual browser verification with no clipping or browser console errors

## Environment Or Schema Impact

No environment variables, schema migrations, webhooks, integrations, or deployment changes.

## Checklist

- [x] I kept this PR focused
- [x] I used existing helpers and patterns where possible
- [x] I added automated regression coverage
- [x] I manually verified the UI in a production build

## Notes For Maintainer

Do not merge until explicitly approved.

CodeRabbit CLI review was attempted repeatedly against the staged diff with AGENTS.md, but the service returned its free-tier rate-limit error each time and produced no review findings.