### PR TITLE
fix(convex): reconcile prospect usage after workspace deletion

### DIFF
--- a/convex/deleteWorkspace.integration.test.ts
+++ b/convex/deleteWorkspace.integration.test.ts
@@ -4,6 +4,8 @@ import { createThread, saveMessage } from "@convex-dev/agent";
 import { convexTest } from "convex-test";
 import { describe, expect, test, vi } from "vitest";
 import { api, components } from "./_generated/api";
+import { computeUsageCycleWindow } from "./lib/planCycleUtils";
+import { buildProspectSummaryRecord } from "./lib/readModelHelpers";
 import schema from "./schema";
 
 const modules = import.meta.glob("./**/*.ts");
@@ -28,13 +30,25 @@ async function registerComponents(t: ReturnType<typeof convexTest>) {
     default: { register: (instance: typeof t) => void };
   };
   ragTest.default.register(t);
+
+  const polarTestPath = ["@convex-dev/polar", "test"].join("/");
+  const polarTest = (await import(polarTestPath)) as {
+    default: { register: (instance: typeof t) => void };
+  };
+  polarTest.default.register(t);
 }
 
 describe("durable workspace deletion", () => {
-  test("deduplicates requests and deletes bounded child batches plus Agent messages", async () => {
+  test("deduplicates requests, deletes bounded children, and reconciles plan usage", async () => {
     vi.useFakeTimers();
     const t = convexTest(schema, modules);
     await registerComponents(t);
+    const now = Date.now();
+    const currentWindow = computeUsageCycleWindow({
+      now,
+      tier: "pro",
+      subscription: null,
+    });
     const seeded = await t.run(async (ctx) => {
       const userId = await ctx.db.insert("users", {
         workosUserId: "workspace-delete-owner",
@@ -45,8 +59,22 @@ describe("durable workspace deletion", () => {
         tier: "pro",
         prospectsLimit: 500,
         workspacesLimit: 10,
-        currentProspectsCount: 1,
+        currentProspectsCount: 3,
+        currentProspectsCycleStart: currentWindow.cycleStart,
+        currentProspectsCycleEnd: currentWindow.cycleEnd,
         currentWorkspacesCount: 2,
+        updatedAt: 1,
+      });
+      const usageCycleId = await ctx.db.insert("planUsageCycles", {
+        userId,
+        tier: "pro",
+        cycleStart: currentWindow.cycleStart,
+        cycleEnd: currentWindow.cycleEnd,
+        prospectsUsed: 3,
+        prospectsLimit: 500,
+        workspacesUsed: 2,
+        workspacesLimit: 10,
+        isCurrent: true,
         updatedAt: 1,
       });
       const workspaceId = await ctx.db.insert("workspaces", {
@@ -74,8 +102,39 @@ describe("durable workspace deletion", () => {
         externalId: "delete-prospect",
         data: {},
         status: "new",
+        qualificationStatus: "qualified",
+        qualifiedAt: now,
         updatedAt: 1,
       });
+      const prospect = await ctx.db.get("prospects", prospectId);
+      if (!prospect) throw new Error("Failed to seed deleting prospect");
+      await ctx.db.insert(
+        "prospectSummaries",
+        buildProspectSummaryRecord(prospect)
+      );
+      const remainingProspectId = await ctx.db.insert("prospects", {
+        workspaceId: replacementId,
+        userId,
+        platform: "twitter",
+        origin: "workspace_discovery",
+        externalId: "remaining-prospect",
+        data: {},
+        status: "new",
+        qualificationStatus: "qualified",
+        qualifiedAt: now,
+        updatedAt: 1,
+      });
+      const remainingProspect = await ctx.db.get(
+        "prospects",
+        remainingProspectId
+      );
+      if (!remainingProspect) {
+        throw new Error("Failed to seed remaining prospect");
+      }
+      await ctx.db.insert(
+        "prospectSummaries",
+        buildProspectSummaryRecord(remainingProspect)
+      );
       for (let index = 0; index < 31; index += 1) {
         await ctx.db.insert("keywords", {
           workspaceId,
@@ -135,9 +194,11 @@ describe("durable workspace deletion", () => {
       return {
         planId,
         prospectId,
+        remainingProspectId,
         replacementId,
         setupSessionId,
         threadId,
+        usageCycleId,
         userId,
         workspaceId,
       };
@@ -211,6 +272,11 @@ describe("durable workspace deletion", () => {
         .query("userPlans")
         .withIndex("by_user", (q) => q.eq("userId", seeded.userId))
         .unique(),
+      usageCycle: await ctx.db.get("planUsageCycles", seeded.usageCycleId),
+      remainingProspect: await ctx.db.get(
+        "prospects",
+        seeded.remainingProspectId
+      ),
       keywords: await ctx.db
         .query("keywords")
         .withIndex("by_workspace", (q) =>
@@ -235,6 +301,19 @@ describe("durable workspace deletion", () => {
     expect(state.setupSession?.targetWorkspaceId).toBeUndefined();
     expect(state.setupSession?.previewProspectIds).toBeUndefined();
     expect(state.userPlan?.currentWorkspacesCount).toBe(1);
+    expect(state.userPlan?.currentProspectsCount).toBe(1);
+    expect(state.userPlan?.currentProspectsCycleStart).toBe(
+      currentWindow.cycleStart
+    );
+    expect(state.userPlan?.currentProspectsCycleEnd).toBe(
+      currentWindow.cycleEnd
+    );
+    expect(state.usageCycle).toMatchObject({
+      prospectsUsed: 1,
+      workspacesUsed: 1,
+      isCurrent: true,
+    });
+    expect(state.remainingProspect?.workspaceId).toBe(seeded.replacementId);
     expect(componentThread).toBeNull();
     expect(deletionsAfterWorkflow).toEqual([]);
     vi.useRealTimers();

--- a/convex/lib/deleteWorkspaceCore.ts
+++ b/convex/lib/deleteWorkspaceCore.ts
@@ -2,8 +2,10 @@ import { paginationOptsValidator } from "convex/server";
 import { v } from "convex/values";
 import type { Doc, TableNames } from "../_generated/dataModel";
 import type { MutationCtx } from "../_generated/server";
+import { polar } from "../polar";
 import { internalMutation, internalQuery } from "./functionBuilders";
 import { decrementWorkspaceCount } from "./planCore";
+import { reconcilePlanUsageForUser } from "./planUsageCore";
 import { deleteWorkspaceAgentMemoryBatch } from "./agentMemoryCore";
 import { getCurrentUTCTimestamp } from "../../shared/lib/utils/time/timeUtils";
 
@@ -753,6 +755,15 @@ export const finalizeWorkspaceDeletionInternal = internalMutation({
       await decrementWorkspaceCount(ctx, args.userId);
     }
     await ctx.db.delete(workspace._id);
+
+    const subscription = await polar.getCurrentSubscription(ctx, {
+      userId: args.userId,
+    });
+    await reconcilePlanUsageForUser(ctx, {
+      userId: args.userId,
+      subscription,
+    });
+
     return { deleted: true };
   },
 });

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -23,6 +23,8 @@ import {
   updateWorkspaceAttachmentStats,
 } from "./lib/workspaceAttachmentCore";
 import { getCurrentUTCTimestamp } from "../shared/lib/utils/time/timeUtils";
+import { polar } from "./polar";
+import { reconcilePlanUsageForUser } from "./lib/planUsageCore";
 
 export const migrations = new Migrations<DataModel, typeof schema>(
   components.migrations,
@@ -94,6 +96,25 @@ export const backfillPlanBatchReferenceKeys = migrations.define({
     }
     await ctx.db.patch("planBatchRuns", run._id, {
       referenceKey: createPlanBatchReferenceKey(),
+    });
+  },
+});
+
+/**
+ * Rerunnable repair for current usage snapshots that drifted from canonical
+ * qualified prospects. One user is reconciled per transaction to keep each
+ * user's prospect recount within an isolated Convex transaction budget.
+ */
+export const reconcileCurrentPlanUsage = migrations.define({
+  table: "userPlans",
+  batchSize: 1,
+  migrateOne: async (ctx, plan) => {
+    const subscription = await polar.getCurrentSubscription(ctx, {
+      userId: plan.userId,
+    });
+    await reconcilePlanUsageForUser(ctx, {
+      userId: plan.userId,
+      subscription,
     });
   },
 });

--- a/convex/planUsageReconciliationMigration.integration.test.ts
+++ b/convex/planUsageReconciliationMigration.integration.test.ts
@@ -1,0 +1,192 @@
+/// <reference types="vite/client" />
+
+import type { MigrationResult } from "@convex-dev/migrations";
+import { convexTest, type TestConvex } from "convex-test";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import {
+  computeUsageCycleWindow,
+  getUtcMonthBounds,
+} from "./lib/planCycleUtils";
+import { PLAN_LIMITS } from "./lib/planConstants";
+import { buildProspectSummaryRecord } from "./lib/readModelHelpers";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+
+vi.stubEnv("OPENAI_API_KEY", "plan-usage-reconciliation-test-key");
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+async function registerPolarComponent(t: TestConvex<typeof schema>) {
+  const polarTestPath = ["@convex-dev/polar", "test"].join("/");
+  const polarTest = (await import(polarTestPath)) as {
+    default: { register: (instance: typeof t) => void };
+  };
+  polarTest.default.register(t);
+}
+
+async function readUsageState(
+  t: TestConvex<typeof schema>,
+  userId: Id<"users">
+) {
+  return await t.run(async (ctx) => {
+    const plan = await ctx.db
+      .query("userPlans")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .unique();
+    const cycles = await ctx.db
+      .query("planUsageCycles")
+      .withIndex("by_user_cycle_start", (q) => q.eq("userId", userId))
+      .collect();
+    return {
+      plan,
+      currentCycle: cycles.find((cycle) => cycle.isCurrent),
+      historicalCycles: cycles.filter((cycle) => !cycle.isCurrent),
+    };
+  });
+}
+
+describe("current plan usage reconciliation migration", () => {
+  test("repairs stale 32-to-24 usage and is safe to rerun", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-26T12:00:00.000Z"));
+
+    const t = convexTest(schema, modules);
+    await registerPolarComponent(t);
+    const now = Date.now();
+    const currentWindow = computeUsageCycleWindow({
+      now,
+      tier: "hobby",
+      subscription: null,
+    });
+    const previousWindow = getUtcMonthBounds(currentWindow.cycleStart - 1);
+
+    const userId = await t.run(async (ctx) => {
+      const seededUserId = await ctx.db.insert("users", {
+        workosUserId: "plan-usage-reconciliation-owner",
+        email: "usage-reconciliation@example.com",
+      });
+      await ctx.db.insert("userPlans", {
+        userId: seededUserId,
+        tier: "hobby",
+        prospectsLimit: PLAN_LIMITS.hobby.prospectsLimit,
+        workspacesLimit: PLAN_LIMITS.hobby.workspacesLimit,
+        currentProspectsCount: 32,
+        currentProspectsCycleStart: currentWindow.cycleStart,
+        currentProspectsCycleEnd: currentWindow.cycleEnd,
+        currentWorkspacesCount: 1,
+        updatedAt: 1,
+      });
+      await ctx.db.insert("planUsageCycles", {
+        userId: seededUserId,
+        tier: "hobby",
+        cycleStart: currentWindow.cycleStart,
+        cycleEnd: currentWindow.cycleEnd,
+        prospectsUsed: 32,
+        prospectsLimit: PLAN_LIMITS.hobby.prospectsLimit,
+        workspacesUsed: 1,
+        workspacesLimit: PLAN_LIMITS.hobby.workspacesLimit,
+        isCurrent: true,
+        updatedAt: 1,
+      });
+      await ctx.db.insert("planUsageCycles", {
+        userId: seededUserId,
+        tier: "hobby",
+        cycleStart: previousWindow.cycleStart,
+        cycleEnd: previousWindow.cycleEnd,
+        prospectsUsed: 8,
+        prospectsLimit: PLAN_LIMITS.hobby.prospectsLimit,
+        workspacesUsed: 1,
+        workspacesLimit: PLAN_LIMITS.hobby.workspacesLimit,
+        isCurrent: false,
+        updatedAt: 1,
+      });
+      const workspaceId = await ctx.db.insert("workspaces", {
+        userId: seededUserId,
+        name: "Untitled workspace",
+        description: "Production-style usage reconciliation fixture.",
+        isDefault: true,
+        setupCompletedAt: now,
+        updatedAt: now,
+      });
+
+      for (let index = 0; index < 24; index += 1) {
+        const prospectId = await ctx.db.insert("prospects", {
+          workspaceId,
+          userId: seededUserId,
+          platform: "twitter",
+          origin: "workspace_discovery",
+          externalId: `remaining-qualified-${index}`,
+          data: {},
+          status: "new",
+          qualificationStatus: "qualified",
+          qualifiedAt: now,
+          updatedAt: now,
+        });
+        const prospect = await ctx.db.get("prospects", prospectId);
+        if (!prospect) throw new Error("Failed to seed qualified prospect");
+        await ctx.db.insert(
+          "prospectSummaries",
+          buildProspectSummaryRecord(prospect)
+        );
+      }
+
+      return seededUserId;
+    });
+
+    const runMigrationPass = async () => {
+      let cursor: string | null = null;
+      let processed = 0;
+      let batches = 0;
+
+      while (true) {
+        const result: MigrationResult = await t.mutation(
+          internal.migrations.reconcileCurrentPlanUsage,
+          {
+            cursor,
+            dryRun: false,
+            oneBatchOnly: true,
+          }
+        );
+        processed += result.processed;
+        batches += 1;
+        if (result.isDone) return { processed, batches };
+        cursor = result.continueCursor;
+      }
+    };
+
+    const firstResult = await runMigrationPass();
+    const firstState = await readUsageState(t, userId);
+
+    expect(firstResult).toEqual({ processed: 1, batches: 2 });
+    expect(firstState.plan).toMatchObject({
+      currentProspectsCount: 24,
+      currentProspectsCycleStart: currentWindow.cycleStart,
+      currentProspectsCycleEnd: currentWindow.cycleEnd,
+      currentWorkspacesCount: 1,
+    });
+    expect(firstState.currentCycle).toMatchObject({
+      prospectsUsed: 24,
+      workspacesUsed: 1,
+      isCurrent: true,
+    });
+    expect(firstState.historicalCycles).toHaveLength(1);
+    expect(firstState.historicalCycles[0]).toMatchObject({
+      cycleStart: previousWindow.cycleStart,
+      cycleEnd: previousWindow.cycleEnd,
+      prospectsUsed: 8,
+      isCurrent: false,
+      updatedAt: 1,
+    });
+
+    const secondResult = await runMigrationPass();
+    const secondState = await readUsageState(t, userId);
+
+    expect(secondResult).toEqual({ processed: 1, batches: 2 });
+    expect(secondState).toEqual(firstState);
+  });
+});


### PR DESCRIPTION
## Summary

- Reconcile qualified prospect usage from canonical remaining prospects when workspace deletion finalizes.
- Add an idempotent one-user-per-batch migration for existing stale usage.
- Add regression coverage for deletion and production-style 32 to 24 repair, including safe reruns.

## Type Of Change

- [x] Bug fix
- [ ] Documentation update
- [ ] UI or UX improvement
- [ ] Refactor
- [ ] New feature
- [ ] Infrastructure or tooling

## Why This Change

Deleting a workspace removed its prospects but left their qualified usage in userPlans and the current planUsageCycles row. This could incorrectly consume quota after the source prospects no longer existed.

## Screenshots Or Recordings

Not applicable; backend-only change.

## Testing

- [x] TypeScript: node node_modules/typescript/bin/tsc --noEmit
- [x] Strict lint: pnpm lint:strict
- [x] Full Convex suite: 95 files, 479 tests passed
- [x] Focused migration and deletion tests: 3 tests passed
- [x] Production Next.js build
- [x] CodeRabbit complete-diff review; one valid test cleanup issue fixed and verification rerun

## Environment Or Schema Impact

No schema or environment-variable change.

After this PR is merged and automatically deployed, the new deletion path prevents future drift. Existing production drift is repaired separately by manually running the idempotent migration when approved:

Dry run:
    npx convex run migrations:reconcileCurrentPlanUsage {"dryRun":true,"reset":true} --prod

Apply:
    npx convex run migrations:reconcileCurrentPlanUsage --prod

The migration does not run automatically on deploy.

## Checklist

- [ ] I read README.md and CONTRIBUTING.md
- [x] I kept this PR focused
- [x] I used existing helpers and patterns where possible
- [x] Docs were not needed for this backend bug fix
- [x] Screenshots are not applicable

## Notes For Maintainer

Do not merge until explicitly approved. After merge and automatic deployment, wait for separate approval before running the production backfill. Verify the affected account reads 24 for both currentProspectsCount and current-cycle prospectsUsed after the backfill.