### PR TITLE
refactor(convex): retire legacy workspace counter (phase 1)

### DIFF
--- a/convex/deleteWorkspace.integration.test.ts
+++ b/convex/deleteWorkspace.integration.test.ts
@@ -62,7 +62,6 @@ describe("durable workspace deletion", () => {
         currentProspectsCount: 3,
         currentProspectsCycleStart: currentWindow.cycleStart,
         currentProspectsCycleEnd: currentWindow.cycleEnd,
-        currentWorkspacesCount: 2,
         updatedAt: 1,
       });
       const usageCycleId = await ctx.db.insert("planUsageCycles", {
@@ -300,7 +299,7 @@ describe("durable workspace deletion", () => {
     expect(state.setupSession?.existingWorkspaceId).toBeUndefined();
     expect(state.setupSession?.targetWorkspaceId).toBeUndefined();
     expect(state.setupSession?.previewProspectIds).toBeUndefined();
-    expect(state.userPlan?.currentWorkspacesCount).toBe(1);
+    expect(state.userPlan).not.toHaveProperty("currentWorkspacesCount");
     expect(state.userPlan?.currentProspectsCount).toBe(1);
     expect(state.userPlan?.currentProspectsCycleStart).toBe(
       currentWindow.cycleStart

--- a/convex/legacyWorkspaceCounterRemoval.integration.test.ts
+++ b/convex/legacyWorkspaceCounterRemoval.integration.test.ts
@@ -1,0 +1,132 @@
+/// <reference types="vite/client" />
+
+import type { MigrationResult } from "@convex-dev/migrations";
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { internal } from "./_generated/api";
+import {
+  getOrCreateUserPlan,
+  upgradePlan,
+} from "./lib/planCore";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+
+async function runRemovalMigrationPass(
+  t: ReturnType<typeof convexTest>
+) {
+  let cursor: string | null = null;
+  let processed = 0;
+  let batches = 0;
+
+  while (true) {
+    const result: MigrationResult = await t.mutation(
+      internal.migrations.removeLegacyCurrentWorkspacesCount,
+      {
+        cursor,
+        dryRun: false,
+        oneBatchOnly: true,
+      }
+    );
+    processed += result.processed;
+    batches += 1;
+    if (result.isDone) return { processed, batches };
+    cursor = result.continueCursor;
+  }
+}
+
+describe("legacy workspace counter removal", () => {
+  test("new plan writers omit the legacy workspace counter", async () => {
+    const t = convexTest(schema, modules);
+
+    const state = await t.run(async (ctx) => {
+      const defaultUserId = await ctx.db.insert("users", {
+        workosUserId: "workspace-counter-default-plan",
+        email: "workspace-counter-default@example.com",
+      });
+      const upgradedUserId = await ctx.db.insert("users", {
+        workosUserId: "workspace-counter-upgraded-plan",
+        email: "workspace-counter-upgraded@example.com",
+      });
+
+      await getOrCreateUserPlan(ctx, defaultUserId);
+      await upgradePlan(ctx, upgradedUserId, "hobby");
+
+      const defaultPlan = await ctx.db
+        .query("userPlans")
+        .withIndex("by_user", (q) => q.eq("userId", defaultUserId))
+        .unique();
+      const upgradedPlan = await ctx.db
+        .query("userPlans")
+        .withIndex("by_user", (q) => q.eq("userId", upgradedUserId))
+        .unique();
+
+      return { defaultPlan, upgradedPlan };
+    });
+
+    expect(state.defaultPlan).not.toHaveProperty("currentWorkspacesCount");
+    expect(state.upgradedPlan).not.toHaveProperty("currentWorkspacesCount");
+  });
+
+  test("removes existing values and is safe to rerun", async () => {
+    const t = convexTest(schema, modules);
+
+    const ids = await t.run(async (ctx) => {
+      const legacyUserId = await ctx.db.insert("users", {
+        workosUserId: "workspace-counter-legacy-owner",
+        email: "workspace-counter-legacy@example.com",
+      });
+      const modernUserId = await ctx.db.insert("users", {
+        workosUserId: "workspace-counter-modern-owner",
+        email: "workspace-counter-modern@example.com",
+      });
+      const legacyPlanId = await ctx.db.insert("userPlans", {
+        userId: legacyUserId,
+        tier: "hobby",
+        prospectsLimit: 100,
+        workspacesLimit: 1,
+        currentProspectsCount: 24,
+        currentWorkspacesCount: 7,
+        updatedAt: 1,
+      });
+      const modernPlanId = await ctx.db.insert("userPlans", {
+        userId: modernUserId,
+        tier: "base",
+        prospectsLimit: 1000,
+        workspacesLimit: 2,
+        currentProspectsCount: 12,
+        updatedAt: 2,
+      });
+
+      return { legacyPlanId, modernPlanId };
+    });
+
+    const readPlans = async () =>
+      await t.run(async (ctx) => ({
+        legacy: await ctx.db.get("userPlans", ids.legacyPlanId),
+        modern: await ctx.db.get("userPlans", ids.modernPlanId),
+      }));
+
+    const firstResult = await runRemovalMigrationPass(t);
+    const firstState = await readPlans();
+
+    expect(firstResult.processed).toBe(2);
+    expect(firstResult.batches).toBeGreaterThanOrEqual(1);
+    expect(firstState.legacy).toMatchObject({
+      currentProspectsCount: 24,
+      updatedAt: 1,
+    });
+    expect(firstState.modern).toMatchObject({
+      currentProspectsCount: 12,
+      updatedAt: 2,
+    });
+    expect(firstState.legacy).not.toHaveProperty("currentWorkspacesCount");
+    expect(firstState.modern).not.toHaveProperty("currentWorkspacesCount");
+
+    const secondResult = await runRemovalMigrationPass(t);
+    const secondState = await readPlans();
+
+    expect(secondResult.processed).toBe(2);
+    expect(secondState).toEqual(firstState);
+  });
+});

--- a/convex/lib/deleteWorkspaceCore.ts
+++ b/convex/lib/deleteWorkspaceCore.ts
@@ -4,7 +4,6 @@ import type { Doc, TableNames } from "../_generated/dataModel";
 import type { MutationCtx } from "../_generated/server";
 import { polar } from "../polar";
 import { internalMutation, internalQuery } from "./functionBuilders";
-import { decrementWorkspaceCount } from "./planCore";
 import { reconcilePlanUsageForUser } from "./planUsageCore";
 import { deleteWorkspaceAgentMemoryBatch } from "./agentMemoryCore";
 import { getCurrentUTCTimestamp } from "../../shared/lib/utils/time/timeUtils";
@@ -750,9 +749,6 @@ export const finalizeWorkspaceDeletionInternal = internalMutation({
     }
     if (!workspace.deletionWorkflowId) {
       throw new Error("Workspace deletion was not requested");
-    }
-    if (workspace.setupCompletedAt) {
-      await decrementWorkspaceCount(ctx, args.userId);
     }
     await ctx.db.delete(workspace._id);
 

--- a/convex/lib/planConstants.ts
+++ b/convex/lib/planConstants.ts
@@ -63,7 +63,6 @@ export type UserPlan = {
   currentProspectsCount: number;
   currentProspectsCycleStart?: number;
   currentProspectsCycleEnd?: number;
-  currentWorkspacesCount: number;
   updatedAt: number;
   externalSubscriptionId?: string;
   polarCustomerId?: string;

--- a/convex/lib/planCore.ts
+++ b/convex/lib/planCore.ts
@@ -58,7 +58,6 @@ export async function getOrCreateUserPlan(
       currentProspectsCount: 0,
       currentProspectsCycleStart: undefined,
       currentProspectsCycleEnd: undefined,
-      currentWorkspacesCount: 0,
       updatedAt: now,
     });
     const createdPlan = await mutationCtx.db.get(planId);
@@ -78,7 +77,6 @@ export async function getOrCreateUserPlan(
     currentProspectsCount: 0,
     currentProspectsCycleStart: undefined,
     currentProspectsCycleEnd: undefined,
-    currentWorkspacesCount: 0,
     updatedAt: now,
     polarCustomerId: undefined,
   };
@@ -131,49 +129,6 @@ export async function decrementProspectCount(
 }
 
 /**
- * Increment workspace count for a user
- */
-export async function incrementWorkspaceCount(
-  ctx: MutationCtx,
-  userId: Id<"users">
-) {
-  const plan = await ctx.db
-    .query("userPlans")
-    .withIndex("by_user", (q) => q.eq("userId", userId))
-    .first();
-
-  if (!plan) {
-    await getOrCreateUserPlan(ctx, userId);
-    return incrementWorkspaceCount(ctx, userId);
-  }
-
-  await ctx.db.patch(plan._id, {
-    currentWorkspacesCount: plan.currentWorkspacesCount + 1,
-    updatedAt: getCurrentUTCTimestamp(),
-  });
-}
-
-/**
- * Decrement workspace count for a user
- */
-export async function decrementWorkspaceCount(
-  ctx: MutationCtx,
-  userId: Id<"users">
-) {
-  const plan = await ctx.db
-    .query("userPlans")
-    .withIndex("by_user", (q) => q.eq("userId", userId))
-    .first();
-
-  if (!plan) return;
-
-  await ctx.db.patch(plan._id, {
-    currentWorkspacesCount: Math.max(0, plan.currentWorkspacesCount - 1),
-    updatedAt: getCurrentUTCTimestamp(),
-  });
-}
-
-/**
  * Upgrade a user's plan tier
  */
 export async function upgradePlan(
@@ -203,7 +158,6 @@ export async function upgradePlan(
       currentProspectsCount: 0,
       currentProspectsCycleStart: undefined,
       currentProspectsCycleEnd: undefined,
-      currentWorkspacesCount: 0,
       externalSubscriptionId,
       expiresAt,
       updatedAt: now,

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -119,6 +119,24 @@ export const reconcileCurrentPlanUsage = migrations.define({
   },
 });
 
+/**
+ * Phase one of removing the unused currentWorkspacesCount snapshot. Current
+ * workspace capacity and usage are derived from canonical workspace records,
+ * so clearing this duplicate field cannot affect enforcement or reporting.
+ */
+export const removeLegacyCurrentWorkspacesCount = migrations.define({
+  table: "userPlans",
+  batchSize: 25,
+  migrateOne: async (ctx, plan) => {
+    if (plan.currentWorkspacesCount === undefined) {
+      return;
+    }
+    await ctx.db.patch(plan._id, {
+      currentWorkspacesCount: undefined,
+    });
+  },
+});
+
 function defineQualifiedProspectDisplayNameBackfill(
   workspaceId: Id<"workspaces">
 ) {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -951,7 +951,12 @@ export default defineSchema({
     currentProspectsCount: v.number(),
     currentProspectsCycleStart: v.optional(v.number()),
     currentProspectsCycleEnd: v.optional(v.number()),
-    currentWorkspacesCount: v.number(),
+    /**
+     * @deprecated Workspace capacity and usage are derived from canonical
+     * workspace entitlements and completed workspaces. Kept optional only
+     * until removeLegacyCurrentWorkspacesCount clears deployed documents.
+     */
+    currentWorkspacesCount: v.optional(v.number()),
     // External subscription ID (for future billing integration)
     externalSubscriptionId: v.optional(v.string()),
     /** Polar customer UUID for server-side order history and billing APIs */


### PR DESCRIPTION
## Summary

- Make the unused userPlans.currentWorkspacesCount field optional for a safe phased removal.
- Stop creating, incrementing, or decrementing the duplicate counter.
- Keep workspace capacity and reporting on canonical entitlements, completed workspaces, and planUsageCycles.workspacesUsed.
- Add an idempotent migration that unsets the legacy field from existing plans.

## Type Of Change

- [x] Refactor
- [x] Infrastructure or tooling
- [ ] Bug fix
- [ ] Documentation update
- [ ] UI or UX improvement
- [ ] New feature

## Why This Change

The field has no production readers, its increment helper has no callers, and its stored value can drift from canonical workspace usage. Removing the duplicate state prevents future confusion and eliminates a dead write from workspace deletion.

This is phase one of a two-deployment Convex field removal. The schema field must remain optional until all deployed documents have been cleared.

## Screenshots Or Recordings

Not applicable; backend-only cleanup.

## Testing

- [x] Focused tests: 2 files, 4 tests passed
- [x] Full repository Vitest suite: 96 files, 481 tests passed
- [x] TypeScript: node node_modules/typescript/bin/tsc --noEmit
- [x] Strict lint: pnpm lint:strict
- [x] Production Next.js build
- [x] Convex development deployment validation
- [x] Development migration dry run; no changes committed
- [x] CodeRabbit complete seven-file review; 0 issues

## Environment Or Schema Impact

No environment-variable change.

Schema impact: currentWorkspacesCount becomes optional. Do not remove it from the schema in this PR.

After this PR is merged and automatically deployed, run and verify the production migration before starting phase two:

Dry run:
    npx convex run migrations:removeLegacyCurrentWorkspacesCount {"dryRun":true,"reset":true} --prod

Apply:
    npx convex run migrations:removeLegacyCurrentWorkspacesCount --prod

Status:
    npx convex run --component migrations lib:getStatus {"names":["migrations:removeLegacyCurrentWorkspacesCount"]} --prod

Phase two may remove the field from the schema and delete the temporary migration only after production verification confirms every userPlans document no longer contains it.

## Checklist

- [x] I kept this PR focused
- [x] I used the existing migrations component and canonical workspace helpers
- [x] I added regression coverage
- [x] Screenshots are not applicable

## Notes For Maintainer

Do not merge until explicitly approved. Do not open or merge phase two until this deployment and production migration are confirmed successful.