### PR TITLE
fix(workflows): prevent Unicode preview serialization stalls

### DIFF
--- a/convex/agents/outreach/tools/socialContextShared.ts
+++ b/convex/agents/outreach/tools/socialContextShared.ts
@@ -30,6 +30,7 @@ import {
   MISSING_PROSPECT_SELECTION_MESSAGE,
 } from "./helpers";
 import { getCurrentUTCTimestamp } from "../../../../shared/lib/utils/time/timeUtils";
+import { truncateText } from "../../../../shared/lib/utils/text/truncateText";
 
 export type SocialContextMode =
   | "prospect_profile"
@@ -308,14 +309,6 @@ function toTimestampMs(value: unknown): number | undefined {
     return Number.isFinite(parsed) ? parsed : undefined;
   }
   return undefined;
-}
-
-function truncateText(value: string, maxLength = 280): string {
-  const trimmed = value.trim();
-  if (trimmed.length <= maxLength) {
-    return trimmed;
-  }
-  return `${trimmed.slice(0, maxLength - 1).trimEnd()}…`;
 }
 
 function parseDateBoundary(value: string | undefined): number | undefined {

--- a/convex/lib/workflowSafeProspect.ts
+++ b/convex/lib/workflowSafeProspect.ts
@@ -261,25 +261,27 @@ function sanitizeTwitterPostForWorkflow(
     return null;
   }
 
-  return compactObject({
-    platform: "twitter",
-    ref: summary.ref,
-    textPreview: summary.textPreview,
-    url: summary.url,
-    createdAt: summary.createdAt,
-    author: summary.author,
-    metrics: summary.metrics,
-    media: summary.media,
-    inReplyToPostId: summary.inReplyToPostId,
-    inReplyToHandle: summary.inReplyToHandle,
-    quotePostId: summary.quotePostId,
-    lang: summary.lang,
-    source: summary.source,
-    externalUrls: getExternalArticleUrls(
-      value as Record<string, unknown>,
-      "twitter"
-    ),
-  });
+  return sanitizeWorkflowValue(
+    compactObject({
+      platform: "twitter",
+      ref: summary.ref,
+      textPreview: summary.textPreview,
+      url: summary.url,
+      createdAt: summary.createdAt,
+      author: summary.author,
+      metrics: summary.metrics,
+      media: summary.media,
+      inReplyToPostId: summary.inReplyToPostId,
+      inReplyToHandle: summary.inReplyToHandle,
+      quotePostId: summary.quotePostId,
+      lang: summary.lang,
+      source: summary.source,
+      externalUrls: getExternalArticleUrls(
+        value as Record<string, unknown>,
+        "twitter"
+      ),
+    })
+  );
 }
 
 function sanitizeLinkedInPostForWorkflow(

--- a/convex/prospects.ts
+++ b/convex/prospects.ts
@@ -81,6 +81,7 @@ import {
   getWorkflowEvidencePostId,
   sanitizeProspectDataForWorkflow,
   sanitizeProspectEvidencePostsForWorkflow,
+  sanitizeWorkflowValue,
 } from "./lib/workflowSafeProspect";
 import { PREVIEW_BATCH_LIMITS } from "./lib/previewBatchLimits";
 import {
@@ -757,7 +758,7 @@ export const getProspectWorkflowDataInternal = internalQuery({
       return null;
     }
 
-    return {
+    return sanitizeWorkflowValue({
       _id: prospect._id,
       _creationTime: prospect._creationTime,
       workspaceId: prospect.workspaceId,
@@ -785,7 +786,7 @@ export const getProspectWorkflowDataInternal = internalQuery({
         Array.isArray(prospect.evidencePosts) ? prospect.evidencePosts : [],
         prospect.platform
       ),
-    };
+    });
   },
 });
 

--- a/convex/workflowSafeProspect.integration.test.ts
+++ b/convex/workflowSafeProspect.integration.test.ts
@@ -1,0 +1,79 @@
+/// <reference types="vite/client" />
+
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { internal } from "./_generated/api";
+import { sanitizeWorkflowValue } from "./lib/workflowSafeProspect";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+
+describe("prospect workflow serialization", () => {
+  test("keeps the complete workflow payload free of unpaired surrogates", async () => {
+    const t = convexTest(schema, modules);
+    const boundaryText = `${"a".repeat(278)}\ud835\ude01tail`;
+
+    const prospectId = await t.run(async (ctx) => {
+      const userId = await ctx.db.insert("users", {
+        workosUserId: "workflow-unicode-user",
+        email: "workflow-unicode@example.com",
+      });
+      const workspaceId = await ctx.db.insert("workspaces", {
+        userId,
+        name: "Workflow Unicode",
+        description: "Unicode serialization regression coverage",
+        isDefault: true,
+        entitlementSlot: 1,
+        updatedAt: 1,
+      });
+
+      return await ctx.db.insert("prospects", {
+        workspaceId,
+        userId,
+        platform: "twitter",
+        origin: "workspace_discovery",
+        externalId: "unicode-boundary-prospect",
+        data: {},
+        displayName: "Malformed display name\ud800",
+        matchedKeywords: ["malformed keyword\udc00"],
+        evidencePosts: [
+          {
+            id_str: "unicode-boundary-post",
+            full_text: boundaryText,
+            user: {
+              id_str: "unicode-author",
+              name: "Malformed author\ud800",
+            },
+            entities: {
+              media: [
+                {
+                  type: "photo",
+                  media_url_https: "https://example.com/image.png",
+                  ext_alt_text: "Malformed alt text\udc00",
+                },
+              ],
+            },
+          },
+        ],
+        status: "new",
+        qualificationStatus: "pending",
+        updatedAt: 1,
+      });
+    });
+
+    const result = await t.query(
+      internal.prospects.getProspectWorkflowDataInternal,
+      { prospectId }
+    );
+    const [post] = result?.evidencePosts ?? [];
+
+    expect(result?.displayName).toBe("Malformed display name�");
+    expect(result?.matchedKeywords).toEqual(["malformed keyword�"]);
+    expect(post?.textPreview).toBe(`${"a".repeat(278)}…`);
+    expect((post?.author as { name?: string })?.name).toBe("Malformed author�");
+    expect(
+      (post?.media as Array<{ altText?: string }> | undefined)?.[0]?.altText
+    ).toBe("Malformed alt text�");
+    expect(sanitizeWorkflowValue(result)).toEqual(result);
+  });
+});

--- a/shared/lib/twitter/contracts.ts
+++ b/shared/lib/twitter/contracts.ts
@@ -1,3 +1,5 @@
+import { truncateText } from "../utils/text/truncateText";
+
 export type TwitterPostRef = {
   platform: "twitter";
   postId: string;
@@ -175,14 +177,6 @@ function asTimestampMs(value: unknown): number | undefined {
     return Number.isFinite(timestamp) ? timestamp : undefined;
   }
   return undefined;
-}
-
-function truncateText(value: string, maxLength = 280): string {
-  const trimmed = value.trim();
-  if (trimmed.length <= maxLength) {
-    return trimmed;
-  }
-  return `${trimmed.slice(0, maxLength - 1).trimEnd()}…`;
 }
 
 export function createEmptyTwitterViewerState(input: {

--- a/shared/lib/utils/index.ts
+++ b/shared/lib/utils/index.ts
@@ -126,6 +126,7 @@ export {
 } from "./text";
 export type { HighlightOptions, HighlightResult } from "./text";
 export { getVisibleTweetPlainText, parseTweetSource } from "./text";
+export { truncateText } from "./text";
 export type { ParsedTweetSource } from "./text";
 
 // ============================================================================

--- a/shared/lib/utils/text/index.ts
+++ b/shared/lib/utils/text/index.ts
@@ -10,6 +10,7 @@ export { parseLinkedInText } from "./parseLinkedInText";
 export { parseTweetSource } from "./tweetSource";
 export type { ParsedTweetSource } from "./tweetSource";
 export { getVisibleTweetPlainText } from "./tweetText";
+export { truncateText } from "./truncateText";
 
 // Highlighting
 export {

--- a/shared/lib/utils/text/truncateText.test.ts
+++ b/shared/lib/utils/text/truncateText.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { truncateText } from "./truncateText";
+
+describe("truncateText", () => {
+  it("does not split a surrogate pair at the truncation boundary", () => {
+    const value = `${"a".repeat(278)}\ud835\ude01tail`;
+    const result = truncateText(value, 280);
+
+    expect(result).toBe(`${"a".repeat(278)}…`);
+    expect(result.length).toBeLessThanOrEqual(280);
+    expect(result).not.toMatch(/[\ud800-\udbff](?![\udc00-\udfff])/u);
+  });
+
+  it("keeps a complete surrogate pair when it fits before the ellipsis", () => {
+    const value = `${"a".repeat(277)}\ud835\ude01tail`;
+    const result = truncateText(value, 280);
+
+    expect(result).toBe(`${"a".repeat(277)}\ud835\ude01…`);
+    expect(result.length).toBe(280);
+  });
+
+  it("preserves short text and handles zero-length budgets", () => {
+    expect(truncateText("  short text  ", 20)).toBe("short text");
+    expect(truncateText("long", 1)).toBe("…");
+    expect(truncateText("long", 0)).toBe("");
+  });
+});

--- a/shared/lib/utils/text/truncateText.ts
+++ b/shared/lib/utils/text/truncateText.ts
@@ -1,0 +1,25 @@
+/**
+ * Truncate text to a UTF-16 code-unit budget without splitting a surrogate
+ * pair. The returned value never exceeds maxLength and uses one character for
+ * the ellipsis when truncation is required.
+ */
+export function truncateText(value: string, maxLength = 280): string {
+  const trimmed = value.trim();
+  const boundedMaxLength = Math.max(0, Math.floor(maxLength));
+
+  if (trimmed.length <= boundedMaxLength) {
+    return trimmed;
+  }
+  if (boundedMaxLength === 0) {
+    return "";
+  }
+
+  const prefixLength = boundedMaxLength - 1;
+  const lastPrefixCodeUnit = trimmed.charCodeAt(prefixLength - 1);
+  const safePrefixLength =
+    lastPrefixCodeUnit >= 0xd800 && lastPrefixCodeUnit <= 0xdbff
+      ? prefixLength - 1
+      : prefixLength;
+
+  return `${trimmed.slice(0, safePrefixLength).trimEnd()}…`;
+}


### PR DESCRIPTION
## Summary

- make shared text truncation preserve UTF-16 surrogate pairs while respecting the existing code-unit limit
- recursively sanitize Twitter summaries and the complete prospect workflow payload before crossing the Convex workflow boundary
- add unit and Convex integration regressions for malformed and boundary-split Unicode

## Production evidence reproduced

- prospect `q171v39aahbes2hfyyppt72jqn8d723q` failed JSON return parsing at column 2439 after truncation split a surrogate pair
- a second affected payload, `q17ez9yxnbgekpsz2f9bx9197s8d5nn5`, reproduced the same class of failure at column 2679
- replaying both production records through this fix produced no unpaired-surrogate paths and an idempotent sanitized payload

## Verification

- `pnpm test:convex`: 100 files, 499 tests passed
- focused regressions: 2 files, 4 tests passed
- `tsc --noEmit`: passed
- Oxlint and changed-file ESLint: passed
- Prettier and `git diff --check`: passed
- production Next.js build: passed
- anonymous local Convex deploy/typecheck: passed (`Convex functions ready!`)
- CodeRabbit complete staged-change review: 0 findings

## Post-deploy runbook

Do not retry the stalled workflows before this is merged and deployed. After deployment, cancel or retry the affected qualification, enrichment, and duplicate prospecting workflows; verify that the shared pool drains and workspace stats advance. Remove this branch and its isolated worktree only after that production verification succeeds.