### PR TITLE
fix(chat): accept normalized tagged entity metadata

### DIFF
--- a/convex/agentMessageTaggedEntities.integration.test.ts
+++ b/convex/agentMessageTaggedEntities.integration.test.ts
@@ -1,0 +1,103 @@
+/// <reference types="vite/client" />
+
+import agentTest from "@convex-dev/agent/test";
+import { convexTest } from "convex-test";
+import { describe, expect, test, vi } from "vitest";
+import { buildAgentComposerSubmission } from "../features/agent/lib/buildAgentComposerMessage";
+import { api } from "./_generated/api";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+
+vi.stubEnv("OPENROUTER_API_KEY", "tagged-entity-validator-test-key");
+vi.stubEnv("OPENAI_API_KEY", "tagged-entity-validator-test-key");
+
+describe("Agent message tagged entities", () => {
+  test("creates a prospect thread with every supported tagged entity kind", async () => {
+    const t = convexTest(schema, modules);
+    agentTest.register(t);
+
+    const seeded = await t.run(async (ctx) => {
+      const workosUserId = "tagged-entity-validator-user";
+      const userId = await ctx.db.insert("users", {
+        workosUserId,
+        email: "tagged-entity-validator@example.com",
+      });
+      const workspaceId = await ctx.db.insert("workspaces", {
+        userId,
+        name: "Tagged entity validator workspace",
+        description: "Regression coverage for Agent message tags",
+        isDefault: true,
+        updatedAt: 1,
+      });
+      const prospectId = await ctx.db.insert("prospects", {
+        workspaceId,
+        userId,
+        platform: "twitter",
+        origin: "workspace_discovery",
+        externalId: "tagged-entity-validator-prospect",
+        data: {},
+        status: "new",
+        qualificationStatus: "qualified",
+        displayName: "Tagged Prospect",
+        updatedAt: 1,
+      });
+
+      return { prospectId, workosUserId };
+    });
+
+    const tagKinds = [
+      "prospect",
+      "plan",
+      "task",
+      "attachment",
+      "post",
+    ] as const;
+    const submission = buildAgentComposerSubmission({
+      input: "Use every tagged reference.",
+      taggedEntities: tagKinds.map((kind) => ({
+        id: `${kind}:${kind}-1`,
+        entityId: `${kind}-1`,
+        kind,
+        label: `Tagged ${kind}`,
+        mentionText: `Tagged ${kind}`,
+        secondaryLabel: `${kind} reference`,
+        avatarUrl: null,
+        verified: false,
+        referenceText: `${kind} reference`,
+        attachmentSize: kind === "attachment" ? 4096 : null,
+        attachmentMediaKind: kind === "attachment" ? ("file" as const) : null,
+      })),
+    });
+    if (!submission) {
+      throw new Error("Expected a tagged Agent composer submission.");
+    }
+
+    const result = await t
+      .withIdentity({ subject: seeded.workosUserId })
+      .mutation(api.chat.createProspectThreadWithPrompt, {
+        prospectId: seeded.prospectId,
+        prompt: submission.prompt,
+        metadata: submission.metadata ?? undefined,
+      });
+
+    const storedContext = await t.run((ctx) =>
+      ctx.db
+        .query("agentMessageContexts")
+        .withIndex("by_message", (q) => q.eq("messageId", result.messageId))
+        .unique()
+    );
+
+    expect(storedContext?.taggedEntities.map((entity) => entity.kind)).toEqual(
+      tagKinds
+    );
+    expect(storedContext?.taggedEntities).toHaveLength(tagKinds.length);
+    for (const entity of storedContext?.taggedEntities ?? []) {
+      expect(entity.attachmentSize).toBe(
+        entity.kind === "attachment" ? 4096 : null
+      );
+      expect(entity.attachmentDisabled).toBe(false);
+      expect(entity.attachmentDisabledReason).toBeNull();
+    }
+  });
+});

--- a/convex/validators.ts
+++ b/convex/validators.ts
@@ -1539,9 +1539,12 @@ export const agentMessageTaggedEntityValidator = v.object({
   taskId: v.optional(v.string()),
   attachmentUrl: v.optional(v.union(v.string(), v.null())),
   attachmentMimeType: v.optional(v.union(v.string(), v.null())),
+  attachmentSize: v.optional(v.union(v.number(), v.null())),
   attachmentMediaKind: v.optional(
     v.union(mentionAttachmentMediaKindValidator, v.null())
   ),
+  attachmentDisabled: v.optional(v.boolean()),
+  attachmentDisabledReason: v.optional(v.union(v.string(), v.null())),
   postId: v.optional(v.string()),
   postUrl: v.optional(v.union(v.string(), v.null())),
   postPlatform: v.optional(v.union(mentionPostPlatformValidator, v.null())),


### PR DESCRIPTION
## Summary

- align the Convex tagged-entity validator with the normalized client payload
- accept attachment size and compatibility metadata as optional fields
- add a regression test that submits every supported tag kind through the real client builder and public mutation

## Verification

- regression test fails before the fix with `Unexpected field attachmentSize`
- targeted Convex tests: 8 passed
- mention and context tests: 19 passed
- TypeScript, strict lint, Prettier, and production build passed
- CodeRabbit raised 0 issues
- in-app browser QA passed for people, plans, tasks, attachments, and posts

## Baseline note

The full Convex suite reports 460 passed and 8 existing workflow failures. The same 8 failures reproduce on clean `main` with `process is not defined`.