### PR TITLE
fix(setup): persist generated profile provenance

### DIFF
--- a/convex/setupLifecycle.integration.test.ts
+++ b/convex/setupLifecycle.integration.test.ts
@@ -251,6 +251,58 @@ describe("setup session and workspace lifecycle", () => {
     });
   });
 
+  test("persists AI-generated profile provenance when generation completes", async () => {
+    const t = convexTest(schema, modules);
+    const { userId } = await seedUser(t, "generated-profile-provenance");
+    const sessionId = await seedSetupSession(t, {
+      userId,
+      suffix: "generated-profile-provenance",
+    });
+    await t.run((ctx) =>
+      ctx.db.patch("workspaceSetupSessions", sessionId, {
+        status: "generating_profiles",
+        generationRevision: 1,
+        errorCode: "generation_failed",
+        errorMessage: "A previous generation attempt failed.",
+      })
+    );
+    const generatedProfiles = [
+      {
+        title: "Hands-on SaaS founders",
+        description: "Founders actively improving product-led acquisition.",
+        painPoints: ["Finding qualified buyers"],
+        channels: ["X"],
+        provenance: "ai_generated" as const,
+        syntheticPosts: ["How do I find buyers for my SaaS?"],
+        qualificationKeywords: ["saas founder"],
+      },
+    ];
+
+    const result = await t.mutation(
+      internal.setupSessions.recordGenerationResultInternal,
+      {
+        sessionId,
+        generationRevision: 1,
+        improvedDescription: "Find hands-on SaaS founders with buying intent.",
+        generatedProfiles,
+        generationCompletedAt: 42,
+      }
+    );
+
+    expect(result).toEqual({ updated: true });
+    const session = await t.run((ctx) =>
+      ctx.db.get("workspaceSetupSessions", sessionId)
+    );
+    expect(session).toMatchObject({
+      status: "awaiting_icp_confirmation",
+      improvedDescription: "Find hands-on SaaS founders with buying intent.",
+      generatedProfiles,
+      generationCompletedAt: 42,
+    });
+    expect(session?.errorCode).toBeUndefined();
+    expect(session?.errorMessage).toBeUndefined();
+  });
+
   test("repairs legacy setup descriptions without changing generated profiles", async () => {
     const t = convexTest(schema, modules);
     const { userId } = await seedUser(t, "repair-description");

--- a/convex/setupSessions.ts
+++ b/convex/setupSessions.ts
@@ -2604,16 +2604,7 @@ export const recordGenerationResultInternal = internalMutation({
     sessionId: v.id("workspaceSetupSessions"),
     generationRevision: v.optional(v.number()),
     improvedDescription: v.string(),
-    generatedProfiles: v.array(
-      v.object({
-        title: v.string(),
-        description: v.string(),
-        painPoints: v.array(v.string()),
-        channels: v.array(v.string()),
-        syntheticPosts: v.optional(v.array(v.string())),
-        qualificationKeywords: v.optional(v.array(v.string())),
-      })
-    ),
+    generatedProfiles: v.array(icpValidator),
     draftName: v.optional(v.string()),
     generationCompletedAt: v.number(),
   },


### PR DESCRIPTION
## Summary
- use the shared ICP validator when persisting generated setup profiles
- accept the AI-generated provenance field already added by setup generation
- add a regression test covering the exact persistence failure and state transition

## Root cause
Setup generation produced valid profiles, then marked them with provenance: ai_generated. recordGenerationResultInternal used a duplicated inline validator that did not include provenance, so Convex rejected the payload and the catch path incorrectly surfaced a generic generation failure.

## Verification
- regression test failed before the fix with: Unexpected field provenance in object
- exact regression passes after the fix
- setup lifecycle suite: 23/23 passed
- full Convex suite: 500/500 passed
- TypeScript typecheck passed
- Oxlint passed for both changed files
- Prettier check passed
- CodeRabbit CLI reviewed both changed files with zero findings