### PR TITLE
Fix public interaction discovery and thread loading UX

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -170,6 +170,7 @@ import type * as lib_previewQualificationPool from "../lib/previewQualificationP
 import type * as lib_prospectAnalyticsCore from "../lib/prospectAnalyticsCore.js";
 import type * as lib_prospectIdentityCore from "../lib/prospectIdentityCore.js";
 import type * as lib_prospectInteractionHistoryCore from "../lib/prospectInteractionHistoryCore.js";
+import type * as lib_prospectInteractionSyncCore from "../lib/prospectInteractionSyncCore.js";
 import type * as lib_prospectListFeedUtils from "../lib/prospectListFeedUtils.js";
 import type * as lib_prospectProfileContextCore from "../lib/prospectProfileContextCore.js";
 import type * as lib_prospectProfileContextHelpers from "../lib/prospectProfileContextHelpers.js";
@@ -524,6 +525,7 @@ declare const fullApi: ApiFromModules<{
   "lib/prospectAnalyticsCore": typeof lib_prospectAnalyticsCore;
   "lib/prospectIdentityCore": typeof lib_prospectIdentityCore;
   "lib/prospectInteractionHistoryCore": typeof lib_prospectInteractionHistoryCore;
+  "lib/prospectInteractionSyncCore": typeof lib_prospectInteractionSyncCore;
   "lib/prospectListFeedUtils": typeof lib_prospectListFeedUtils;
   "lib/prospectProfileContextCore": typeof lib_prospectProfileContextCore;
   "lib/prospectProfileContextHelpers": typeof lib_prospectProfileContextHelpers;

--- a/convex/interactions.ts
+++ b/convex/interactions.ts
@@ -175,6 +175,36 @@ export const getProspectInteractionSyncStateInternal = internalQuery({
   },
 });
 
+export const getProspectInteractionsInternal = internalQuery({
+  args: {
+    userId: v.id("users"),
+    prospectId: v.id("prospects"),
+    platform: prospectInteractionHistoryPlatformValidator,
+    limit: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const prospect = await ctx.db.get(args.prospectId);
+    if (!prospect || prospect.userId !== args.userId) {
+      return [];
+    }
+
+    const limit = Math.min(100, Math.max(1, Math.floor(args.limit)));
+    const interactions = await ctx.db
+      .query("prospectInteractions")
+      .withIndex("by_user_prospect_replied", (q) =>
+        q.eq("userId", args.userId).eq("prospectId", args.prospectId)
+      )
+      .order("desc")
+      .take(limit);
+
+    return args.platform === "all"
+      ? interactions
+      : interactions.filter(
+          (interaction) => interaction.platform === args.platform
+        );
+  },
+});
+
 export const upsertProspectInteractionSyncStateInternal = internalMutation({
   args: {
     userId: v.id("users"),
@@ -296,6 +326,8 @@ export const getProspectInteractionsPage = query({
           platform: interaction.platform,
           interactionType: interaction.interactionType,
           threadId: interaction.threadId,
+          sourcePostId: interaction.sourcePostId,
+          replyPostId: interaction.replyPostId,
           repliedAt: interaction.repliedAt,
           originalPost: originalSummary
             ? toFallbackTweetFromSummary(originalSummary)

--- a/convex/interactionsActions.ts
+++ b/convex/interactionsActions.ts
@@ -12,11 +12,41 @@ import {
   summarizeTwitterPost,
 } from "../shared/lib/twitter/contracts";
 import { resolveProspectTwitterIdentity } from "../shared/lib/twitter/prospectTwitterIdentity";
-import { getCurrentUTCTimestamp } from "../shared/lib/utils/time/timeUtils";
+import {
+  getCurrentUTCTimestamp,
+  parseIsoToTimestamp,
+} from "../shared/lib/utils/time/timeUtils";
 import { getXConnectionStatusForUser } from "./lib/xdkAuth";
+import {
+  listLinkedInPostComments,
+  listLinkedInUserComments,
+  listLinkedInUserPosts,
+  type LinkedInUnipileComment,
+  type LinkedInUnipilePost,
+} from "./lib/unipileClient";
+import { resolveLinkedInProspectProfileIdentifiers } from "./integrations/linkedin/profileIdentity";
+import {
+  getNestedRecord,
+  getNumberProperty,
+  getStringProperty,
+  isRecord,
+} from "./lib/typeGuards";
+import {
+  buildTwitterInteractionSearchQueries,
+  getLinkedInCommentAuthorIdentifiers,
+  getLinkedInPostIdentifiers,
+  getStoredLinkedInInteractionCandidateMetadata,
+  isReciprocalTwitterReply,
+  normalizeLinkedInActorIdentifier,
+} from "./lib/prospectInteractionSyncCore";
 
 const SOCIALAPI_BASE_URL = "https://api.socialapi.me";
 const INTERACTION_REFRESH_COOLDOWN_MS = 60_000;
+const SOCIALAPI_SEARCH_PAGE_LIMIT = 2;
+const SOCIALAPI_TIMELINE_PAGE_LIMIT = 2;
+const LINKEDIN_PAGE_LIMIT = 100;
+const LINKEDIN_MAX_PAGES = 3;
+const LINKEDIN_REPLY_THREAD_LIMIT = 30;
 
 type SocialApiSearchResponse = {
   next_cursor?: string;
@@ -32,6 +62,23 @@ type ProspectInteractionRefreshResult = {
   trackingStartedAt: number;
   lastSuccessAt: number | null;
   skipped: boolean;
+};
+
+type LinkedInInteractionCandidate = {
+  commentId: string;
+  postId: string;
+  text: string;
+  createdAt: number;
+  replyCount?: number;
+  interactionType: "comment_posted" | "comment_reply_posted";
+  direction: "outgoing";
+  sourcePostData?: unknown;
+  sourceUrl?: string;
+};
+
+type SocialApiSearchPage = {
+  tweets: unknown[];
+  nextCursor?: string;
 };
 
 function normalizeHandle(value?: string | null): string | undefined {
@@ -176,7 +223,8 @@ function buildParticipants(args: {
 async function searchSocialApiTweets(args: {
   ctx: ActionCtx;
   query: string;
-}): Promise<unknown[]> {
+  cursor?: string;
+}): Promise<SocialApiSearchPage> {
   const apiKey = process.env.SOCIALAPI_API_KEY;
   if (!apiKey) {
     throw new Error("SOCIALAPI_API_KEY is not set");
@@ -186,6 +234,9 @@ async function searchSocialApiTweets(args: {
     query: args.query,
     type: "Latest",
   });
+  if (args.cursor) {
+    params.set("cursor", args.cursor);
+  }
   const response = await fetchSocialApi(
     args.ctx,
     "interactions.searchSocialApiTweets",
@@ -203,10 +254,182 @@ async function searchSocialApiTweets(args: {
     throw new Error(payload.message ?? `HTTP ${response.status}`);
   }
 
-  return Array.isArray(payload.tweets) ? payload.tweets : [];
+  return {
+    tweets: Array.isArray(payload.tweets) ? payload.tweets : [],
+    nextCursor:
+      typeof payload.next_cursor === "string" && payload.next_cursor.length > 0
+        ? payload.next_cursor
+        : undefined,
+  };
 }
 
-export const runProspectInteractionDiscovery = internalAction({
+async function searchSocialApiTweetPages(args: {
+  ctx: ActionCtx;
+  query: string;
+}): Promise<unknown[]> {
+  const tweets: unknown[] = [];
+  let cursor: string | undefined;
+
+  for (
+    let pageIndex = 0;
+    pageIndex < SOCIALAPI_SEARCH_PAGE_LIMIT;
+    pageIndex++
+  ) {
+    const page = await searchSocialApiTweets({ ...args, cursor });
+    tweets.push(...page.tweets);
+    if (!page.nextCursor || page.nextCursor === cursor) {
+      break;
+    }
+    cursor = page.nextCursor;
+  }
+
+  return tweets;
+}
+
+async function listSocialApiUserTweetReplyPages(args: {
+  ctx: ActionCtx;
+  xUserId: string;
+}): Promise<unknown[]> {
+  const apiKey = process.env.SOCIALAPI_API_KEY;
+  if (!apiKey) {
+    throw new Error("SOCIALAPI_API_KEY is not set");
+  }
+
+  const tweets: unknown[] = [];
+  let cursor: string | undefined;
+
+  for (
+    let pageIndex = 0;
+    pageIndex < SOCIALAPI_TIMELINE_PAGE_LIMIT;
+    pageIndex++
+  ) {
+    const url = new URL(
+      `${SOCIALAPI_BASE_URL}/twitter/user/${args.xUserId}/tweets-and-replies`
+    );
+    if (cursor) {
+      url.searchParams.set("cursor", cursor);
+    }
+
+    const response = await fetchSocialApi(
+      args.ctx,
+      "interactions.listSocialApiUserTweetReplies",
+      url,
+      {
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          Accept: "application/json",
+        },
+      }
+    );
+    const payload = (await response.json()) as SocialApiSearchResponse;
+    if (!response.ok) {
+      throw new Error(payload.message ?? `HTTP ${response.status}`);
+    }
+
+    tweets.push(...(Array.isArray(payload.tweets) ? payload.tweets : []));
+    const nextCursor =
+      typeof payload.next_cursor === "string" && payload.next_cursor.length > 0
+        ? payload.next_cursor
+        : undefined;
+    if (!nextCursor || nextCursor === cursor) {
+      break;
+    }
+    cursor = nextCursor;
+  }
+
+  return tweets;
+}
+
+function getLinkedInCommentTimestamp(comment: LinkedInUnipileComment): number {
+  return comment.date
+    ? (parseIsoToTimestamp(comment.date) ?? getCurrentUTCTimestamp())
+    : getCurrentUTCTimestamp();
+}
+
+async function listLinkedInUserPostPages(args: {
+  accountId: string;
+  userId: string;
+}): Promise<LinkedInUnipilePost[]> {
+  const posts: LinkedInUnipilePost[] = [];
+  let cursor: string | undefined;
+
+  for (let pageIndex = 0; pageIndex < LINKEDIN_MAX_PAGES; pageIndex++) {
+    const page = await listLinkedInUserPosts({
+      ...args,
+      cursor,
+      limit: LINKEDIN_PAGE_LIMIT,
+    });
+    const pageItems = Array.isArray(page.items) ? page.items : [];
+    posts.push(...pageItems);
+    if (pageItems.length < LINKEDIN_PAGE_LIMIT) {
+      break;
+    }
+    if (!page.cursor || page.cursor === cursor) {
+      break;
+    }
+    cursor = page.cursor;
+  }
+
+  return posts;
+}
+
+async function listLinkedInUserCommentPages(args: {
+  accountId: string;
+  userId: string;
+}): Promise<LinkedInUnipileComment[]> {
+  const comments: LinkedInUnipileComment[] = [];
+  let cursor: string | undefined;
+
+  for (let pageIndex = 0; pageIndex < LINKEDIN_MAX_PAGES; pageIndex++) {
+    const page = await listLinkedInUserComments({
+      ...args,
+      cursor,
+      limit: LINKEDIN_PAGE_LIMIT,
+    });
+    const pageItems = Array.isArray(page.items) ? page.items : [];
+    comments.push(...pageItems);
+    if (pageItems.length < LINKEDIN_PAGE_LIMIT) {
+      break;
+    }
+    if (!page.cursor || page.cursor === cursor) {
+      break;
+    }
+    cursor = page.cursor;
+  }
+
+  return comments;
+}
+
+async function listLinkedInCommentReplyPages(args: {
+  accountId: string;
+  postId: string;
+  commentId: string;
+}): Promise<LinkedInUnipileComment[]> {
+  const comments: LinkedInUnipileComment[] = [];
+  let cursor: string | undefined;
+
+  for (let pageIndex = 0; pageIndex < LINKEDIN_MAX_PAGES; pageIndex++) {
+    const page = await listLinkedInPostComments({
+      ...args,
+      cursor,
+      limit: LINKEDIN_PAGE_LIMIT,
+      sortBy: "MOST_RECENT",
+    });
+    const pageItems = Array.isArray(page.items) ? page.items : [];
+    comments.push(...pageItems);
+    if (pageItems.length < LINKEDIN_PAGE_LIMIT) {
+      break;
+    }
+    if (!page.cursor || page.cursor === cursor) {
+      break;
+    }
+    cursor = page.cursor;
+  }
+
+  return comments;
+}
+
+export const runTwitterProspectInteractionDiscovery = internalAction({
   args: {
     userId: v.id("users"),
     prospectId: v.id("prospects"),
@@ -238,7 +461,7 @@ export const runProspectInteractionDiscovery = internalAction({
     const trackingStartedAt =
       connectionStatus.connectedAt ??
       existingSyncState?.trackingStartedAt ??
-      Date.now();
+      getCurrentUTCTimestamp();
 
     if (!connectionStatus.isConnected || !connectionStatus.screenName) {
       return {
@@ -257,7 +480,7 @@ export const runProspectInteractionDiscovery = internalAction({
       throw new Error("Prospect or viewer handle is unavailable.");
     }
 
-    const now = Date.now();
+    const now = getCurrentUTCTimestamp();
 
     if (
       !args.force &&
@@ -286,16 +509,51 @@ export const runProspectInteractionDiscovery = internalAction({
 
     const checkpoint = getSyncCheckpoint(existingSyncState, trackingStartedAt);
     const sinceTime = buildSinceTimeOperator(checkpoint);
-    const outgoingQuery = `from:${viewerHandle} @${prospectHandle} ${sinceTime}`;
-    const incomingQuery = `from:${prospectHandle} @${viewerHandle} ${sinceTime}`;
+    const { outgoing: outgoingQuery, incoming: incomingQuery } =
+      buildTwitterInteractionSearchQueries({
+        viewerHandle,
+        prospectHandle,
+        sinceTimeOperator: sinceTime,
+      });
 
     try {
       const [outgoingTweets, incomingTweets] = await Promise.all([
-        searchSocialApiTweets({ ctx, query: outgoingQuery }),
-        searchSocialApiTweets({ ctx, query: incomingQuery }),
+        searchSocialApiTweetPages({ ctx, query: outgoingQuery }),
+        searchSocialApiTweetPages({ ctx, query: incomingQuery }),
       ]);
 
-      const allTweets = [...outgoingTweets, ...incomingTweets];
+      const prospectXUserId = prospectIdentity.userId;
+      const shouldCheckProspectTimeline =
+        incomingTweets.length === 0 &&
+        Boolean(prospectXUserId) &&
+        outgoingTweets.some(
+          (tweet) =>
+            isRecord(tweet) &&
+            (getNumberProperty(tweet, "reply_count") ?? 0) > 0
+        );
+      const prospectTimelineTweets =
+        shouldCheckProspectTimeline && prospectXUserId
+          ? await listSocialApiUserTweetReplyPages({
+              ctx,
+              xUserId: prospectXUserId,
+            })
+          : [];
+
+      const reciprocalTimelineTweets = prospectTimelineTweets.filter((tweet) =>
+        isReciprocalTwitterReply({
+          tweet,
+          viewerHandle,
+          viewerUserId: connectionStatus.xUserId,
+          prospectHandle,
+          prospectUserId: prospectIdentity.userId,
+        })
+      );
+
+      const allTweets = [
+        ...outgoingTweets,
+        ...incomingTweets,
+        ...reciprocalTimelineTweets,
+      ];
       const seenReplyIds = new Set<string>();
       let createdCount = 0;
       let newestCreatedAt = existingSyncState?.lastSeenCreatedAt ?? checkpoint;
@@ -393,6 +651,239 @@ export const runProspectInteractionDiscovery = internalAction({
       );
       throw error;
     }
+  },
+});
+
+export const runLinkedInProspectInteractionDiscovery = internalAction({
+  args: {
+    userId: v.id("users"),
+    prospectId: v.id("prospects"),
+  },
+  handler: async (ctx, args): Promise<ProspectInteractionRefreshResult> => {
+    const prospect: Doc<"prospects"> | null = await ctx.runQuery(
+      internal.prospects.getProspectInternal,
+      { prospectId: args.prospectId }
+    );
+    if (
+      !prospect ||
+      prospect.userId !== args.userId ||
+      prospect.platform !== "linkedin"
+    ) {
+      throw new Error("LinkedIn prospect not found");
+    }
+
+    const account: Doc<"linkedinAccounts"> | null = await ctx.runQuery(
+      internal.linkedinStore.getLinkedInAccountForUserInternal,
+      { userId: args.userId }
+    );
+    if (!account?.accountId || !account.providerId) {
+      throw new Error("Connect LinkedIn before syncing public interactions.");
+    }
+
+    const prospectIdentity = resolveLinkedInProspectProfileIdentifiers(
+      prospect as unknown as Record<string, unknown>
+    );
+    if (!prospectIdentity.profileUrn) {
+      throw new Error("This prospect is missing a LinkedIn provider id.");
+    }
+
+    const now = getCurrentUTCTimestamp();
+    const [prospectPosts, viewerComments, storedInteractions] =
+      await Promise.all([
+        listLinkedInUserPostPages({
+          accountId: account.accountId,
+          userId: prospectIdentity.profileUrn,
+        }),
+        listLinkedInUserCommentPages({
+          accountId: account.accountId,
+          userId: account.providerId,
+        }),
+        ctx.runQuery(internal.interactions.getProspectInteractionsInternal, {
+          userId: args.userId,
+          prospectId: args.prospectId,
+          platform: "linkedin",
+          limit: LINKEDIN_REPLY_THREAD_LIMIT,
+        }),
+      ]);
+
+    const sourcePostsById = new Map<string, LinkedInUnipilePost>();
+    for (const post of prospectPosts) {
+      for (const postId of getLinkedInPostIdentifiers(post)) {
+        sourcePostsById.set(postId, post);
+      }
+    }
+
+    const candidates = new Map<string, LinkedInInteractionCandidate>();
+    for (const comment of viewerComments) {
+      const sourcePost = sourcePostsById.get(comment.post_id);
+      if (!sourcePost || !comment.id) {
+        continue;
+      }
+      candidates.set(comment.id, {
+        commentId: comment.id,
+        postId: comment.post_id,
+        text: comment.text?.trim() ?? "",
+        createdAt: getLinkedInCommentTimestamp(comment),
+        replyCount: comment.reply_counter,
+        interactionType: "comment_posted",
+        direction: "outgoing",
+        sourcePostData: sourcePost,
+        sourceUrl: sourcePost.share_url,
+      });
+    }
+
+    for (const interaction of storedInteractions) {
+      const metadata = getStoredLinkedInInteractionCandidateMetadata({
+        interactionType: interaction.interactionType,
+        direction: interaction.direction,
+      });
+      if (!metadata || candidates.has(interaction.replyPostId)) {
+        continue;
+      }
+      candidates.set(interaction.replyPostId, {
+        commentId: interaction.replyPostId,
+        postId: interaction.sourcePostId,
+        text: interaction.replyText ?? "",
+        createdAt: interaction.repliedAt,
+        sourcePostData: interaction.sourcePostData,
+        sourceUrl: interaction.sourceUrl,
+        ...metadata,
+      });
+    }
+
+    const prospectActorIds = new Set(
+      [prospectIdentity.profileUrn, prospectIdentity.username]
+        .map(normalizeLinkedInActorIdentifier)
+        .filter((value): value is string => Boolean(value))
+    );
+    const prospectAuthor = getNestedRecord(
+      getNestedRecord(prospect, "data"),
+      "author"
+    );
+    const participants = [
+      {
+        id: prospectIdentity.profileUrn,
+        handle: prospectIdentity.username,
+        name: prospect.displayName ?? prospectIdentity.username,
+        avatarUrl: getStringProperty(prospectAuthor, "profilePictureURL"),
+      },
+      {
+        id: account.providerId,
+        handle: account.publicIdentifier ?? account.username,
+        name: account.displayName ?? "You",
+        avatarUrl: account.profileImageUrl,
+        isViewer: true,
+      },
+    ];
+
+    let syncedCount = 0;
+    for (const candidate of candidates.values()) {
+      await ctx.runMutation(
+        internal.interactions.upsertLinkedInCommentInteractionInternal,
+        {
+          userId: args.userId,
+          prospectId: args.prospectId,
+          sourcePostId: candidate.postId,
+          replyPostId: candidate.commentId,
+          threadId: candidate.postId,
+          sourcePostData: candidate.sourcePostData,
+          sourceUrl: candidate.sourceUrl,
+          replyText: candidate.text,
+          interactionType: candidate.interactionType,
+          origin: "unknown",
+          discoveredVia: "live_reconcile",
+          status: "active",
+          direction: candidate.direction,
+          discoveredAt: candidate.createdAt,
+          lastSeenAt: now,
+          participants,
+        }
+      );
+      syncedCount++;
+    }
+
+    const replyCandidates = Array.from(candidates.values())
+      .filter((candidate) => candidate.replyCount !== 0)
+      .slice(0, LINKEDIN_REPLY_THREAD_LIMIT);
+    for (const candidate of replyCandidates) {
+      const replies = await listLinkedInCommentReplyPages({
+        accountId: account.accountId,
+        postId: candidate.postId,
+        commentId: candidate.commentId,
+      });
+
+      for (const reply of replies) {
+        const isProspectReply = getLinkedInCommentAuthorIdentifiers(reply).some(
+          (identifier) => prospectActorIds.has(identifier)
+        );
+        if (!isProspectReply || !reply.id) {
+          continue;
+        }
+
+        const repliedAt = getLinkedInCommentTimestamp(reply);
+        await ctx.runMutation(
+          internal.interactions.upsertLinkedInCommentInteractionInternal,
+          {
+            userId: args.userId,
+            prospectId: args.prospectId,
+            sourcePostId: candidate.postId,
+            replyPostId: reply.id,
+            threadId: candidate.postId,
+            sourcePostData: candidate.sourcePostData,
+            sourceUrl: candidate.sourceUrl,
+            replyText: reply.text?.trim() ?? "",
+            interactionType: "comment_reply_posted",
+            origin: "unknown",
+            discoveredVia: "live_reconcile",
+            status: "active",
+            direction: "incoming",
+            discoveredAt: repliedAt,
+            lastSeenAt: now,
+            participants,
+          }
+        );
+        syncedCount++;
+      }
+    }
+
+    return {
+      createdCount: syncedCount,
+      trackingStartedAt: now,
+      lastSuccessAt: now,
+      skipped: false,
+    };
+  },
+});
+
+export const runProspectInteractionDiscovery = internalAction({
+  args: {
+    userId: v.id("users"),
+    prospectId: v.id("prospects"),
+    force: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args): Promise<ProspectInteractionRefreshResult> => {
+    const prospect = await ctx.runQuery(
+      internal.prospects.getProspectInternal,
+      { prospectId: args.prospectId }
+    );
+    if (!prospect || prospect.userId !== args.userId) {
+      throw new Error("Prospect not found");
+    }
+
+    if (prospect.platform === "linkedin") {
+      return await ctx.runAction(
+        internal.interactionsActions.runLinkedInProspectInteractionDiscovery,
+        {
+          userId: args.userId,
+          prospectId: args.prospectId,
+        }
+      );
+    }
+
+    return await ctx.runAction(
+      internal.interactionsActions.runTwitterProspectInteractionDiscovery,
+      args
+    );
   },
 });
 

--- a/convex/lib/prospectInteractionSyncCore.test.ts
+++ b/convex/lib/prospectInteractionSyncCore.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildTwitterInteractionSearchQueries,
+  getLinkedInCommentAuthorIdentifiers,
+  getLinkedInPostIdentifiers,
+  getStoredLinkedInInteractionCandidateMetadata,
+  isReciprocalTwitterReply,
+  normalizeLinkedInActorIdentifier,
+} from "./prospectInteractionSyncCore";
+
+describe("prospect interaction sync core", () => {
+  test("builds reciprocal X reply searches scoped to both people", () => {
+    expect(
+      buildTwitterInteractionSearchQueries({
+        viewerHandle: "owner",
+        prospectHandle: "prospect",
+        sinceTimeOperator: "since_time:1700000000",
+      })
+    ).toEqual({
+      outgoing: "from:owner to:prospect filter:replies since_time:1700000000",
+      incoming: "from:prospect to:owner filter:replies since_time:1700000000",
+    });
+  });
+
+  test("matches LinkedIn actors across provider URNs and profile URLs", () => {
+    expect(
+      normalizeLinkedInActorIdentifier(
+        "urn:li:fsd_profile:ACoAAExampleIdentifier"
+      )
+    ).toBe("acoaaexampleidentifier");
+    expect(
+      getLinkedInCommentAuthorIdentifiers({
+        id: "comment-1",
+        post_id: "post-1",
+        author_details: {
+          id: "ACoAAExampleIdentifier",
+          profile_url: "https://www.linkedin.com/in/example-user/",
+        },
+      })
+    ).toEqual(["acoaaexampleidentifier", "example-user"]);
+  });
+
+  test("indexes both Unipile post id forms used by comment payloads", () => {
+    expect(
+      getLinkedInPostIdentifiers({
+        provider: "LINKEDIN",
+        id: "encoded-post-id",
+        social_id: "urn:li:activity:123",
+      })
+    ).toEqual(["encoded-post-id", "urn:li:activity:123"]);
+  });
+
+  test("keeps only reciprocal replies from an X user timeline", () => {
+    const shared = {
+      viewerHandle: "Owner",
+      viewerUserId: "viewer-1",
+      prospectHandle: "Prospect",
+      prospectUserId: "prospect-1",
+    };
+
+    expect(
+      isReciprocalTwitterReply({
+        ...shared,
+        tweet: {
+          user: { id_str: "prospect-1", screen_name: "prospect" },
+          in_reply_to_status_id_str: "parent-1",
+          in_reply_to_user_id_str: "viewer-1",
+          in_reply_to_screen_name: "OWNER",
+        },
+      })
+    ).toBe(true);
+    expect(
+      isReciprocalTwitterReply({
+        ...shared,
+        tweet: {
+          user: { id_str: "stranger-1", screen_name: "stranger" },
+          in_reply_to_status_id_str: "parent-2",
+          in_reply_to_user_id_str: "prospect-1",
+          in_reply_to_screen_name: "prospect",
+        },
+      })
+    ).toBe(false);
+    expect(
+      isReciprocalTwitterReply({
+        ...shared,
+        tweet: {
+          user: { id_str: "prospect-1", screen_name: "prospect" },
+          in_reply_to_user_id_str: null,
+          in_reply_to_screen_name: null,
+        },
+      })
+    ).toBe(false);
+  });
+
+  test("does not rebuild incoming LinkedIn replies as outgoing comments", () => {
+    expect(
+      getStoredLinkedInInteractionCandidateMetadata({
+        interactionType: "comment_reply_posted",
+        direction: "incoming",
+      })
+    ).toBeNull();
+    expect(
+      getStoredLinkedInInteractionCandidateMetadata({
+        interactionType: "comment_reply_posted",
+        direction: "outgoing",
+      })
+    ).toEqual({
+      interactionType: "comment_reply_posted",
+      direction: "outgoing",
+    });
+  });
+});

--- a/convex/lib/prospectInteractionSyncCore.ts
+++ b/convex/lib/prospectInteractionSyncCore.ts
@@ -1,0 +1,135 @@
+import { extractLinkedInUsername } from "../../shared/lib/utils/url/socialProfiles";
+import type {
+  LinkedInUnipileComment,
+  LinkedInUnipilePost,
+} from "./unipileClient";
+
+export type StoredLinkedInInteractionCandidateMetadata = {
+  interactionType: "comment_posted" | "comment_reply_posted";
+  direction: "outgoing";
+};
+
+export function getStoredLinkedInInteractionCandidateMetadata(interaction: {
+  interactionType?: string;
+  direction?: "incoming" | "outgoing";
+}): StoredLinkedInInteractionCandidateMetadata | null {
+  if (interaction.direction === "incoming") {
+    return null;
+  }
+
+  return {
+    interactionType:
+      interaction.interactionType === "comment_reply_posted"
+        ? "comment_reply_posted"
+        : "comment_posted",
+    direction: "outgoing",
+  };
+}
+
+export function getLinkedInPostIdentifiers(
+  post: LinkedInUnipilePost
+): string[] {
+  return [post.id, post.social_id].filter(
+    (value): value is string =>
+      typeof value === "string" && value.trim().length > 0
+  );
+}
+
+export function normalizeLinkedInActorIdentifier(
+  value?: string | null
+): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  return trimmed
+    .replace(/^urn:li:(?:fsd_profile|member):/i, "")
+    .replace(/^https?:\/\/(?:www\.)?linkedin\.com\/in\//i, "")
+    .replace(/\/$/, "")
+    .toLowerCase();
+}
+
+export function getLinkedInCommentAuthorIdentifiers(
+  comment: LinkedInUnipileComment
+): string[] {
+  const profileUrl = comment.author_details?.profile_url;
+  return [
+    comment.author_details?.id,
+    profileUrl ? extractLinkedInUsername(profileUrl) : undefined,
+  ]
+    .map(normalizeLinkedInActorIdentifier)
+    .filter((value): value is string => Boolean(value));
+}
+
+export function buildTwitterInteractionSearchQueries(args: {
+  viewerHandle: string;
+  prospectHandle: string;
+  sinceTimeOperator: string;
+}) {
+  return {
+    outgoing: `from:${args.viewerHandle} to:${args.prospectHandle} filter:replies ${args.sinceTimeOperator}`,
+    incoming: `from:${args.prospectHandle} to:${args.viewerHandle} filter:replies ${args.sinceTimeOperator}`,
+  };
+}
+
+function normalizeTwitterIdentifier(value?: string | null) {
+  return value?.trim().replace(/^@/, "").toLowerCase() || undefined;
+}
+
+export function isReciprocalTwitterReply(args: {
+  tweet: unknown;
+  viewerHandle: string;
+  viewerUserId?: string;
+  prospectHandle: string;
+  prospectUserId?: string;
+}) {
+  if (!args.tweet || typeof args.tweet !== "object") {
+    return false;
+  }
+
+  const tweet = args.tweet as Record<string, unknown>;
+  const user =
+    tweet.user && typeof tweet.user === "object"
+      ? (tweet.user as Record<string, unknown>)
+      : undefined;
+  const authorHandle = normalizeTwitterIdentifier(
+    typeof user?.screen_name === "string" ? user.screen_name : undefined
+  );
+  const authorUserId =
+    typeof user?.id_str === "string" ? user.id_str.trim() : undefined;
+  const targetHandle = normalizeTwitterIdentifier(
+    typeof tweet.in_reply_to_screen_name === "string"
+      ? tweet.in_reply_to_screen_name
+      : undefined
+  );
+  const targetUserId =
+    typeof tweet.in_reply_to_user_id_str === "string"
+      ? tweet.in_reply_to_user_id_str.trim()
+      : undefined;
+  const parentPostId =
+    typeof tweet.in_reply_to_status_id_str === "string"
+      ? tweet.in_reply_to_status_id_str.trim()
+      : undefined;
+
+  if (!parentPostId) {
+    return false;
+  }
+
+  const viewerHandle = normalizeTwitterIdentifier(args.viewerHandle);
+  const prospectHandle = normalizeTwitterIdentifier(args.prospectHandle);
+  const isViewer =
+    authorHandle === viewerHandle ||
+    Boolean(args.viewerUserId && authorUserId === args.viewerUserId);
+  const isProspect =
+    authorHandle === prospectHandle ||
+    Boolean(args.prospectUserId && authorUserId === args.prospectUserId);
+  const targetsViewer =
+    targetHandle === viewerHandle ||
+    Boolean(args.viewerUserId && targetUserId === args.viewerUserId);
+  const targetsProspect =
+    targetHandle === prospectHandle ||
+    Boolean(args.prospectUserId && targetUserId === args.prospectUserId);
+
+  return (isViewer && targetsProspect) || (isProspect && targetsViewer);
+}

--- a/convex/lib/unipileClient.ts
+++ b/convex/lib/unipileClient.ts
@@ -292,6 +292,12 @@ export type LinkedInUnipileCommentList = {
   };
 };
 
+export type LinkedInUnipilePostList = {
+  object?: "PostList";
+  items: LinkedInUnipilePost[];
+  cursor: string | null;
+};
+
 type UnipileClientConfig = {
   baseUrl: string;
   apiKey: string;
@@ -1037,6 +1043,44 @@ export async function getLinkedInPost(args: {
       method: "GET",
       query: {
         account_id: args.accountId,
+      },
+    }
+  );
+}
+
+export async function listLinkedInUserPosts(args: {
+  accountId: string;
+  userId: string;
+  cursor?: string;
+  limit?: number;
+}) {
+  return await requestUnipile<LinkedInUnipilePostList>(
+    `/api/v1/users/${encodeURIComponent(args.userId)}/posts`,
+    {
+      method: "GET",
+      query: {
+        account_id: args.accountId,
+        cursor: args.cursor,
+        limit: args.limit,
+      },
+    }
+  );
+}
+
+export async function listLinkedInUserComments(args: {
+  accountId: string;
+  userId: string;
+  cursor?: string;
+  limit?: number;
+}) {
+  return await requestUnipile<LinkedInUnipileCommentList>(
+    `/api/v1/users/${encodeURIComponent(args.userId)}/comments`,
+    {
+      method: "GET",
+      query: {
+        account_id: args.accountId,
+        cursor: args.cursor,
+        limit: args.limit,
       },
     }
   );

--- a/convex/x.ts
+++ b/convex/x.ts
@@ -103,7 +103,10 @@ import {
   getDmTextLimitError,
   hasDmBody,
 } from "../shared/lib/twitter/xPostTextLimit";
-import { resolveProspectTwitterIdentity } from "../shared/lib/twitter/prospectTwitterIdentity";
+import {
+  buildTwitterReplyInteractionParticipants,
+  resolveProspectTwitterIdentity,
+} from "../shared/lib/twitter/prospectTwitterIdentity";
 
 const xLogger = logger.withScope("X/Twitter");
 
@@ -1953,11 +1956,20 @@ export const replyToPost = action({
     mediaUrls: v.optional(v.array(v.string())),
     mediaDescriptions: v.optional(v.array(v.string())),
     parentAuthorId: v.optional(v.string()),
+    parentAuthorHandle: v.optional(v.string()),
+    prospectId: v.optional(v.id("prospects")),
+    conversationId: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const mediaUrls = normalizeMediaUrls(args.mediaUrls);
     assertValidMediaDescriptions(mediaUrls, args.mediaDescriptions);
     const userId = await getCurrentUserId(ctx);
+    const prospect = args.prospectId
+      ? await getOwnedTwitterProspectForUser(ctx, userId, args.prospectId)
+      : null;
+    if (args.prospectId && !prospect) {
+      throw new Error("X prospect not found or not authorized.");
+    }
     const postLimit = await ctx.runQuery(
       internal.xPostLimits.getEffectivePostLimitInternal,
       { userId }
@@ -1968,8 +1980,9 @@ export const replyToPost = action({
       userId,
       requiredScopes: entry.requiredScopes,
     });
+    let result;
     try {
-      const result = await executeCuratedTwitterAction(provider, {
+      result = await executeCuratedTwitterAction(provider, {
         actionKey: "reply_to_post",
         toolSlug: entry.toolSlug,
         toolVersion: entry.toolVersion,
@@ -1978,6 +1991,11 @@ export const replyToPost = action({
         mediaUrls,
         mediaDescriptions: args.mediaDescriptions,
       });
+    } catch (error) {
+      throw await handleDirectXWriteActionError(ctx, userId, error);
+    }
+
+    try {
       await ctx.runMutation(
         internal.twitterEngagement.upsertPostEngagementInternal,
         {
@@ -1994,10 +2012,68 @@ export const replyToPost = action({
         message: args.text.trim(),
         actionId: result.createdTweetId ?? args.tweetId,
       });
-      return result;
     } catch (error) {
-      throw await handleDirectXWriteActionError(ctx, userId, error);
+      console.error("[XReplyToPost] Failed to record local engagement", error);
     }
+
+    if (prospect && result.createdTweetId) {
+      try {
+        const now = getCurrentUTCTimestamp();
+        const prospectIdentity = resolveProspectTwitterIdentity(
+          prospect as Record<string, unknown>
+        );
+        const conversationId = args.conversationId?.trim() || args.tweetId;
+        await ctx.runMutation(internal.outreach.upsertTwitterInteraction, {
+          userId,
+          prospectId: prospect._id,
+          sourcePostRef: {
+            platform: "twitter",
+            postId: args.tweetId,
+            conversationId,
+            authorId: args.parentAuthorId,
+            authorHandle: args.parentAuthorHandle,
+          },
+          replyPostRef: {
+            platform: "twitter",
+            postId: result.createdTweetId,
+            conversationId,
+          },
+          replyPostSummary: {
+            platform: "twitter",
+            ref: {
+              platform: "twitter",
+              postId: result.createdTweetId,
+              conversationId,
+            },
+            url: `https://x.com/i/status/${result.createdTweetId}`,
+            textPreview: args.text.trim(),
+            createdAt: now,
+            inReplyToPostId: args.tweetId,
+            inReplyToHandle: args.parentAuthorHandle,
+          },
+          threadId: conversationId,
+          repliedAt: now,
+          origin: "manual_reacherx",
+          discoveredVia: "action_request",
+          status: "active",
+          direction: "outgoing",
+          discoveredAt: now,
+          lastSeenAt: now,
+          participants: buildTwitterReplyInteractionParticipants({
+            prospect: prospectIdentity,
+            parentAuthorId: args.parentAuthorId,
+            parentAuthorHandle: args.parentAuthorHandle,
+          }),
+        });
+      } catch (error) {
+        console.error(
+          "[XReplyToPost] Failed to record prospect interaction",
+          error
+        );
+      }
+    }
+
+    return result;
   },
 });
 

--- a/features/prospects/lib/prospectInteractionThreads.test.ts
+++ b/features/prospects/lib/prospectInteractionThreads.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it } from "vitest";
+import type { ProspectInteraction } from "@/features/prospects/types";
+import {
+  buildTwitterInteractionThreadFallbackTweets,
+  groupProspectInteractionsByThread,
+} from "./prospectInteractionThreads";
+import {
+  dedupeAndSortConversationTweets,
+  mergeConversationTweetWithFallback,
+  mergeConversationTweetsPreservingOrder,
+} from "./twitterConversation";
+
+function interaction(
+  overrides: Partial<ProspectInteraction> & Pick<ProspectInteraction, "id">
+): ProspectInteraction {
+  return {
+    platform: "twitter",
+    originalPost: null,
+    participants: [],
+    threadId: "thread-1",
+    repliedAt: 1,
+    origin: "unknown",
+    discoveredVia: "live_reconcile",
+    ...overrides,
+  };
+}
+
+describe("groupProspectInteractionsByThread", () => {
+  it("renders reciprocal replies as one canonical thread", () => {
+    const threads = groupProspectInteractionsByThread(
+      [
+        interaction({
+          id: "incoming",
+          repliedAt: 3,
+          direction: "incoming",
+          sourcePostRef: { platform: "twitter", postId: "owner-reply" },
+        }),
+        interaction({
+          id: "outgoing",
+          repliedAt: 2,
+          direction: "outgoing",
+          sourcePostRef: { platform: "twitter", postId: "thread-1" },
+        }),
+      ],
+      "twitter"
+    );
+
+    expect(threads).toHaveLength(1);
+    expect(threads[0].interactions.map((item) => item.id)).toEqual([
+      "outgoing",
+      "incoming",
+    ]);
+    expect(threads[0].representative.id).toBe("outgoing");
+  });
+
+  it("normalizes equivalent LinkedIn post URNs", () => {
+    const threads = groupProspectInteractionsByThread(
+      [
+        interaction({
+          id: "first",
+          platform: "linkedin",
+          threadId: "urn:li:activity:123",
+        }),
+        interaction({
+          id: "second",
+          platform: "linkedin",
+          threadId: "123",
+        }),
+      ],
+      "linkedin"
+    );
+
+    expect(threads).toHaveLength(1);
+    expect(threads[0].threadId).toBe("123");
+  });
+});
+
+describe("buildTwitterInteractionThreadFallbackTweets", () => {
+  it("preserves the entire stored thread once and in chronological order", () => {
+    const [thread] = groupProspectInteractionsByThread(
+      [
+        interaction({
+          id: "outgoing",
+          repliedAt: 2,
+          sourcePostSummary: {
+            platform: "twitter",
+            ref: { platform: "twitter", postId: "root" },
+            url: "https://x.com/prospect/status/root",
+            textPreview: "Root",
+            createdAt: 1,
+          },
+          replyPostSummary: {
+            platform: "twitter",
+            ref: { platform: "twitter", postId: "owner" },
+            url: "https://x.com/owner/status/owner",
+            textPreview: "Owner reply",
+            createdAt: 2,
+          },
+        }),
+        interaction({
+          id: "incoming",
+          repliedAt: 3,
+          sourcePostSummary: {
+            platform: "twitter",
+            ref: { platform: "twitter", postId: "owner" },
+            url: "https://x.com/owner/status/owner",
+            textPreview: "Owner reply",
+            createdAt: 2,
+          },
+          replyPostSummary: {
+            platform: "twitter",
+            ref: { platform: "twitter", postId: "prospect" },
+            url: "https://x.com/prospect/status/prospect",
+            textPreview: "Prospect response",
+            createdAt: 3,
+          },
+        }),
+      ],
+      "twitter"
+    );
+
+    expect(
+      buildTwitterInteractionThreadFallbackTweets(thread).map(
+        (tweet) => tweet.id_str
+      )
+    ).toEqual(["root", "owner", "prospect"]);
+  });
+
+  it("does not let a partial provider payload erase a durable reply", () => {
+    const merged = mergeConversationTweetWithFallback(
+      {
+        id_str: "owner",
+        full_text: "Owner reply",
+        tweet_created_at: "2026-08-27T10:43:00.000Z",
+      },
+      {
+        id_str: "owner",
+        full_text: "",
+        text: "",
+      }
+    );
+
+    expect(merged?.full_text).toBe("Owner reply");
+    expect(merged?.tweet_created_at).toBe("2026-08-27T10:43:00.000Z");
+  });
+
+  it("keeps rich reply snapshots when a later interaction only has a source ref", () => {
+    const [thread] = groupProspectInteractionsByThread(
+      [
+        interaction({
+          id: "outgoing",
+          repliedAt: 2,
+          originalPost: { id_str: "root" },
+          replyPostSummary: {
+            platform: "twitter",
+            ref: { platform: "twitter", postId: "owner" },
+            url: "https://x.com/owner/status/owner",
+            textPreview: "Owner reply",
+            createdAt: 2,
+            inReplyToPostId: "root",
+          },
+        }),
+        interaction({
+          id: "incoming",
+          repliedAt: 3,
+          originalPost: {
+            id_str: "owner",
+            in_reply_to_status_id_str: "root",
+          },
+          replyPostSummary: {
+            platform: "twitter",
+            ref: { platform: "twitter", postId: "prospect" },
+            url: "https://x.com/prospect/status/prospect",
+            textPreview: "Prospect response",
+            createdAt: 3,
+            inReplyToPostId: "owner",
+          },
+        }),
+      ],
+      "twitter"
+    );
+
+    const fallbackTweets = buildTwitterInteractionThreadFallbackTweets(thread);
+
+    expect(fallbackTweets.map((tweet) => tweet.id_str)).toEqual([
+      "root",
+      "owner",
+      "prospect",
+    ]);
+    expect(fallbackTweets[1].full_text).toBe("Owner reply");
+    expect(fallbackTweets[1].tweet_created_at).toBe("1970-01-01T00:00:00.002Z");
+  });
+
+  it("enriches existing posts without changing their rendered order", () => {
+    const stable = dedupeAndSortConversationTweets([
+      { id_str: "root", full_text: "Root" },
+      {
+        id_str: "owner",
+        full_text: "Owner reply",
+        in_reply_to_status_id_str: "root",
+      },
+      {
+        id_str: "prospect",
+        full_text: "Prospect response",
+        tweet_created_at: "2026-08-27T10:44:00.000Z",
+        in_reply_to_status_id_str: "owner",
+      },
+    ]);
+
+    const enriched = mergeConversationTweetsPreservingOrder(stable, [
+      {
+        id_str: "owner",
+        full_text: "Owner reply",
+        tweet_created_at: "2026-08-27T10:43:00.000Z",
+        in_reply_to_status_id_str: "root",
+      },
+      {
+        id_str: "root",
+        full_text: "Root",
+        tweet_created_at: "2026-08-27T10:42:00.000Z",
+      },
+    ]);
+
+    expect(stable.map((tweet) => tweet.id_str)).toEqual([
+      "root",
+      "owner",
+      "prospect",
+    ]);
+    expect(enriched.map((tweet) => tweet.id_str)).toEqual([
+      "root",
+      "owner",
+      "prospect",
+    ]);
+    expect(enriched[1].tweet_created_at).toBe("2026-08-27T10:43:00.000Z");
+  });
+
+  it("keeps provider posts when there is no stable conversation yet", () => {
+    const merged = mergeConversationTweetsPreservingOrder(
+      [],
+      [
+        {
+          id_str: "reply",
+          full_text: "Newly hydrated reply",
+          tweet_created_at: "2026-08-27T10:43:00.000Z",
+          in_reply_to_status_id_str: "root",
+        },
+        {
+          id_str: "root",
+          full_text: "Newly hydrated root",
+          tweet_created_at: "2026-08-27T10:42:00.000Z",
+        },
+      ]
+    );
+
+    expect(merged.map((tweet) => tweet.id_str)).toEqual(["root", "reply"]);
+  });
+});

--- a/features/prospects/lib/prospectInteractionThreads.ts
+++ b/features/prospects/lib/prospectInteractionThreads.ts
@@ -1,0 +1,156 @@
+import type { Tweet } from "@/features/threads/types";
+import type {
+  ProspectInteraction,
+  ProspectInteractionParticipant,
+} from "@/features/prospects/types";
+import { dedupeAndSortConversationTweets } from "./twitterConversation";
+import { normalizeLinkedInReadUrn } from "@/shared/lib/linkedin/comments";
+import { getTwitterPostId } from "@/shared/lib/twitter/contracts";
+import { toFallbackTweetFromSummary } from "@/shared/lib/twitter/ui";
+
+export interface ProspectInteractionThread {
+  id: string;
+  platform: "twitter" | "linkedin";
+  threadId: string;
+  interactions: ProspectInteraction[];
+  representative: ProspectInteraction;
+  participants: ProspectInteractionParticipant[];
+  latestInteractionAt: number;
+}
+
+function getCanonicalThreadId(
+  interaction: ProspectInteraction,
+  platform: "twitter" | "linkedin"
+): string {
+  const rawThreadId =
+    interaction.threadId?.trim() ||
+    interaction.sourcePostRef?.conversationId?.trim() ||
+    interaction.sourcePostRef?.postId?.trim() ||
+    getTwitterPostId(interaction.originalPost)?.trim() ||
+    interaction.id;
+
+  return platform === "linkedin"
+    ? (normalizeLinkedInReadUrn(rawThreadId) ?? rawThreadId)
+    : rawThreadId;
+}
+
+function sourceMatchesThread(
+  interaction: ProspectInteraction,
+  platform: "twitter" | "linkedin",
+  canonicalThreadId: string
+): boolean {
+  if (platform === "linkedin") {
+    return normalizeLinkedInReadUrn(interaction.threadId) === canonicalThreadId;
+  }
+
+  return (
+    interaction.sourcePostRef?.postId === canonicalThreadId ||
+    getTwitterPostId(interaction.originalPost) === canonicalThreadId
+  );
+}
+
+function mergeParticipants(
+  interactions: ProspectInteraction[]
+): ProspectInteractionParticipant[] {
+  const byIdentity = new Map<string, ProspectInteractionParticipant>();
+
+  for (const interaction of interactions) {
+    for (const participant of interaction.participants) {
+      const identity =
+        participant.username.trim().toLowerCase() ||
+        participant.name.trim().toLowerCase();
+      if (identity && !byIdentity.has(identity)) {
+        byIdentity.set(identity, participant);
+      }
+    }
+  }
+
+  return Array.from(byIdentity.values());
+}
+
+export function groupProspectInteractionsByThread(
+  interactions: ProspectInteraction[],
+  fallbackPlatform: "twitter" | "linkedin"
+): ProspectInteractionThread[] {
+  const groups = new Map<
+    string,
+    {
+      platform: "twitter" | "linkedin";
+      threadId: string;
+      interactions: ProspectInteraction[];
+    }
+  >();
+
+  for (const interaction of interactions) {
+    const platform = interaction.platform ?? fallbackPlatform;
+    const threadId = getCanonicalThreadId(interaction, platform);
+    const id = `${platform}:${threadId}`;
+    const existing = groups.get(id);
+
+    if (existing) {
+      existing.interactions.push(interaction);
+    } else {
+      groups.set(id, { platform, threadId, interactions: [interaction] });
+    }
+  }
+
+  return Array.from(groups.entries())
+    .map(([id, group]) => {
+      const orderedInteractions = [...group.interactions].sort(
+        (left, right) => left.repliedAt - right.repliedAt
+      );
+      const representative =
+        orderedInteractions.find((interaction) =>
+          sourceMatchesThread(interaction, group.platform, group.threadId)
+        ) ?? orderedInteractions[0];
+
+      return {
+        id,
+        platform: group.platform,
+        threadId: group.threadId,
+        interactions: orderedInteractions,
+        representative,
+        participants: mergeParticipants(orderedInteractions),
+        latestInteractionAt: Math.max(
+          ...orderedInteractions.map((interaction) => interaction.repliedAt)
+        ),
+      };
+    })
+    .sort(
+      (left, right) => right.latestInteractionAt - left.latestInteractionAt
+    );
+}
+
+export function buildTwitterInteractionThreadFallbackTweets(
+  thread: ProspectInteractionThread
+): Tweet[] {
+  return dedupeAndSortConversationTweets(
+    thread.interactions.flatMap((interaction) => [
+      interaction.originalPost,
+      interaction.sourcePostSummary
+        ? toFallbackTweetFromSummary(interaction.sourcePostSummary)
+        : null,
+      interaction.replyPostSummary
+        ? toFallbackTweetFromSummary(interaction.replyPostSummary)
+        : null,
+    ])
+  );
+}
+
+export function getLinkedInThreadCommentIds(
+  thread: ProspectInteractionThread
+): string[] {
+  return Array.from(
+    new Set(
+      thread.interactions
+        .filter((interaction) => interaction.direction === "outgoing")
+        .map(
+          (interaction) =>
+            interaction.replyPostId ??
+            interaction.replyPostRef?.postId ??
+            interaction.replyPostSummary?.ref.postId
+        )
+        .filter((commentId): commentId is string => Boolean(commentId))
+    )
+  );
+}

--- a/features/prospects/lib/twitterConversation.ts
+++ b/features/prospects/lib/twitterConversation.ts
@@ -1,5 +1,71 @@
 import type { Tweet } from "@/features/threads/types";
 
+function nonEmpty(value: string | null | undefined): string | undefined {
+  return value?.trim() ? value : undefined;
+}
+
+export function mergeConversationTweetWithFallback(
+  fallback: Tweet | null | undefined,
+  hydrated: Tweet | null | undefined
+): Tweet | null {
+  if (!hydrated) {
+    return fallback ?? null;
+  }
+  if (!fallback) {
+    return hydrated;
+  }
+
+  const fallbackUser = fallback.user;
+  const hydratedUser = hydrated.user;
+
+  return {
+    ...fallback,
+    ...hydrated,
+    id_str: nonEmpty(hydrated.id_str) ?? fallback.id_str,
+    full_text:
+      nonEmpty(hydrated.full_text) ??
+      nonEmpty(hydrated.text) ??
+      nonEmpty(fallback.full_text) ??
+      nonEmpty(fallback.text),
+    text:
+      nonEmpty(hydrated.text) ??
+      nonEmpty(hydrated.full_text) ??
+      nonEmpty(fallback.text) ??
+      nonEmpty(fallback.full_text),
+    tweet_created_at:
+      nonEmpty(hydrated.tweet_created_at) ?? fallback.tweet_created_at,
+    conversation_id_str:
+      nonEmpty(hydrated.conversation_id_str) ?? fallback.conversation_id_str,
+    in_reply_to_status_id_str:
+      nonEmpty(hydrated.in_reply_to_status_id_str) ??
+      fallback.in_reply_to_status_id_str,
+    in_reply_to_screen_name:
+      nonEmpty(hydrated.in_reply_to_screen_name) ??
+      fallback.in_reply_to_screen_name,
+    source: nonEmpty(hydrated.source) ?? fallback.source,
+    entities: hydrated.entities ?? fallback.entities,
+    user: hydratedUser
+      ? {
+          ...fallbackUser,
+          ...hydratedUser,
+          name: nonEmpty(hydratedUser.name) ?? fallbackUser?.name ?? "Unknown",
+          screen_name:
+            nonEmpty(hydratedUser.screen_name) ??
+            fallbackUser?.screen_name ??
+            "unknown",
+          profile_image_url_https:
+            nonEmpty(hydratedUser.profile_image_url_https) ??
+            fallbackUser?.profile_image_url_https ??
+            "",
+        }
+      : fallbackUser,
+  };
+}
+
+export function hasRenderableTweetContent(tweet: Tweet): boolean {
+  return Boolean(nonEmpty(tweet.full_text) ?? nonEmpty(tweet.text));
+}
+
 function getTweetTimestamp(tweet: Tweet): number | null {
   if (!tweet.tweet_created_at) {
     return null;
@@ -23,7 +89,9 @@ export function dedupeAndSortConversationTweets(
 
     const prior = byId.get(tweetId);
     byId.set(tweetId, {
-      tweet,
+      tweet: prior
+        ? (mergeConversationTweetWithFallback(prior.tweet, tweet) ?? tweet)
+        : tweet,
       order: prior?.order ?? order,
     });
     order += 1;
@@ -34,17 +102,113 @@ export function dedupeAndSortConversationTweets(
       const leftTimestamp = getTweetTimestamp(left.tweet);
       const rightTimestamp = getTweetTimestamp(right.tweet);
 
+      if (isTweetAncestor(left.tweet, right.tweet, byId)) {
+        return -1;
+      }
+      if (isTweetAncestor(right.tweet, left.tweet, byId)) {
+        return 1;
+      }
+
       if (leftTimestamp != null && rightTimestamp != null) {
         if (leftTimestamp !== rightTimestamp) {
           return leftTimestamp - rightTimestamp;
         }
-      } else if (leftTimestamp != null) {
-        return -1;
-      } else if (rightTimestamp != null) {
-        return 1;
       }
 
       return left.order - right.order;
     })
     .map((entry) => entry.tweet);
+}
+
+function isTweetAncestor(
+  possibleAncestor: Tweet,
+  tweet: Tweet,
+  tweetsById: Map<string, { tweet: Tweet }>
+): boolean {
+  const ancestorId = possibleAncestor.id_str;
+  let parentId = nonEmpty(tweet.in_reply_to_status_id_str);
+  const visited = new Set<string>();
+
+  while (parentId && !visited.has(parentId)) {
+    if (parentId === ancestorId) {
+      return true;
+    }
+    visited.add(parentId);
+    parentId = nonEmpty(
+      tweetsById.get(parentId)?.tweet.in_reply_to_status_id_str
+    );
+  }
+
+  return false;
+}
+
+/**
+ * Enriches an already-rendered conversation without changing the relative
+ * order of its existing posts. Newly discovered posts are inserted around the
+ * stable posts according to the canonical conversation sort.
+ */
+export function mergeConversationTweetsPreservingOrder(
+  stableTweets: Array<Tweet | null | undefined>,
+  updates: Array<Tweet | null | undefined>
+): Tweet[] {
+  const stable = dedupeAndSortConversationTweets(stableTweets);
+  const dedupedUpdates = dedupeAndSortConversationTweets(updates);
+  const updatesById = new Map(
+    dedupedUpdates.map((tweet) => [tweet.id_str, tweet])
+  );
+  const stableIds = new Set(stable.map((tweet) => tweet.id_str));
+  const enrichedStable = stable.map(
+    (tweet) =>
+      mergeConversationTweetWithFallback(
+        tweet,
+        updatesById.get(tweet.id_str)
+      ) ?? tweet
+  );
+  const additions = dedupedUpdates.filter(
+    (tweet) => !stableIds.has(tweet.id_str)
+  );
+
+  if (additions.length === 0) {
+    return enrichedStable;
+  }
+  if (enrichedStable.length === 0) {
+    return additions;
+  }
+
+  const canonical = dedupeAndSortConversationTweets([
+    ...enrichedStable,
+    ...additions,
+  ]);
+  const additionsBeforeStableId = new Map<string, Tweet[]>();
+  const trailingAdditions: Tweet[] = [];
+
+  for (let index = 0; index < canonical.length; index += 1) {
+    const tweet = canonical[index];
+    const tweetId = nonEmpty(tweet.id_str);
+    if (!tweetId || stableIds.has(tweetId)) {
+      continue;
+    }
+
+    const nextStableTweet = canonical
+      .slice(index + 1)
+      .find((candidate) => stableIds.has(nonEmpty(candidate.id_str) ?? ""));
+    const nextStableTweetId = nonEmpty(nextStableTweet?.id_str);
+    if (!nextStableTweetId) {
+      trailingAdditions.push(tweet);
+      continue;
+    }
+
+    const existing = additionsBeforeStableId.get(nextStableTweetId) ?? [];
+    existing.push(tweet);
+    additionsBeforeStableId.set(nextStableTweetId, existing);
+  }
+
+  return enrichedStable.flatMap((tweet, index) => {
+    const tweetId = nonEmpty(tweet.id_str);
+    return [
+      ...(tweetId ? (additionsBeforeStableId.get(tweetId) ?? []) : []),
+      tweet,
+      ...(index === enrichedStable.length - 1 ? trailingAdditions : []),
+    ];
+  });
 }

--- a/features/prospects/types.ts
+++ b/features/prospects/types.ts
@@ -41,6 +41,10 @@ export interface ProspectInteraction {
   participants: ProspectInteractionParticipant[];
   /** Thread ID for fetching full conversation */
   threadId: string;
+  /** Provider id of the source post containing the interaction */
+  sourcePostId?: string;
+  /** Provider id of the comment/reply represented by this row */
+  replyPostId?: string;
   /** When the user's reply was posted */
   repliedAt: number;
   /** Provenance when ReacherX can determine it */

--- a/features/prospects/ui/components/ConversationPanel.tsx
+++ b/features/prospects/ui/components/ConversationPanel.tsx
@@ -21,11 +21,17 @@ import { usePanelStack } from "../../contexts/PanelStackContext";
 import { Tweet, TweetSkeleton } from "@/features/webapp/ui/components/tweet";
 import type { Tweet as TweetType } from "@/features/threads/types";
 import type { TwitterPostSummary } from "@/shared/lib/twitter/contracts";
-import { usePostEngagementMerge } from "@/shared/hooks/usePostEngagementMerge";
 import { useTwitterTimelineEngagementMerge } from "@/shared/hooks/useTwitterTimelineEngagementMerge";
 import { useHydratedTwitterPosts } from "@/shared/hooks/useHydratedTwitterPosts";
 import { mergeLocalEngagementIntoTweet } from "@/shared/lib/twitter/mergeViewerState";
 import { toFallbackTweetFromSummary } from "@/shared/lib/twitter/ui";
+import {
+  dedupeAndSortConversationTweets,
+  hasRenderableTweetContent,
+  mergeConversationTweetsPreservingOrder,
+} from "@/features/prospects/lib/twitterConversation";
+
+const EMPTY_FALLBACK_TWEETS: TweetType[] = [];
 
 export interface ConversationPanelProps {
   /** Original tweet ID to fetch conversation for */
@@ -42,59 +48,13 @@ export interface ConversationPanelProps {
   replyTweetId?: string;
   /** Reply tweet fallback summary when SocialAPI omits it */
   replyTweetSummary?: TwitterPostSummary | null;
+  /** Durable snapshots for every known post in this interaction thread */
+  fallbackTweets?: TweetType[];
   /** Whether the source tweet should display as commented/replied */
   overlayCommented?: boolean;
   /** Additional className */
   className?: string;
   onBack?: () => void;
-}
-
-function getTweetTimestamp(tweet: TweetType): number | null {
-  if (!tweet.tweet_created_at) {
-    return null;
-  }
-  const timestamp = Date.parse(tweet.tweet_created_at);
-  return Number.isFinite(timestamp) ? timestamp : null;
-}
-
-function dedupeAndSortConversationTweets(
-  tweets: Array<TweetType | null | undefined>
-): TweetType[] {
-  const byId = new Map<string, { tweet: TweetType; order: number }>();
-  let order = 0;
-
-  for (const tweet of tweets) {
-    const tweetId = tweet?.id_str;
-    if (!tweetId) {
-      continue;
-    }
-
-    const prior = byId.get(tweetId);
-    byId.set(tweetId, {
-      tweet,
-      order: prior?.order ?? order,
-    });
-    order += 1;
-  }
-
-  return Array.from(byId.values())
-    .sort((left, right) => {
-      const leftTimestamp = getTweetTimestamp(left.tweet);
-      const rightTimestamp = getTweetTimestamp(right.tweet);
-
-      if (leftTimestamp != null && rightTimestamp != null) {
-        if (leftTimestamp !== rightTimestamp) {
-          return leftTimestamp - rightTimestamp;
-        }
-      } else if (leftTimestamp != null) {
-        return -1;
-      } else if (rightTimestamp != null) {
-        return 1;
-      }
-
-      return left.order - right.order;
-    })
-    .map((entry) => entry.tweet);
 }
 
 export function ConversationPanel({
@@ -105,6 +65,7 @@ export function ConversationPanel({
   sourceTweetSummary,
   replyTweetId,
   replyTweetSummary,
+  fallbackTweets = EMPTY_FALLBACK_TWEETS,
   overlayCommented = false,
   className,
   onBack,
@@ -120,48 +81,55 @@ export function ConversationPanel({
     string | null
   >(null);
   const mergedTweets = useTwitterTimelineEngagementMerge(tweets);
-  const normalizedReplyTweetId = React.useMemo(
-    () => replyTweetId?.trim() || replyTweetSummary?.ref.postId || "",
-    [replyTweetId, replyTweetSummary]
+  const durableFallbackTweets = React.useMemo(
+    () =>
+      dedupeAndSortConversationTweets([
+        sourceTweet,
+        sourceTweetSummary
+          ? toFallbackTweetFromSummary(sourceTweetSummary)
+          : null,
+        ...fallbackTweets,
+        replyTweetSummary
+          ? toFallbackTweetFromSummary(replyTweetSummary)
+          : null,
+      ]),
+    [fallbackTweets, replyTweetSummary, sourceTweet, sourceTweetSummary]
   );
-  const { tweetsById: replyTweetsById } = useHydratedTwitterPosts(
-    normalizedReplyTweetId ? [normalizedReplyTweetId] : []
+  const fallbackTweetIds = React.useMemo(
+    () =>
+      Array.from(
+        new Set([
+          ...durableFallbackTweets.map((tweet) => tweet.id_str),
+          replyTweetId?.trim(),
+        ])
+      ).filter((tweetId): tweetId is string => Boolean(tweetId)),
+    [durableFallbackTweets, replyTweetId]
   );
-
-  const fallbackSourceTweet = React.useMemo(() => {
-    if (sourceTweet?.id_str) {
-      return sourceTweet;
-    }
-    return sourceTweetSummary
-      ? toFallbackTweetFromSummary(sourceTweetSummary)
-      : null;
-  }, [sourceTweet, sourceTweetSummary]);
-
-  const fallbackReplyTweet = React.useMemo(() => {
-    return replyTweetSummary
-      ? toFallbackTweetFromSummary(replyTweetSummary)
-      : null;
-  }, [replyTweetSummary]);
-  const mergedFallbackSourceTweet = usePostEngagementMerge(fallbackSourceTweet);
-  const mergedFallbackReplyTweet = usePostEngagementMerge(fallbackReplyTweet);
+  const { tweetsById: hydratedFallbackTweetsById } =
+    useHydratedTwitterPosts(fallbackTweetIds);
+  const hydratedFallbackTweets = React.useMemo(
+    () =>
+      mergeConversationTweetsPreservingOrder(
+        durableFallbackTweets,
+        fallbackTweetIds.map((tweetId) => hydratedFallbackTweetsById[tweetId])
+      ),
+    [durableFallbackTweets, fallbackTweetIds, hydratedFallbackTweetsById]
+  );
+  const mergedFallbackTweets = useTwitterTimelineEngagementMerge(
+    hydratedFallbackTweets
+  );
 
   const sourceTweetIdForDisplay =
-    sourceTweetId ?? mergedFallbackSourceTweet?.id_str ?? threadId;
+    sourceTweetId ?? mergedFallbackTweets[0]?.id_str ?? threadId;
   const shouldOverlayCommented =
     overlayCommented ||
-    mergedFallbackSourceTweet?.viewerState?.commented === true;
+    mergedFallbackTweets.some((tweet) => tweet.viewerState?.commented === true);
 
   const conversationTweets = React.useMemo(() => {
-    const supplementalReplyTweet =
-      (normalizedReplyTweetId
-        ? replyTweetsById[normalizedReplyTweetId]
-        : null) ?? mergedFallbackReplyTweet;
-
-    return dedupeAndSortConversationTweets([
-      mergedFallbackSourceTweet,
-      ...mergedTweets,
-      supplementalReplyTweet,
-    ]).map((tweet) => {
+    return mergeConversationTweetsPreservingOrder(
+      mergedFallbackTweets,
+      mergedTweets
+    ).map((tweet) => {
       if (
         !shouldOverlayCommented ||
         !sourceTweetIdForDisplay ||
@@ -175,11 +143,8 @@ export function ConversationPanel({
       });
     });
   }, [
-    mergedFallbackReplyTweet,
-    mergedFallbackSourceTweet,
+    mergedFallbackTweets,
     mergedTweets,
-    normalizedReplyTweetId,
-    replyTweetsById,
     shouldOverlayCommented,
     sourceTweetIdForDisplay,
   ]);
@@ -245,7 +210,7 @@ export function ConversationPanel({
           viewportClassName="pb-6"
         >
           <PageContent className="pt-4">
-            {isLoading ? (
+            {isLoading && conversationTweets.length === 0 ? (
               <ConversationSkeleton />
             ) : conversationTweets.length === 0 ? (
               <div className="text-muted-foreground py-8 text-center text-sm">
@@ -255,11 +220,17 @@ export function ConversationPanel({
               <section>
                 {conversationTweets.map((tweet, index) => (
                   <article key={tweet.id_str} className="px-4">
-                    <Tweet
-                      tweet={tweet}
-                      characterLimit={280}
-                      showThread={index === conversationTweets.length - 1}
-                    />
+                    {hasRenderableTweetContent(tweet) ? (
+                      <Tweet
+                        tweet={tweet}
+                        characterLimit={280}
+                        showThread={index === conversationTweets.length - 1}
+                      />
+                    ) : (
+                      <TweetSkeleton
+                        showThread={index === conversationTweets.length - 1}
+                      />
+                    )}
                   </article>
                 ))}
                 <InfiniteScrollTrigger

--- a/features/prospects/ui/components/ProspectPanelRenderer.tsx
+++ b/features/prospects/ui/components/ProspectPanelRenderer.tsx
@@ -255,6 +255,14 @@ export function ProspectPanelRenderer({
                 | import("@/features/webapp/ui/components").LinkedInCommentThreadPreviewScenario
                 | undefined
             }
+            initialSort={
+              currentPanel.props.initialSort as
+                | import("@/shared/lib/linkedin/comments").LinkedInCommentSort
+                | undefined
+            }
+            autoExpandCommentIds={
+              currentPanel.props.autoExpandCommentIds as string[] | undefined
+            }
             onBack={closeCurrentSubPanel}
           />
         );
@@ -307,6 +315,9 @@ export function ProspectPanelRenderer({
                 | TwitterPostSummary
                 | null
                 | undefined
+            }
+            fallbackTweets={
+              currentPanel.props.fallbackTweets as Tweet[] | undefined
             }
             overlayCommented={
               currentPanel.props.overlayCommented as boolean | undefined

--- a/features/prospects/ui/components/ProspectProfilePanel.tsx
+++ b/features/prospects/ui/components/ProspectProfilePanel.tsx
@@ -7,8 +7,6 @@
 "use client";
 
 import * as React from "react";
-import { useAction } from "convex/react";
-import { api } from "@/convex/_generated/api";
 import { cn, parseText } from "@/shared/lib/utils";
 import {
   PageLayout,
@@ -149,9 +147,6 @@ export function ProspectProfilePanel({
   const entitySingularLower = entitySingular.toLowerCase();
   const { popPanel, pushPanel } = usePanelStack();
   const { openProfile } = useTwitterProfileNavigation();
-  const refreshProspectInteractions = useAction(
-    api.interactionsActions.refreshProspectInteractions
-  );
   const [activeTab, setActiveTab] = React.useState<ProfileTab>("overview");
   const [showFullIntro, setShowFullIntro] = React.useState(false);
   const isMobile = useIsMobile();
@@ -327,24 +322,6 @@ export function ProspectProfilePanel({
         []),
     ]);
   }, [prospect]);
-
-  React.useEffect(() => {
-    if (!prospect?.id || prospect.platform !== "twitter" || isReadOnlyPreview) {
-      return;
-    }
-
-    void refreshProspectInteractions({
-      prospectId: prospect.id as never,
-      force: false,
-    }).catch(() => {
-      // Background refresh is intentionally silent.
-    });
-  }, [
-    isReadOnlyPreview,
-    prospect?.id,
-    prospect?.platform,
-    refreshProspectInteractions,
-  ]);
 
   const panel = (
     <aside
@@ -545,6 +522,7 @@ export function ProspectProfilePanel({
                       prospectId={prospect.id}
                       platform={prospect.platform || "twitter"}
                       readOnly={isReadOnlyPreview}
+                      syncEnabled={activeTab === "interactions"}
                       previewInteractions={
                         isUiPreview ? UI_PREVIEW_INTERACTIONS : undefined
                       }

--- a/features/prospects/ui/components/ReplyPanel.tsx
+++ b/features/prospects/ui/components/ReplyPanel.tsx
@@ -202,6 +202,12 @@ export function ReplyPanel({
                             mediaUrls,
                             mediaDescriptions,
                             parentAuthorId: tweet.user?.id_str,
+                            parentAuthorHandle: tweet.user?.screen_name,
+                            prospectId: prospectId
+                              ? (prospectId as import("@/convex/_generated/dataModel").Id<"prospects">)
+                              : undefined,
+                            conversationId:
+                              tweet.conversation_id_str || threadId,
                           });
                           cacheTwitterPostEngagement({
                             postId: tweetId,

--- a/features/prospects/ui/components/tabs/YourInteractionsTab.tsx
+++ b/features/prospects/ui/components/tabs/YourInteractionsTab.tsx
@@ -6,7 +6,7 @@
 "use client";
 
 import * as React from "react";
-import { useMutation, usePaginatedQuery } from "convex/react";
+import { useAction, useMutation, usePaginatedQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
 import { Button } from "@/shared/ui/components/Button";
@@ -20,13 +20,23 @@ import {
 import { AvatarStack } from "@/shared/ui/components/AvatarStack";
 import { usePanelStack } from "../../../contexts/PanelStackContext";
 import type { ProspectInteraction } from "@/features/prospects/types";
-import { getTwitterPostId } from "@/shared/lib/twitter/contracts";
 import { mergeLocalEngagementIntoTweet } from "@/shared/lib/twitter/mergeViewerState";
 import { useHydratedTwitterPosts } from "@/shared/hooks/useHydratedTwitterPosts";
 import type { UnifiedPost } from "@/shared/lib/platforms/types";
 import { UnavailableInteractionCard } from "./UnavailableInteractionCard";
 import { UI_PREVIEW_LINKEDIN_THREAD_SCENARIOS } from "@/features/prospects/lib/uiPreviewData";
 import { normalizeLinkedInPost } from "@/shared/lib/linkedin/post";
+import type { Tweet as TweetType } from "@/features/threads/types";
+import {
+  buildTwitterInteractionThreadFallbackTweets,
+  getLinkedInThreadCommentIds,
+  groupProspectInteractionsByThread,
+  type ProspectInteractionThread,
+} from "@/features/prospects/lib/prospectInteractionThreads";
+import {
+  hasRenderableTweetContent,
+  mergeConversationTweetWithFallback,
+} from "@/features/prospects/lib/twitterConversation";
 
 const INITIAL_PAGE_SIZE = 10;
 
@@ -34,6 +44,7 @@ export interface YourInteractionsTabProps {
   prospectId: string;
   platform: "twitter" | "linkedin";
   readOnly?: boolean;
+  syncEnabled?: boolean;
   previewInteractions?: ProspectInteraction[];
 }
 
@@ -41,11 +52,19 @@ export function YourInteractionsTab({
   prospectId,
   platform,
   readOnly = false,
+  syncEnabled = false,
   previewInteractions,
 }: YourInteractionsTabProps) {
   const { pushPanel } = usePanelStack();
   const markedUnavailableRef = React.useRef<Set<string>>(new Set());
+  const activeSyncRef = React.useRef<string | null>(null);
+  const syncRequestIdRef = React.useRef(0);
+  const [isSyncing, setIsSyncing] = React.useState(false);
+  const [syncError, setSyncError] = React.useState<string>();
   const isPreview = Array.isArray(previewInteractions);
+  const refreshProspectInteractions = useAction(
+    api.interactionsActions.refreshProspectInteractions
+  );
 
   const interactionsQuery = usePaginatedQuery(
     api.interactions.getProspectInteractionsPage,
@@ -60,6 +79,63 @@ export function YourInteractionsTab({
     api.interactions.markInteractionUnavailable
   );
 
+  React.useEffect(() => {
+    if (!syncEnabled || readOnly || isPreview) {
+      syncRequestIdRef.current += 1;
+      setIsSyncing(false);
+      setSyncError(undefined);
+      return;
+    }
+    const syncKey = `${platform}:${prospectId}`;
+    if (activeSyncRef.current === syncKey) {
+      return;
+    }
+
+    const requestId = syncRequestIdRef.current + 1;
+    syncRequestIdRef.current = requestId;
+    activeSyncRef.current = syncKey;
+    setIsSyncing(true);
+    setSyncError(undefined);
+    void refreshProspectInteractions({
+      prospectId: prospectId as Id<"prospects">,
+      force: true,
+    })
+      .then((result) => {
+        if (result.skipped && activeSyncRef.current === syncKey) {
+          activeSyncRef.current = null;
+        }
+        if (syncRequestIdRef.current === requestId && result.skipped) {
+          setSyncError(
+            `Connect ${platform === "twitter" ? "X" : "LinkedIn"} to sync interactions.`
+          );
+        }
+      })
+      .catch((error: unknown) => {
+        if (activeSyncRef.current === syncKey) {
+          activeSyncRef.current = null;
+        }
+        if (syncRequestIdRef.current === requestId) {
+          setSyncError(
+            error instanceof Error
+              ? error.message
+              : "Could not sync interactions right now."
+          );
+        }
+      })
+      .finally(() => {
+        if (syncRequestIdRef.current === requestId) {
+          setIsSyncing(false);
+        }
+      });
+  }, [
+    isPreview,
+    platform,
+    prospectId,
+    readOnly,
+    refreshProspectInteractions,
+    syncEnabled,
+  ]);
+
   const interactions = React.useMemo(
     () =>
       isPreview
@@ -68,14 +144,17 @@ export function YourInteractionsTab({
     [interactionsQuery.results, isPreview, previewInteractions]
   );
 
+  const interactionThreads = React.useMemo(
+    () => groupProspectInteractionsByThread(interactions, platform),
+    [interactions, platform]
+  );
+
   const visibleTwitterPostIds = React.useMemo(
     () =>
       platform === "twitter"
-        ? interactions
-            .map((interaction) => getTwitterPostId(interaction.originalPost))
-            .filter((postId): postId is string => Boolean(postId))
+        ? interactionThreads.map((thread) => thread.threadId)
         : [],
-    [interactions, platform]
+    [interactionThreads, platform]
   );
 
   const {
@@ -95,19 +174,17 @@ export function YourInteractionsTab({
       return;
     }
 
-    const missingInteractionIds = interactions
-      .filter((interaction) => interaction.status === "active")
-      .filter((interaction) => {
-        const postId = getTwitterPostId(interaction.originalPost);
-        if (!postId) {
-          return false;
-        }
-        return resultsById[postId]?.status === "not_found";
-      })
-      .map((interaction) => interaction.id)
-      .filter(
-        (interactionId) => !markedUnavailableRef.current.has(interactionId)
-      );
+    const missingInteractionIds: string[] = [];
+    for (const thread of interactionThreads) {
+      const interactionId = thread.representative.id;
+      if (
+        thread.representative.status === "active" &&
+        resultsById[thread.threadId]?.status === "not_found" &&
+        !markedUnavailableRef.current.has(interactionId)
+      ) {
+        missingInteractionIds.push(interactionId);
+      }
+    }
 
     if (missingInteractionIds.length === 0) {
       return;
@@ -125,7 +202,7 @@ export function YourInteractionsTab({
     }
   }, [
     hydrateError,
-    interactions,
+    interactionThreads,
     isHydratingTweets,
     markInteractionUnavailable,
     platform,
@@ -134,32 +211,30 @@ export function YourInteractionsTab({
   ]);
 
   const handleShowConversation = (
-    interaction: ProspectInteraction,
-    sourceTweet: import("@/features/threads/types").Tweet | null
+    thread: ProspectInteractionThread,
+    sourceTweet: TweetType | null
   ) => {
+    const fallbackTweets = buildTwitterInteractionThreadFallbackTweets(thread);
     pushPanel("conversation", {
-      threadId: interaction.threadId,
-      sourceTweetId:
-        interaction.sourcePostRef?.postId ??
-        getTwitterPostId(interaction.originalPost) ??
-        undefined,
+      threadId: thread.threadId,
+      sourceTweetId: thread.threadId,
       sourceTweet,
-      sourceTweetSummary: interaction.sourcePostSummary ?? undefined,
-      replyTweetId:
-        interaction.replyPostRef?.postId ??
-        interaction.replyPostSummary?.ref.postId ??
-        undefined,
-      replyTweetSummary: interaction.replyPostSummary ?? undefined,
+      fallbackTweets,
       overlayCommented: true,
     });
   };
 
   const handleOpenLinkedInThread = React.useCallback(
-    (interaction: ProspectInteraction, post: UnifiedPost) => {
+    (thread: ProspectInteractionThread, post: UnifiedPost) => {
       pushPanel("linkedin-post-thread", {
         post,
+        initialSort: "MOST_RECENT",
+        autoExpandCommentIds: getLinkedInThreadCommentIds(thread),
         previewScenario: isPreview
-          ? buildLinkedInInteractionPreviewScenario(post, interaction.replyText)
+          ? buildLinkedInInteractionPreviewScenario(
+              post,
+              thread.representative.replyText
+            )
           : undefined,
       });
     },
@@ -183,14 +258,17 @@ export function YourInteractionsTab({
 
   return (
     <section className="space-y-4 pb-4">
-      {interactions.length === 0 ? (
+      {interactionThreads.length === 0 ? (
         <div className="text-muted-foreground px-4 py-8 text-center text-sm">
-          We&apos;ll start tracking new interactions from now. Historical import
-          is off.
+          {syncError ??
+            (isSyncing
+              ? "Syncing latest interactions…"
+              : "No public interactions found with this prospect.")}
         </div>
       ) : (
         <div className="divide-y">
-          {interactions.map((interaction) => {
+          {interactionThreads.map((thread) => {
+            const interaction = thread.representative;
             if (platform === "linkedin") {
               const linkedinPost = normalizeLinkedInPost(
                 interaction.sourcePostData,
@@ -198,7 +276,7 @@ export function YourInteractionsTab({
               );
 
               return (
-                <article key={interaction.id} className="space-y-3 p-4">
+                <article key={thread.id} className="space-y-3 p-4">
                   {linkedinPost ? (
                     <LinkedInPostCard
                       post={linkedinPost}
@@ -208,7 +286,7 @@ export function YourInteractionsTab({
                       commentBehavior="none"
                       disableExternalNavigation
                       onClick={() =>
-                        handleOpenLinkedInThread(interaction, linkedinPost)
+                        handleOpenLinkedInThread(thread, linkedinPost)
                       }
                     />
                   ) : (
@@ -222,12 +300,10 @@ export function YourInteractionsTab({
 
                   <footer className="flex flex-wrap items-center gap-2 pl-1">
                     <AvatarStack
-                      participants={interaction.participants.map(
-                        (participant) => ({
-                          name: participant.name,
-                          avatarUrl: participant.avatarUrl,
-                        })
-                      )}
+                      participants={thread.participants.map((participant) => ({
+                        name: participant.name,
+                        avatarUrl: participant.avatarUrl,
+                      }))}
                       maxVisible={5}
                       size="sm"
                     />
@@ -237,7 +313,7 @@ export function YourInteractionsTab({
                         variant="outline"
                         size="xs"
                         onClick={() =>
-                          handleOpenLinkedInThread(interaction, linkedinPost)
+                          handleOpenLinkedInThread(thread, linkedinPost)
                         }
                       >
                         Open thread
@@ -248,22 +324,38 @@ export function YourInteractionsTab({
               );
             }
 
-            const postId = getTwitterPostId(interaction.originalPost);
+            const fallbackTweets =
+              buildTwitterInteractionThreadFallbackTweets(thread);
+            const fallbackRootTweet =
+              fallbackTweets.find(
+                (tweet) => tweet.id_str === thread.threadId
+              ) ??
+              fallbackTweets[0] ??
+              null;
+            const postId = thread.threadId;
             const hydratedTweet = postId ? tweetsById[postId] : undefined;
-            const displayTweet =
-              hydratedTweet &&
-              mergeLocalEngagementIntoTweet(hydratedTweet, {
-                overlayCommented: true,
-              });
-            const isUnavailable = interaction.status !== "active";
+            const isUnavailable = thread.interactions.every(
+              (item) => item.status !== "active"
+            );
             const hydrationResult = postId ? resultsById[postId] : undefined;
+            const hydrationSettled = Boolean(hydrationResult || hydrateError);
+            const resolvedTweet = mergeConversationTweetWithFallback(
+              fallbackRootTweet,
+              hydratedTweet
+            );
+            const displayTweet =
+              resolvedTweet && hasRenderableTweetContent(resolvedTweet)
+                ? mergeLocalEngagementIntoTweet(resolvedTweet, {
+                    overlayCommented: true,
+                  })
+                : null;
             const shouldShowSkeleton =
               !displayTweet &&
               !isUnavailable &&
-              (isHydratingTweets || !hydrationResult);
+              (isHydratingTweets || !hydrationSettled);
 
             return (
-              <article key={interaction.id} className="space-y-3 p-4">
+              <article key={thread.id} className="space-y-3 p-4">
                 {isUnavailable ? (
                   <UnavailableInteractionCard
                     message={
@@ -292,12 +384,10 @@ export function YourInteractionsTab({
 
                 <footer className="flex flex-wrap items-center gap-2 pl-1">
                   <AvatarStack
-                    participants={interaction.participants.map(
-                      (participant) => ({
-                        name: participant.name,
-                        avatarUrl: participant.avatarUrl,
-                      })
-                    )}
+                    participants={thread.participants.map((participant) => ({
+                      name: participant.name,
+                      avatarUrl: participant.avatarUrl,
+                    }))}
                     maxVisible={5}
                     size="sm"
                   />
@@ -308,8 +398,8 @@ export function YourInteractionsTab({
                     disabled={readOnly}
                     onClick={() =>
                       handleShowConversation(
-                        interaction,
-                        displayTweet ?? interaction.originalPost
+                        thread,
+                        displayTweet ?? fallbackRootTweet
                       )
                     }
                   >
@@ -324,12 +414,24 @@ export function YourInteractionsTab({
         </div>
       )}
 
+      {isSyncing && interactions.length > 0 ? (
+        <p className="text-muted-foreground px-4 text-xs" role="status">
+          Syncing latest interactions…
+        </p>
+      ) : null}
+
+      {syncError && interactions.length > 0 ? (
+        <p className="text-destructive px-4 text-xs" role="alert">
+          {syncError}
+        </p>
+      ) : null}
+
       {!isPreview ? (
         <InfiniteScrollTrigger
           hasMore={canLoadMore}
           isLoading={isLoadingMore}
           onLoadMore={() => interactionsQuery.loadMore(INITIAL_PAGE_SIZE)}
-          resultCount={interactions.length}
+          resultCount={interactionThreads.length}
           className="mx-4"
           loadingLabel="Loading more interactions"
           loadMoreLabel="Load more interactions"
@@ -385,14 +487,7 @@ export function YourInteractionsTabSkeleton() {
     <div className="divide-y">
       {[1, 2].map((i) => (
         <div key={i} className="space-y-3 px-4 py-3">
-          <div className="flex items-start gap-3">
-            <Skeleton className="size-10 shrink-0 rounded-full" />
-            <div className="flex-1 space-y-2">
-              <Skeleton className="h-4 w-32" />
-              <Skeleton className="h-3 w-24" />
-            </div>
-          </div>
-          <Skeleton className="h-16 w-full" />
+          <TweetSkeleton showThread={false} />
           <div className="flex items-center gap-3">
             <div className="flex -space-x-2">
               {[1, 2, 3].map((j) => (

--- a/features/webapp/ui/components/linkedin/LinkedInCommentThread.tsx
+++ b/features/webapp/ui/components/linkedin/LinkedInCommentThread.tsx
@@ -26,16 +26,17 @@ import {
   AlertDescription,
   AlertTitle,
 } from "@/shared/ui/components/Alert";
-import { Skeleton } from "@/shared/ui/components/Skeleton";
 import { KeyboardArrowDownIcon } from "@/shared/ui/components/icons";
 import { LinkedInReplyComposer } from "./LinkedInReplyComposer";
 import { LinkedInCommentItem } from "./LinkedInCommentItem";
+import { LinkedInCommentThreadSkeleton } from "./LinkedInCommentThreadSkeleton";
 import { extractTextFromEditorState } from "@/shared/lib/utils";
 import { toast } from "sonner";
 import { buildLinkedInPostMentionEntities } from "./linkedinComposerMentions";
 import { resolveLinkedInRecoveryAction } from "@/shared/lib/linkedin/recovery";
 
 const INITIAL_COMMENT_LIMIT = 10;
+const EMPTY_COMMENT_IDS: string[] = [];
 
 export interface LinkedInCommentThreadPreviewScenario {
   thread: LinkedInPostThreadContext;
@@ -48,6 +49,8 @@ export interface LinkedInCommentThreadProps {
   post: UnifiedPost;
   prospectId?: string;
   previewScenario?: LinkedInCommentThreadPreviewScenario;
+  initialSort?: LinkedInCommentSort;
+  autoExpandCommentIds?: string[];
   className?: string;
   onResolvedPost?: (post: UnifiedPost) => void;
 }
@@ -146,6 +149,8 @@ export function LinkedInCommentThread({
   post,
   prospectId,
   previewScenario,
+  initialSort = "MOST_RELEVANT",
+  autoExpandCommentIds = EMPTY_COMMENT_IDS,
   className,
   onResolvedPost,
 }: LinkedInCommentThreadProps) {
@@ -156,9 +161,9 @@ export function LinkedInCommentThread({
   const getReplies = useAction((api as any).linkedin.getLinkedInCommentReplies);
   const sendComment = useAction((api as any).linkedin.sendLinkedInPostComment);
   const likeComment = useAction((api as any).linkedin.likeLinkedInComment);
-  const [sort, setSort] = React.useState<LinkedInCommentSort>("MOST_RELEVANT");
+  const [sort, setSort] = React.useState<LinkedInCommentSort>(initialSort);
   const [thread, setThread] = React.useState<LinkedInPostThreadContext | null>(
-    previewScenario?.thread ?? null
+    previewScenario?.loading ? null : (previewScenario?.thread ?? null)
   );
   const [loading, setLoading] = React.useState(
     Boolean(previewScenario?.loading)
@@ -190,8 +195,9 @@ export function LinkedInCommentThread({
     );
   });
   const threadRef = React.useRef<LinkedInPostThreadContext | null>(
-    previewScenario?.thread ?? null
+    previewScenario?.loading ? null : (previewScenario?.thread ?? null)
   );
+  const autoExpandedCommentIdsRef = React.useRef(new Set<string>());
 
   const loadThread = React.useCallback(
     async (opts?: {
@@ -323,6 +329,25 @@ export function LinkedInCommentThread({
     },
     [getReplies, post, previewScenario, prospectId, sort]
   );
+
+  React.useEffect(() => {
+    if (!thread || autoExpandCommentIds.length === 0) {
+      return;
+    }
+
+    const visibleCommentIds = new Set(
+      thread.topLevelComments.items.map((comment) => comment.id)
+    );
+    for (const commentId of autoExpandCommentIds) {
+      if (
+        visibleCommentIds.has(commentId) &&
+        !autoExpandedCommentIdsRef.current.has(commentId)
+      ) {
+        autoExpandedCommentIdsRef.current.add(commentId);
+        void loadRepliesForComment(commentId);
+      }
+    }
+  }, [autoExpandCommentIds, loadRepliesForComment, thread]);
 
   const applyCommentUpdate = React.useCallback(
     (
@@ -755,6 +780,7 @@ export function LinkedInCommentThread({
     thread?.warning?.code === "read_only_fallback"
       ? "Comments are available read-only. Connect LinkedIn to comment or reply."
       : thread?.eligibility.reasonLabel;
+  const isInitialLoading = loading && !thread;
 
   return (
     <section className={className}>
@@ -764,7 +790,12 @@ export function LinkedInCommentThread({
             <div className="text-sm font-medium">Comments</div>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="xs" className="gap-1">
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  className="gap-1"
+                  disabled={loading}
+                >
                   {sort === "MOST_RELEVANT" ? "Most relevant" : "Most recent"}
                   <KeyboardArrowDownIcon className="fill-current" />
                 </Button>
@@ -793,7 +824,9 @@ export function LinkedInCommentThread({
             </DropdownMenu>
           </div>
 
-          {showComposer ? (
+          {isInitialLoading ? (
+            <LinkedInCommentThreadSkeleton prospectId={prospectId} />
+          ) : showComposer ? (
             <LinkedInReplyComposer
               key={`linkedin-top-level-${topLevelComposerVersion}`}
               prospectId={prospectId}
@@ -823,12 +856,7 @@ export function LinkedInCommentThread({
             </Alert>
           ) : null}
 
-          {loading && !thread ? (
-            <div className="space-y-3">
-              <Skeleton className="h-16 w-full rounded-[20px]" />
-              <Skeleton className="h-20 w-full rounded-[20px]" />
-            </div>
-          ) : error && !thread ? (
+          {!isInitialLoading && error && !thread ? (
             <Alert>
               <AlertTitle>Could not load comments</AlertTitle>
               <AlertDescription className="space-y-3">
@@ -848,7 +876,7 @@ export function LinkedInCommentThread({
                 </div>
               </AlertDescription>
             </Alert>
-          ) : (
+          ) : !isInitialLoading ? (
             <>
               {showComposer && thread?.warning ? (
                 <Alert>
@@ -963,7 +991,7 @@ export function LinkedInCommentThread({
                 />
               ) : null}
             </>
-          )}
+          ) : null}
         </div>
       </div>
     </section>

--- a/features/webapp/ui/components/linkedin/LinkedInCommentThreadSkeleton.tsx
+++ b/features/webapp/ui/components/linkedin/LinkedInCommentThreadSkeleton.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { Skeleton } from "@/shared/ui/components/Skeleton";
+import { LinkedInReplyComposer } from "./LinkedInReplyComposer";
+
+export interface LinkedInCommentThreadSkeletonProps {
+  prospectId?: string;
+}
+
+function LinkedInCommentItemSkeleton() {
+  return (
+    <article className="flex items-start gap-3" aria-hidden="true">
+      <Skeleton className="size-8 shrink-0 rounded-full" />
+      <div className="min-w-0 flex-1 space-y-3">
+        <div className="space-y-1.5">
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-3 w-48 max-w-[70%]" />
+        </div>
+        <div className="space-y-1.5">
+          <Skeleton className="h-3.5 w-full" />
+          <Skeleton className="h-3.5 w-4/5" />
+        </div>
+        <div className="flex items-center gap-3 pl-1">
+          <Skeleton className="h-5 w-10 rounded-md" />
+          <Skeleton className="h-5 w-12 rounded-md" />
+        </div>
+      </div>
+    </article>
+  );
+}
+
+export function LinkedInCommentThreadSkeleton({
+  prospectId,
+}: LinkedInCommentThreadSkeletonProps) {
+  return (
+    <div
+      className="space-y-5"
+      role="status"
+      aria-label="Loading comments"
+      aria-live="polite"
+    >
+      <LinkedInReplyComposer
+        prospectId={prospectId}
+        placeholder="Add a comment..."
+        submitLabel="Comment"
+        disabled
+        onSubmit={() => undefined}
+      />
+      <div className="space-y-5">
+        <LinkedInCommentItemSkeleton />
+        <LinkedInCommentItemSkeleton />
+        <LinkedInCommentItemSkeleton />
+      </div>
+      <span className="sr-only">Loading comments</span>
+    </div>
+  );
+}

--- a/features/webapp/ui/components/linkedin/LinkedInPostThreadPanel.tsx
+++ b/features/webapp/ui/components/linkedin/LinkedInPostThreadPanel.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import type { UnifiedPost } from "@/shared/lib/platforms/types";
+import type { LinkedInCommentSort } from "@/shared/lib/linkedin/comments";
 import {
   PageContent,
   PageHeader,
@@ -19,6 +20,8 @@ export interface LinkedInPostThreadPanelProps {
   prospectId?: string;
   onBack?: () => void;
   previewScenario?: LinkedInCommentThreadPreviewScenario;
+  initialSort?: LinkedInCommentSort;
+  autoExpandCommentIds?: string[];
 }
 
 export function LinkedInPostThreadPanel({
@@ -26,6 +29,8 @@ export function LinkedInPostThreadPanel({
   prospectId,
   onBack,
   previewScenario,
+  initialSort,
+  autoExpandCommentIds,
 }: LinkedInPostThreadPanelProps) {
   const [resolvedPostsById, setResolvedPostsById] = React.useState<
     Record<string, UnifiedPost>
@@ -65,6 +70,8 @@ export function LinkedInPostThreadPanel({
             post={post}
             prospectId={prospectId}
             previewScenario={previewScenario}
+            initialSort={initialSort}
+            autoExpandCommentIds={autoExpandCommentIds}
             onResolvedPost={handleResolvedPost}
           />
         </PageContent>

--- a/features/webapp/ui/components/linkedin/index.ts
+++ b/features/webapp/ui/components/linkedin/index.ts
@@ -18,10 +18,12 @@ export { LinkedInMediaGrid } from "./LinkedInMediaGrid";
 export type { LinkedInMediaGridProps } from "./LinkedInMediaGrid";
 export { default as LinkedInGalleryViewer } from "./LinkedInGalleryViewer";
 export { LinkedInCommentThread } from "./LinkedInCommentThread";
+export { LinkedInCommentThreadSkeleton } from "./LinkedInCommentThreadSkeleton";
 export type {
   LinkedInCommentThreadProps,
   LinkedInCommentThreadPreviewScenario,
 } from "./LinkedInCommentThread";
+export type { LinkedInCommentThreadSkeletonProps } from "./LinkedInCommentThreadSkeleton";
 export { LinkedInCommentItem } from "./LinkedInCommentItem";
 export type { LinkedInCommentItemProps } from "./LinkedInCommentItem";
 export { LinkedInReplyComposer } from "./LinkedInReplyComposer";

--- a/shared/lib/twitter/prospectTwitterIdentity.test.ts
+++ b/shared/lib/twitter/prospectTwitterIdentity.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildTwitterReplyInteractionParticipants,
+  resolveProspectTwitterIdentity,
+} from "./prospectTwitterIdentity";
+
+describe("buildTwitterReplyInteractionParticipants", () => {
+  const prospect = {
+    userId: "prospect-id",
+    username: "prospect",
+    displayName: "Prospect Person",
+    avatarUrl: "https://example.com/prospect.jpg",
+  };
+
+  test("uses the prospect's own id when replying to the prospect", () => {
+    expect(
+      buildTwitterReplyInteractionParticipants({
+        prospect,
+        parentAuthorId: "prospect-id",
+        parentAuthorHandle: "Prospect",
+      })
+    ).toEqual([
+      {
+        id: "prospect-id",
+        handle: "prospect",
+        name: "Prospect Person",
+        avatarUrl: "https://example.com/prospect.jpg",
+      },
+      { name: "You", isViewer: true },
+    ]);
+  });
+
+  test("keeps a different parent author as a separate participant", () => {
+    expect(
+      buildTwitterReplyInteractionParticipants({
+        prospect,
+        parentAuthorId: "third-party-id",
+        parentAuthorHandle: "thirdparty",
+      })
+    ).toEqual([
+      {
+        id: "prospect-id",
+        handle: "prospect",
+        name: "Prospect Person",
+        avatarUrl: "https://example.com/prospect.jpg",
+      },
+      {
+        id: "third-party-id",
+        handle: "thirdparty",
+        name: "thirdparty",
+      },
+      { name: "You", isViewer: true },
+    ]);
+  });
+
+  test("does not let a matching handle override conflicting user ids", () => {
+    expect(
+      buildTwitterReplyInteractionParticipants({
+        prospect,
+        parentAuthorId: "third-party-id",
+        parentAuthorHandle: "prospect",
+      })
+    ).toHaveLength(3);
+  });
+
+  test("rejects unsafe numeric X ids before participant construction", () => {
+    const identity = resolveProspectTwitterIdentity({
+      displayName: "Unsafe Numeric ID",
+      data: {
+        user: {
+          id: Number.MAX_SAFE_INTEGER + 1,
+          screen_name: "unsafe-id",
+        },
+      },
+    });
+
+    expect(identity.userId).toBeUndefined();
+    expect(
+      buildTwitterReplyInteractionParticipants({
+        prospect: identity,
+        parentAuthorHandle: "unsafe-id",
+      })[0]?.id
+    ).toBeUndefined();
+  });
+});

--- a/shared/lib/twitter/prospectTwitterIdentity.ts
+++ b/shared/lib/twitter/prospectTwitterIdentity.ts
@@ -7,6 +7,7 @@ import {
   getTwitterProfileWebsiteEntity,
   selectProfileWebsiteHref,
 } from "./profileLinks";
+import type { TwitterConversationParticipant } from "./contracts";
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   return typeof value === "object" && value !== null
@@ -39,7 +40,7 @@ function readTwitterUserId(user: Record<string, unknown>): string | undefined {
   const restId = asString(user.rest_id);
   if (restId) return restId;
   const id = user.id;
-  if (typeof id === "number" && Number.isFinite(id)) {
+  if (typeof id === "number" && Number.isSafeInteger(id)) {
     return String(Math.trunc(id));
   }
   if (typeof id === "string" && /^\d+$/.test(id.trim())) {
@@ -135,4 +136,36 @@ export function resolveProspectTwitterIdentity(
     canDm,
     userId,
   };
+}
+
+export function buildTwitterReplyInteractionParticipants(args: {
+  prospect: ProspectTwitterIdentity;
+  parentAuthorId?: string;
+  parentAuthorHandle?: string;
+}): TwitterConversationParticipant[] {
+  const prospectHandle = args.prospect.username?.toLowerCase();
+  const parentAuthorHandle = args.parentAuthorHandle?.toLowerCase();
+  const parentIsProspect =
+    args.prospect.userId && args.parentAuthorId
+      ? args.prospect.userId === args.parentAuthorId
+      : Boolean(prospectHandle && parentAuthorHandle === prospectHandle);
+  const participants: TwitterConversationParticipant[] = [
+    {
+      id: args.prospect.userId,
+      handle: args.prospect.username,
+      name: args.prospect.displayName,
+      avatarUrl: args.prospect.avatarUrl,
+    },
+  ];
+
+  if (!parentIsProspect && (args.parentAuthorId || args.parentAuthorHandle)) {
+    participants.push({
+      id: args.parentAuthorId,
+      handle: args.parentAuthorHandle,
+      name: args.parentAuthorHandle,
+    });
+  }
+
+  participants.push({ name: "You", isViewer: true });
+  return participants;
 }

--- a/tests/post-panel-navigation.test.ts
+++ b/tests/post-panel-navigation.test.ts
@@ -66,7 +66,77 @@ test("explicit interaction conversations and reply composition remain separate",
   );
 
   assert.match(interactionsSource, /pushPanel\("conversation"/);
+  assert.match(interactionsSource, /groupProspectInteractionsByThread/);
+  assert.match(interactionsSource, /fallbackTweets/);
+  assert.match(interactionsSource, /AvatarStack/);
+  assert.match(interactionsSource, /Show conversation/);
+  assert.match(interactionsSource, /Open thread/);
+  assert.match(interactionsSource, /TweetSkeleton/);
+  assert.match(interactionsSource, /mergeConversationTweetWithFallback/);
+  assert.doesNotMatch(
+    interactionsSource,
+    /LoadingFirstPage"\s*\|\|\s*isSyncing/
+  );
+  assert.doesNotMatch(interactionsSource, /InteractionReplyPreview/);
   assert.match(replyProviderSource, /pushPanel\("post-compose"/);
+});
+
+test("conversation hydration enriches posts without reordering rendered items", () => {
+  const panelSource = readSource(
+    "features/prospects/ui/components/ConversationPanel.tsx"
+  );
+
+  assert.match(panelSource, /mergeConversationTweetsPreservingOrder/);
+  assert.match(panelSource, /hasRenderableTweetContent/);
+});
+
+test("public interactions sync only while the tab is open", () => {
+  const profileSource = readSource(
+    "features/prospects/ui/components/ProspectProfilePanel.tsx"
+  );
+  const interactionsSource = readSource(
+    "features/prospects/ui/components/tabs/YourInteractionsTab.tsx"
+  );
+
+  assert.match(profileSource, /syncEnabled=\{activeTab === "interactions"\}/);
+  assert.doesNotMatch(profileSource, /refreshProspectInteractions/);
+  assert.match(
+    interactionsSource,
+    /if \(!syncEnabled \|\| readOnly \|\| isPreview\)/
+  );
+  const disabledSyncBranch = interactionsSource.match(
+    /if \(!syncEnabled \|\| readOnly \|\| isPreview\) \{([\s\S]*?)return;\n    \}/
+  )?.[1];
+  assert.ok(disabledSyncBranch);
+  assert.doesNotMatch(disabledSyncBranch, /activeSyncRef\.current = null/);
+  assert.match(interactionsSource, /force: true/);
+  assert.match(
+    interactionsSource,
+    /isSyncing[\s\S]*?Syncing latest interactions…/
+  );
+});
+
+test("public interaction discovery enforces ownership and dispatches by platform", () => {
+  const actionSource = readSource("convex/interactionsActions.ts");
+
+  assert.match(actionSource, /prospect\.userId !== args\.userId/);
+  assert.match(
+    actionSource,
+    /prospect\.platform === "linkedin"[\s\S]*runLinkedInProspectInteractionDiscovery/
+  );
+  assert.match(actionSource, /runTwitterProspectInteractionDiscovery/);
+});
+
+test("direct X replies retain prospect context for immediate recording", () => {
+  const replySource = readSource(
+    "features/prospects/ui/components/ReplyPanel.tsx"
+  );
+  const actionSource = readSource("convex/x.ts");
+
+  assert.match(replySource, /prospectId:/);
+  assert.match(replySource, /conversationId:/);
+  assert.match(actionSource, /upsertTwitterInteraction/);
+  assert.match(actionSource, /origin: "manual_reacherx"/);
 });
 
 test("page-originated panels start a clean stack and nested panels push", () => {

--- a/tests/ui-consistency-regressions.test.ts
+++ b/tests/ui-consistency-regressions.test.ts
@@ -171,6 +171,36 @@ test("LinkedIn unavailable states use shared actionable alerts", () => {
   assert.match(conversationSource, /messagingRecoveryAction\.label/);
 });
 
+test("LinkedIn comments use a structural initial loading state", () => {
+  const commentThreadSource = readSource(
+    "features/webapp/ui/components/linkedin/LinkedInCommentThread.tsx"
+  );
+  const skeletonSource = readSource(
+    "features/webapp/ui/components/linkedin/LinkedInCommentThreadSkeleton.tsx"
+  );
+
+  assert.match(
+    commentThreadSource,
+    /const isInitialLoading = loading && !thread/
+  );
+  assert.match(commentThreadSource, /disabled=\{loading\}/);
+  assert.match(commentThreadSource, /<LinkedInCommentThreadSkeleton/);
+  assert.match(
+    commentThreadSource,
+    /previewScenario\?\.loading \? null : \(previewScenario\?\.thread \?\? null\)/
+  );
+  assert.doesNotMatch(commentThreadSource, /h-16 w-full rounded-\[20px\]/);
+  assert.match(skeletonSource, /<LinkedInReplyComposer/);
+  assert.match(skeletonSource, /placeholder="Add a comment\.\.\."/);
+  assert.match(skeletonSource, /disabled/);
+  assert.equal(
+    (skeletonSource.match(/<LinkedInCommentItemSkeleton \/>/g) ?? []).length,
+    3
+  );
+  assert.match(skeletonSource, /role="status"/);
+  assert.match(skeletonSource, /aria-label="Loading comments"/);
+});
+
 test("DM panels use circular loading and X/Twitter product copy", () => {
   const xConversationSource = readSource(
     "features/prospects/ui/components/XConversationPanel.tsx"


### PR DESCRIPTION
## Summary

- reconcile X and LinkedIn public interactions when Your interactions opens
- persist canonical thread records, group duplicate rows, and preserve stable post ordering during hydration
- restore avatar/thread controls and open complete X and LinkedIn conversations
- replace the Comments placeholder blocks with a disabled real composer and structural comment skeletons
- prevent overlapping comment sort requests and repeated forced interaction syncs

## Production behavior

No schema migration is required. Existing durable rows render immediately, and opening a prospect interaction tab performs a bounded provider reconciliation that persists newly discovered rows. Full historical recovery remains limited by provider pagination and the X account connection checkpoint.

## Validation

- 495/495 Vitest tests
- 30/30 navigation and UI regression tests
- TypeScript noEmit
- strict Oxlint with zero warnings
- TypeScript language-service diagnostics clean
- production Next.js build
- Convex development deployment
- browser E2E for X and LinkedIn interaction threads, Comments loading-to-loaded state, composer enablement, and sort refetch locking
- three completed CodeRabbit review cycles; eight confirmed issues fixed and one unsupported pagination suggestion rejected after source review

## Commits

1. fix(interactions): reconcile public prospect threads
2. fix(interactions): stabilize thread loading UX