### PR TITLE
fix: stabilize prospect persistence and tenant admission

### DIFF
--- a/convex/lib/prospectPersistenceHelpers.test.ts
+++ b/convex/lib/prospectPersistenceHelpers.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "vitest";
 import {
   chunkProspectsForPersistence,
+  getProspectPersistenceRetryDelayMs,
+  isProspectPersistenceOccError,
+  persistProspectWithRetry,
   PROSPECT_WRITE_TRANSACTION_BATCH_SIZE,
 } from "./prospectPersistenceHelpers";
 
@@ -19,5 +22,49 @@ describe("prospect persistence batching", () => {
 
   test("does not create an empty transaction", () => {
     expect(chunkProspectsForPersistence([])).toEqual([]);
+  });
+
+  test("uses one prospect per transaction to bound heavyweight reads", () => {
+    expect(PROSPECT_WRITE_TRANSACTION_BATCH_SIZE).toBe(1);
+    expect(chunkProspectsForPersistence([1, 2, 3])).toEqual([[1], [2], [3]]);
+  });
+
+  test("retries permanent OCC failures and preserves the committed result", async () => {
+    let attempts = 0;
+    const result = await persistProspectWithRetry(async () => {
+      attempts += 1;
+      if (attempts < 3) {
+        throw new Error(
+          "Documents read from or written to the prospects table changed while this mutation was being run"
+        );
+      }
+      return "saved";
+    });
+
+    expect(result).toBe("saved");
+    expect(attempts).toBe(3);
+  });
+
+  test("does not retry non-OCC failures", async () => {
+    let attempts = 0;
+    await expect(
+      persistProspectWithRetry(async () => {
+        attempts += 1;
+        throw new Error("validation failed");
+      })
+    ).rejects.toThrow("validation failed");
+    expect(attempts).toBe(1);
+  });
+
+  test("bounds retry delay deterministically", () => {
+    expect(getProspectPersistenceRetryDelayMs(1, 0)).toBe(100);
+    expect(getProspectPersistenceRetryDelayMs(3, 1)).toBe(500);
+    expect(
+      isProspectPersistenceOccError(
+        new Error(
+          "Documents read from or written to workspaceStatsStripes changed while this mutation was being run"
+        )
+      )
+    ).toBe(true);
   });
 });

--- a/convex/lib/prospectPersistenceHelpers.ts
+++ b/convex/lib/prospectPersistenceHelpers.ts
@@ -3,7 +3,66 @@
  * summary and analytics read models. Keep each transaction well below the
  * Convex 16 MiB read budget even when a provider returns unusually large rows.
  */
-export const PROSPECT_WRITE_TRANSACTION_BATCH_SIZE = 5;
+export const PROSPECT_WRITE_TRANSACTION_BATCH_SIZE = 1;
+export const PROSPECT_PERSISTENCE_MAX_ATTEMPTS = 5;
+const PROSPECT_PERSISTENCE_RETRY_BASE_MS = 100;
+
+export function isProspectPersistenceOccError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    /Documents read from or written to .* changed while this mutation was being run/i.test(
+      error.message
+    )
+  );
+}
+
+export function getProspectPersistenceRetryDelayMs(
+  failedAttempt: number,
+  jitterFraction = Math.random()
+) {
+  const normalizedAttempt = Math.max(1, Math.floor(failedAttempt));
+  const normalizedJitter = Math.max(0, Math.min(1, jitterFraction));
+  return (
+    PROSPECT_PERSISTENCE_RETRY_BASE_MS * 2 ** (normalizedAttempt - 1) +
+    Math.floor(normalizedJitter * PROSPECT_PERSISTENCE_RETRY_BASE_MS)
+  );
+}
+
+/**
+ * Retry the one-row, idempotent prospect mutation after Convex has exhausted
+ * its built-in OCC retries. Stable provider identity makes an uncertain
+ * committed response converge on the same prospect on the next attempt.
+ */
+export async function persistProspectWithRetry<T>(
+  persist: () => Promise<T>
+): Promise<T> {
+  let lastError: unknown;
+
+  for (
+    let attempt = 1;
+    attempt <= PROSPECT_PERSISTENCE_MAX_ATTEMPTS;
+    attempt += 1
+  ) {
+    try {
+      return await persist();
+    } catch (error) {
+      lastError = error;
+      if (
+        !isProspectPersistenceOccError(error) ||
+        attempt === PROSPECT_PERSISTENCE_MAX_ATTEMPTS
+      ) {
+        throw error;
+      }
+      await new Promise((resolve) =>
+        setTimeout(resolve, getProspectPersistenceRetryDelayMs(attempt))
+      );
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("Failed to persist prospect after repeated OCC conflicts");
+}
 
 export function chunkProspectsForPersistence<T>(prospects: T[]): T[][] {
   const batches: T[][] = [];

--- a/convex/lib/tenantSchedulerCore.test.ts
+++ b/convex/lib/tenantSchedulerCore.test.ts
@@ -7,6 +7,7 @@ import {
   clampTenantSchedulerSlotCount,
   getTenantEnqueueRetryDelayMs,
   getTenantDispatchCap,
+  getTenantStartRateDrainTimeMs,
 } from "./tenantSchedulerCore";
 
 describe("tenant scheduler capacity policy", () => {
@@ -71,5 +72,9 @@ describe("tenant scheduler capacity policy", () => {
     expect(getTenantEnqueueRetryDelayMs(1, 0)).toBe(250);
     expect(getTenantEnqueueRetryDelayMs(2, 0.5)).toBe(625);
     expect(getTenantEnqueueRetryDelayMs(3, 1)).toBe(1_250);
+  });
+
+  it("does not rate-limit the observed 219-job single-tenant burst past one minute", () => {
+    expect(getTenantStartRateDrainTimeMs(219)).toBeLessThan(60_000);
   });
 });

--- a/convex/lib/tenantSchedulerCore.ts
+++ b/convex/lib/tenantSchedulerCore.ts
@@ -1,6 +1,7 @@
 import type { Id } from "../_generated/dataModel";
 
 export const TENANT_EXECUTION_POOL_MAX_PARALLELISM = 36;
+export const TENANT_JOB_START_RATE_PER_MINUTE = 240;
 export const DEFAULT_TENANT_SCHEDULER_SLOT_COUNT = 36;
 export const DEFAULT_TENANT_BASE_SLOTS = 1;
 export const DEFAULT_TENANT_BURST_SLOTS = 30;
@@ -76,6 +77,17 @@ export function getTenantDispatchCap(args: {
     Math.floor(args.slotCount / activeTenantCount)
   );
   return Math.min(args.burstSlotsPerTenant, fairShare);
+}
+
+export function getTenantStartRateDrainTimeMs(jobCount: number) {
+  const normalizedJobCount = Math.max(0, Math.floor(jobCount));
+  const jobsAfterInitialCapacity = Math.max(
+    0,
+    normalizedJobCount - TENANT_EXECUTION_POOL_MAX_PARALLELISM
+  );
+  return Math.ceil(
+    (jobsAfterInitialCapacity / TENANT_JOB_START_RATE_PER_MINUTE) * 60_000
+  );
 }
 
 export function isTenantJobTerminal(status: string) {

--- a/convex/lib/tenantSchedulerHelpers.ts
+++ b/convex/lib/tenantSchedulerHelpers.ts
@@ -7,12 +7,13 @@ import { isTenantJobTerminal } from "./tenantSchedulerCore";
 type TenantJobCompletionKind = "succeeded" | "failed" | "cancelled";
 
 /**
- * Rebuild the lane's queue metadata from the durable queued jobs.
+ * Refresh the lane's dispatch marker from the first durable queued job.
  *
  * Enqueue deliberately does not increment the lane document: same-workspace
- * bursts otherwise make every producer contend on one row. The job rows are
- * the source of truth and this small reconciliation mutation maintains the
- * fair-dispatch index without losing increments when activations race.
+ * bursts otherwise make every producer contend on one row. `tenantJobs` is
+ * the source of truth; lane counts are only a 0/1 dispatch marker. Reading one
+ * indexed job keeps activation O(1), and once a lane is ready the remaining
+ * burst activations become read-only instead of rewriting the hot lane.
  */
 export async function reconcileTenantLaneQueueState(
   ctx: MutationCtx,
@@ -23,30 +24,40 @@ export async function reconcileTenantLaneQueueState(
 ): Promise<{
   lane: Doc<"tenantJobLanes"> | null;
   pendingCount: number;
+  activated: boolean;
 }> {
   const lane = await ctx.db.get("tenantJobLanes", args.laneId);
   if (!lane) {
-    return { lane: null, pendingCount: 0 };
+    return { lane: null, pendingCount: 0, activated: false };
   }
 
-  let pendingCount = 0;
-  let minPriority = Number.MAX_SAFE_INTEGER;
-  for await (const job of ctx.db
+  if (!args.resume && (lane.state === "ready" || lane.state === "paused")) {
+    return {
+      lane,
+      pendingCount: lane.state === "ready" ? 1 : lane.pendingCount,
+      activated: false,
+    };
+  }
+
+  const firstQueuedJob = await ctx.db
     .query("tenantJobs")
     .withIndex("by_lane_and_status_and_priority_and_queued_at", (q) =>
       q.eq("laneId", lane._id).eq("status", "queued")
-    )) {
-    pendingCount += 1;
-    minPriority = Math.min(minPriority, job.priority);
-  }
+    )
+    .first();
+  const pendingCount = firstQueuedJob ? 1 : 0;
+  const minPriority = firstQueuedJob?.priority ?? Number.MAX_SAFE_INTEGER;
 
   const state =
     lane.state === "paused" && !args.resume
       ? ("paused" as const)
-      : pendingCount > 0
+      : firstQueuedJob
         ? ("ready" as const)
         : ("idle" as const);
   const now = getCurrentUTCTimestamp();
+  const activated =
+    state === "ready" &&
+    (lane.state !== "ready" || lane.pendingCount !== pendingCount);
   if (
     lane.pendingCount !== pendingCount ||
     lane.minPriority !== minPriority ||
@@ -69,6 +80,7 @@ export async function reconcileTenantLaneQueueState(
       updatedAt: now,
     },
     pendingCount,
+    activated,
   };
 }
 

--- a/convex/lib/tenantSchedulerRateLimiter.ts
+++ b/convex/lib/tenantSchedulerRateLimiter.ts
@@ -1,6 +1,9 @@
 import { MINUTE, RateLimiter } from "@convex-dev/rate-limiter";
 import { components } from "../_generated/api";
-import { TENANT_EXECUTION_POOL_MAX_PARALLELISM } from "./tenantSchedulerCore";
+import {
+  TENANT_EXECUTION_POOL_MAX_PARALLELISM,
+  TENANT_JOB_START_RATE_PER_MINUTE,
+} from "./tenantSchedulerCore";
 
 /** Admission-rate protection is separate from concurrency slots. */
 export const tenantSchedulerRateLimiter = new RateLimiter(
@@ -8,16 +11,20 @@ export const tenantSchedulerRateLimiter = new RateLimiter(
   {
     globalTenantJobStarts: {
       kind: "token bucket",
-      rate: 240,
+      rate: TENANT_JOB_START_RATE_PER_MINUTE,
       period: MINUTE,
       capacity: TENANT_EXECUTION_POOL_MAX_PARALLELISM,
       shards: 4,
     },
     tenantJobStarts: {
       kind: "token bucket",
-      rate: 60,
+      // A single active workspace may borrow the global start budget. Slot
+      // caps still preserve newcomer headroom and rebalance across active
+      // lanes, while this no longer forces a healthy one-tenant queue to
+      // drain at only one job per second.
+      rate: TENANT_JOB_START_RATE_PER_MINUTE,
       period: MINUTE,
-      capacity: 30,
+      capacity: TENANT_EXECUTION_POOL_MAX_PARALLELISM,
     },
   }
 );

--- a/convex/prospectPersistence.integration.test.ts
+++ b/convex/prospectPersistence.integration.test.ts
@@ -1,0 +1,90 @@
+/// <reference types="vite/client" />
+
+import { convexTest } from "convex-test";
+import { describe, expect, test, vi } from "vitest";
+import { internal } from "./_generated/api";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+
+async function seedWorkspace(t: ReturnType<typeof convexTest>) {
+  return await t.run(async (ctx) => {
+    const userId = await ctx.db.insert("users", {
+      workosUserId: "prospect-persistence-user",
+      email: "prospect-persistence@example.com",
+    });
+    const workspaceId = await ctx.db.insert("workspaces", {
+      userId,
+      name: "Prospect persistence",
+      description: "Reliability test workspace",
+      isDefault: true,
+      prospectingWorkflowStatus: "running",
+      updatedAt: 1,
+    });
+    return { userId, workspaceId };
+  });
+}
+
+describe("prospect persistence reliability", () => {
+  test("persists one heavyweight prospect idempotently without a plan scan", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const workspace = await seedWorkspace(t);
+    const largeProviderPayload = "x".repeat(250_000);
+    const baseProspect = {
+      platform: "twitter" as const,
+      externalId: "provider-post-1",
+      data: {
+        id_str: "provider-post-1",
+        text: largeProviderPayload,
+        user: {
+          id_str: "provider-user-1",
+          name: "Heavy Prospect",
+          screen_name: "heavy_prospect",
+        },
+      },
+      discoverySource: "search_post" as const,
+    };
+
+    const created = await t.mutation(internal.prospects.createProspectsBatch, {
+      ...workspace,
+      prospects: [baseProspect],
+    });
+    const repeated = await t.mutation(internal.prospects.createProspectsBatch, {
+      ...workspace,
+      prospects: [
+        {
+          ...baseProspect,
+          externalId: "provider-post-2",
+          matchReason: "Updated through stable actor identity",
+        },
+      ],
+    });
+
+    expect(created).toMatchObject({ created: 1, updated: 0 });
+    expect(repeated).toMatchObject({ created: 0, updated: 1 });
+    expect(repeated.prospectIds).toEqual(created.prospectIds);
+    const stored = await t.run((ctx) => ctx.db.query("prospects").collect());
+    expect(stored).toHaveLength(1);
+    expect(stored[0]?.matchReason).toBe(
+      "Updated through stable actor identity"
+    );
+  });
+
+  test("rejects multi-row write transactions before reading prospect rows", async () => {
+    const t = convexTest(schema, modules);
+    const workspace = await seedWorkspace(t);
+    const prospect = (externalId: string) => ({
+      platform: "twitter" as const,
+      externalId,
+      data: { id_str: externalId },
+    });
+
+    await expect(
+      t.mutation(internal.prospects.createProspectsBatch, {
+        ...workspace,
+        prospects: [prospect("one"), prospect("two")],
+      })
+    ).rejects.toThrow("at most 1 rows");
+  });
+});

--- a/convex/prospects.ts
+++ b/convex/prospects.ts
@@ -1064,6 +1064,11 @@ export const createProspectsBatch = internalMutation({
       })
     ),
   },
+  returns: v.object({
+    created: v.number(),
+    updated: v.number(),
+    prospectIds: v.array(v.id("prospects")),
+  }),
   handler: async (ctx, args) => {
     // Project logging policy requires console.log for canonical success-path events.
     // eslint-disable-next-line no-console
@@ -1136,10 +1141,15 @@ export const createProspectsBatch = internalMutation({
       }
     }
 
+    // Qualification transitions own exact cycle-limit accounting and schedule
+    // capacity reconciliation. Prospect discovery only creates pending rows,
+    // so repeating the full qualified-prospect scan here amplified every save
+    // and pushed burst transactions over Convex's read limit.
     const canCreateNewProspects =
       isValidatedSetupPreviewBatch ||
-      (workspace?.prospectingWorkflowStatus !== "limit_reached" &&
-        (await canAddProspects(ctx, args.workspaceId, 1)).allowed);
+      Boolean(
+        workspace && workspace.prospectingWorkflowStatus !== "limit_reached"
+      );
 
     if (!canCreateNewProspects && processingMode !== "preview") {
       await ctx.scheduler.runAfter(
@@ -1184,15 +1194,18 @@ export const createProspectsBatch = internalMutation({
               )
               .first()
           : null;
-      const existingByExternalId = await ctx.db
-        .query("prospects")
-        .withIndex("by_external_id", (q) =>
-          q
-            .eq("workspaceId", args.workspaceId)
-            .eq("platform", p.platform)
-            .eq("externalId", p.externalId)
-        )
-        .first();
+      const existingByExternalId =
+        existingByTwitterUserId || existingByLinkedInUrn
+          ? null
+          : await ctx.db
+              .query("prospects")
+              .withIndex("by_external_id", (q) =>
+                q
+                  .eq("workspaceId", args.workspaceId)
+                  .eq("platform", p.platform)
+                  .eq("externalId", p.externalId)
+              )
+              .first();
       const existing =
         existingByTwitterUserId ??
         existingByLinkedInUrn ??

--- a/convex/tenantScheduler.integration.test.ts
+++ b/convex/tenantScheduler.integration.test.ts
@@ -2,7 +2,7 @@
 
 import { convexTest } from "convex-test";
 import { describe, expect, test, vi } from "vitest";
-import { internal } from "./_generated/api";
+import { api, internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 import schema from "./schema";
 
@@ -226,7 +226,7 @@ describe("tenant scheduler integration", () => {
     expect(
       lanesAfter.find((lane) => lane.workspaceId === paused.workspaceId)
         ?.pendingCount
-    ).toBe(2);
+    ).toBe(1);
     expect(
       lanesAfter.find((lane) => lane.workspaceId === running.workspaceId)?.state
     ).toBe("ready");
@@ -431,7 +431,7 @@ describe("tenant scheduler integration", () => {
     expect(beforeActivation.lane?.pendingCount).toBe(0);
 
     const activation = await activateWorkspaceLane(t, workspace.workspaceId);
-    expect(activation.pendingCount).toBe(100);
+    expect(activation.pendingCount).toBe(1);
     const laneAfter = await t.run(async (ctx) =>
       ctx.db
         .query("tenantJobLanes")
@@ -441,9 +441,59 @@ describe("tenant scheduler integration", () => {
         .unique()
     );
     expect(laneAfter).toMatchObject({
-      pendingCount: 100,
+      pendingCount: 1,
       minPriority: 30,
       state: "ready",
+    });
+    expect(
+      await t
+        .withIdentity({ subject: "tenant-scheduler-burst" })
+        .query(api.tenantScheduler.getWorkspaceSchedulerStatus, {
+          workspaceId: workspace.workspaceId,
+        })
+    ).toMatchObject({
+      state: "ready",
+      queuedCount: 100,
+      runningCount: 0,
+    });
+
+    expect(await activateWorkspaceLane(t, workspace.workspaceId)).toEqual({
+      pendingCount: 1,
+    });
+  });
+
+  test("repairs a stale ready marker without scanning scheduler history", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    await registerSchedulerComponents(t);
+    const workspace = await seedWorkspace(t, "stale-ready-marker");
+    await t.mutation(internal.tenantScheduler.setControlInternal, {
+      mode: "enforced",
+    });
+    const laneId = await t.run((ctx) =>
+      ctx.db.insert("tenantJobLanes", {
+        tenantKey: `workspace:${workspace.workspaceId}`,
+        workspaceId: workspace.workspaceId,
+        userId: workspace.userId,
+        state: "ready",
+        pendingCount: 1,
+        runningCount: 0,
+        minPriority: 30,
+        lastDispatchedAt: 0,
+        updatedAt: 1,
+      })
+    );
+
+    expect(
+      await t.mutation(
+        internal.tenantScheduler.reconcileQueuedLanesInternal,
+        {}
+      )
+    ).toMatchObject({ reconciled: 1, hasMore: false });
+    expect(await t.run((ctx) => ctx.db.get(laneId))).toMatchObject({
+      state: "idle",
+      pendingCount: 0,
+      minPriority: Number.MAX_SAFE_INTEGER,
     });
   });
 
@@ -1039,7 +1089,7 @@ describe("tenant scheduler integration", () => {
           )
           .unique()
       )
-    ).toMatchObject({ state: "paused", pendingCount: 5 });
+    ).toMatchObject({ state: "paused", pendingCount: 1 });
     await t.mutation(internal.tenantScheduler.resumeWorkspaceInternal, {
       workspaceId: owner.workspaceId,
     });
@@ -1055,7 +1105,7 @@ describe("tenant scheduler integration", () => {
           )
           .unique()
       )
-    ).toMatchObject({ state: "ready", pendingCount: 5 });
+    ).toMatchObject({ state: "ready", pendingCount: 1 });
 
     await t.run(async (ctx) => {
       const countsByLane = new Map<string, number>();

--- a/convex/tenantScheduler.ts
+++ b/convex/tenantScheduler.ts
@@ -412,8 +412,8 @@ export const enqueueTenantJobInternal = internalMutation({
 
     // Do not update the lane in the enqueue transaction. Concurrent producers
     // for one workspace used to conflict permanently on this shared row. The
-    // durable job is the source of truth; an idempotent activation reconciles
-    // exact queue metadata after commit.
+    // durable job is the source of truth; an idempotent activation maintains
+    // only the O(1) ready marker after commit.
     await ctx.scheduler.runAfter(
       0,
       internal.tenantScheduler.activateLaneInternal,
@@ -538,7 +538,7 @@ export const activateLaneInternal = internalMutation({
   returns: v.object({ pendingCount: v.number() }),
   handler: async (ctx, args) => {
     const result = await reconcileTenantLaneQueueState(ctx, args);
-    if (result.pendingCount > 0 && result.lane?.state !== "paused") {
+    if (result.activated) {
       await pingDispatcher(ctx);
     }
     return { pendingCount: result.pendingCount };
@@ -549,22 +549,39 @@ export const reconcileQueuedLanesInternal = internalMutation({
   args: {},
   returns: v.object({ reconciled: v.number(), hasMore: v.boolean() }),
   handler: async (ctx) => {
-    const queuedJobs = await ctx.db
-      .query("tenantJobs")
-      .withIndex("by_status_and_lease_expires_at", (q) =>
-        q.eq("status", "queued")
-      )
-      .take(100);
-    const laneIds = Array.from(new Set(queuedJobs.map((job) => job.laneId)));
+    const [queuedJobs, readyLanes] = await Promise.all([
+      ctx.db
+        .query("tenantJobs")
+        .withIndex("by_status_and_lease_expires_at", (q) =>
+          q.eq("status", "queued")
+        )
+        .take(100),
+      ctx.db
+        .query("tenantJobLanes")
+        .withIndex("by_state_and_last_dispatched_at", (q) =>
+          q.eq("state", "ready")
+        )
+        .take(100),
+    ]);
+    const laneIds = Array.from(
+      new Set([
+        ...queuedJobs.map((job) => job.laneId),
+        ...readyLanes.map((lane) => lane._id),
+      ])
+    );
+    const readyLaneIds = new Set(readyLanes.map((lane) => String(lane._id)));
     for (const laneId of laneIds) {
-      await reconcileTenantLaneQueueState(ctx, { laneId });
+      await reconcileTenantLaneQueueState(ctx, {
+        laneId,
+        resume: readyLaneIds.has(String(laneId)) ? true : undefined,
+      });
     }
     if (laneIds.length > 0) {
       await pingDispatcher(ctx);
     }
     return {
       reconciled: laneIds.length,
-      hasMore: queuedJobs.length === 100,
+      hasMore: queuedJobs.length === 100 || readyLanes.length === 100,
     };
   },
 });
@@ -837,7 +854,7 @@ export const dispatchBatchInternal = internalMutation({
 
       const now = getCurrentUTCTimestamp();
       const leaseExpiresAt = now + control.leaseDurationMs;
-      const nextPendingCount = Math.max(0, lane.pendingCount - 1);
+      const hasNextQueuedJob = candidate.nextPriority !== undefined;
       await Promise.all([
         ctx.db.patch("tenantJobs", job._id, {
           status: "running",
@@ -857,12 +874,10 @@ export const dispatchBatchInternal = internalMutation({
           updatedAt: now,
         }),
         ctx.db.patch("tenantJobLanes", lane._id, {
-          pendingCount: nextPendingCount,
+          pendingCount: hasNextQueuedJob ? 1 : 0,
           runningCount: lane.runningCount + 1,
-          minPriority:
-            candidate.nextPriority ??
-            (nextPendingCount > 0 ? lane.minPriority : Number.MAX_SAFE_INTEGER),
-          state: nextPendingCount > 0 ? "ready" : "idle",
+          minPriority: candidate.nextPriority ?? Number.MAX_SAFE_INTEGER,
+          state: hasNextQueuedJob ? "ready" : "idle",
           lastDispatchedAt: now,
           updatedAt: now,
         }),
@@ -1465,27 +1480,40 @@ export const getWorkspaceSchedulerStatus = query({
   }),
   handler: async (ctx, { workspaceId }) => {
     await requireOwnedWorkspace(ctx, workspaceId);
-    const [control, override, lane] = await Promise.all([
-      ctx.db
-        .query("tenantSchedulerControls")
-        .withIndex("by_key", (q) => q.eq("key", "global"))
-        .unique(),
-      ctx.db
-        .query("tenantSchedulerWorkspaceOverrides")
-        .withIndex("by_workspace", (q) => q.eq("workspaceId", workspaceId))
-        .unique(),
-      ctx.db
-        .query("tenantJobLanes")
-        .withIndex("by_workspace", (q) => q.eq("workspaceId", workspaceId))
-        .unique(),
-    ]);
+    const [control, override, lane, queuedJobs, runningJobs] =
+      await Promise.all([
+        ctx.db
+          .query("tenantSchedulerControls")
+          .withIndex("by_key", (q) => q.eq("key", "global"))
+          .unique(),
+        ctx.db
+          .query("tenantSchedulerWorkspaceOverrides")
+          .withIndex("by_workspace", (q) => q.eq("workspaceId", workspaceId))
+          .unique(),
+        ctx.db
+          .query("tenantJobLanes")
+          .withIndex("by_workspace", (q) => q.eq("workspaceId", workspaceId))
+          .unique(),
+        ctx.db
+          .query("tenantJobs")
+          .withIndex("by_workspace_and_status", (q) =>
+            q.eq("workspaceId", workspaceId).eq("status", "queued")
+          )
+          .take(1001),
+        ctx.db
+          .query("tenantJobs")
+          .withIndex("by_workspace_and_status", (q) =>
+            q.eq("workspaceId", workspaceId).eq("status", "running")
+          )
+          .take(1001),
+      ]);
     const state: "not_initialized" | "idle" | "ready" | "paused" =
       lane?.state ?? "not_initialized";
     return {
       mode: override?.mode ?? control?.mode ?? "legacy",
       state,
-      queuedCount: lane?.pendingCount ?? 0,
-      runningCount: lane?.runningCount ?? 0,
+      queuedCount: Math.min(queuedJobs.length, 1000),
+      runningCount: Math.min(runningJobs.length, 1000),
       globalSlots: control?.slotCount ?? DEFAULT_TENANT_SCHEDULER_SLOT_COUNT,
       baseSlotsPerTenant:
         control?.baseSlotsPerTenant ?? DEFAULT_TENANT_BASE_SLOTS,

--- a/convex/workflows/prospecting.ts
+++ b/convex/workflows/prospecting.ts
@@ -38,7 +38,10 @@ import {
   normalizeLinkedInPostQueryStats,
 } from "../lib/linkedinSearchHelpers";
 import { PREVIEW_BATCH_LIMITS } from "../lib/previewBatchLimits";
-import { chunkProspectsForPersistence } from "../lib/prospectPersistenceHelpers";
+import {
+  chunkProspectsForPersistence,
+  persistProspectWithRetry,
+} from "../lib/prospectPersistenceHelpers";
 import { hasRequiredWorkspaceAgentData } from "../lib/workspaceSetup";
 import type {
   TwitterPost,
@@ -1111,9 +1114,8 @@ export const searchTwitterInternal = internalAction({
 
     let saved = 0;
     for (const batch of chunkProspectsForPersistence(prospectsToSave)) {
-      const saveResult = await ctx.runMutation(
-        internal.prospects.createProspectsBatch,
-        {
+      const saveResult = await persistProspectWithRetry(() =>
+        ctx.runMutation(internal.prospects.createProspectsBatch, {
           userId: workspace.userId,
           workspaceId: args.workspaceId,
           processingMode: args.processingMode,
@@ -1125,7 +1127,7 @@ export const searchTwitterInternal = internalAction({
               setupRevision: args.setupRevision,
             })
           ),
-        }
+        })
       );
       saved += saveResult.created + saveResult.updated;
     }
@@ -1349,9 +1351,8 @@ export const searchLinkedInInternal = internalAction({
     ) => {
       for (const batch of chunkLinkedInProspectsForSave(prospects)) {
         try {
-          const saveResult = await ctx.runMutation(
-            internal.prospects.createProspectsBatch,
-            {
+          const saveResult = await persistProspectWithRetry(() =>
+            ctx.runMutation(internal.prospects.createProspectsBatch, {
               userId: workspace.userId,
               workspaceId: args.workspaceId,
               processingMode: args.processingMode,
@@ -1363,7 +1364,7 @@ export const searchLinkedInInternal = internalAction({
                   setupRevision: args.setupRevision,
                 })
               ),
-            }
+            })
           );
           totalSaved += saveResult.created + saveResult.updated;
           if (surface === "people") {
@@ -1747,14 +1748,13 @@ async function expandPreviewSimilarProfiles(args: {
 
   let saved = 0;
   for (const batch of chunkProspectsForPersistence(prospectsToSave)) {
-    const saveResult = await args.ctx.runMutation(
-      internal.prospects.createProspectsBatch,
-      {
+    const saveResult = await persistProspectWithRetry(() =>
+      args.ctx.runMutation(internal.prospects.createProspectsBatch, {
         userId: args.workspace.userId,
         workspaceId: args.workspace._id,
         processingMode: "preview",
         prospects: batch,
-      }
+      })
     );
     saved += saveResult.created + saveResult.updated;
   }

--- a/docs/convex/reliability-program-2026-08-27.md
+++ b/docs/convex/reliability-program-2026-08-27.md
@@ -148,6 +148,31 @@ source-document changes write signed deltas, and readers combine baseline plus
 stripes before clamping user-visible totals. This makes the cutover correct for
 updates and deletes of pre-cutover rows without scanning 60,000+ prospects.
 
+### Post-rollup stabilization incident — 2026-08-28
+
+After PR #41 deployed, production remained globally enforced with the correct
+Workflow 64 + tenant execution 36 pool split, no overrides, no expired leases,
+and no new permanent enqueue/resume OCC. A one-workspace traffic burst exposed
+two remaining hot-path problems:
+
+- the queue reached 219 queued and 20 running jobs while 16 of 36 execution
+  slots were still free; oldest queue age rose from about 370 to 386 seconds;
+  the queue later drained without mutation, but the last 800 admissions retained
+  p50 about 122 seconds, p95 about 439 seconds, and max about 474 seconds;
+- `activateLaneInternal` accumulated about 4,007 OCC retries on
+  `tenantJobLanes` and 2,524 on the queued `tenantJobs` range because every
+  enqueue scheduled a full same-lane reconciliation; and
+- `createProspectsBatch` bytes-read failures continued after the five-row batch
+  mitigation, reaching 126, while new permanent OCC appeared on `prospects`,
+  `prospectSummaries`, and `workspaceStatsStripes`. Each failed transaction
+  repeated heavyweight identity reads and a full qualified-prospect capacity
+  scan before the row could be persisted.
+
+The queue recovery proves no durable scheduler job was lost, but it does not
+meet the admission SLO. This evidence is the gate for the focused stabilization
+branch; the deferred fit-score Aggregate branch remains unpushed until these
+write-path failures are fixed and canaried.
+
 ## Changes and invariants
 
 ### Tenant enqueue contention
@@ -155,16 +180,26 @@ updates and deletes of pre-cutover rows without scanning 60,000+ prospects.
 `tenantJobs` is now the durable queue source of truth. Enqueue resolves its lane
 through an immutable per-tenant binding, inserts a job without reading or
 incrementing the mutable lane row, then schedules a lane activation.
-Activation rebuilds exact `pendingCount`, `minPriority`, and ready/paused state
-from the lane's indexed queued jobs. A one-minute bounded repair pass catches a
+Activation now reads at most the first indexed queued job and stores only a 0/1
+ready marker plus its priority. Once a lane is ready, duplicate burst
+activations return without reading the queued range, rewriting the lane, or
+pinging the dispatcher. Durable job rows remain the exact queue source, and the
+workspace status query counts bounded indexed queued/running rows rather than
+presenting the marker as a total. A one-minute bounded repair pass catches a
 missed activation independently of the external heartbeat.
 
 This preserves one fair lane per workspace, exact priority/queue ordering,
 idempotency keys, workspace ownership checks, and pause semantics. It does not
 replace the lane with a deployment-wide counter or another global write point.
 The 100-job same-workspace concurrency test asserts one immutable binding, 100
-durable jobs, and exact reconciled lane totals; activation can no longer make a
-steady-state producer read `tenantJobLanes`.
+durable jobs, and one ready marker; activation can no longer make a steady-state
+producer read or update the mutable lane.
+
+The per-tenant start limiter now matches the existing 240 starts/minute global
+budget with an initial capacity of 36. Per-tenant slot caps remain the fairness
+authority: one active workspace may borrow capacity, while 2, 3, 10, 50, or 100
+active lanes immediately reduce its fair share. The measured 219-job burst is
+therefore no longer forced past one minute by the old 60 starts/minute limiter.
 
 Every action caller now uses a shared, bounded three-attempt recovery helper;
 setup and plan-batch workflows put the same idempotent operation behind durable
@@ -181,7 +216,7 @@ remain visible for operator action.
 `resumeWorkspaceInternal` no longer reads or writes `tenantJobLanes` or scans
 the queued `tenantJobs` range in the caller's transaction. It atomically
 schedules an internal reconciliation mutation and returns. The scheduled
-mutation resolves the lane and rebuilds exact queue metadata with resume
+mutation resolves the lane and rebuilds its bounded ready marker with resume
 enabled; Convex durably retries internal OCC errors, and duplicate resume
 requests are idempotent. This removes both measured conflict surfaces from the
 recovery call while preserving jobs enqueued before or after the resume request.
@@ -200,10 +235,19 @@ stale RAG entries can be reindexed later as a bounded cleanup.
 ### Prospect persistence read budget
 
 All three production writers that call `createProspectsBatch` now use one
-central persistence batch size of 5. The mutation rejects a larger internal
-batch so a future caller cannot silently reintroduce the large transaction.
-Twitter, LinkedIn, and setup-preview writers retain every input and combine the
-per-batch results; no prospect is truncated or filtered by this change.
+prospect per transaction. The mutation rejects a larger internal batch so a
+future caller cannot silently reintroduce read amplification. Identity lookup
+stops after a stable Twitter/LinkedIn actor match instead of also reading the
+external-ID row, and pending discovery no longer repeats the full qualified
+capacity scan already owned by the workflow gate and qualification transition.
+
+Every one-row save is idempotent by stable provider identity and has a bounded
+five-attempt action-level OCC retry after Convex's built-in retries are
+exhausted. Twitter, LinkedIn, and setup-preview writers retain every input and
+combine the per-row results; no prospect is truncated or filtered by this
+change. This also covers measured conflicts in `prospectSummaries` and
+`workspaceStatsStripes`, because those trigger writes remain in the same
+one-prospect transaction and the entire idempotent operation is retried.
 
 ### Setup workflow self-healing
 
@@ -247,17 +291,17 @@ reports the expected split and the repair pass bounds external drift.
 
 ## Contention audit
 
-| State                     | Write shape               | Finding                                                                      | Decision                                                                              |
-| ------------------------- | ------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| `prospectSummaries`       | One row per prospect      | Naturally partitioned; the large batch amplified reads, not one global write | Keep; batch writers at 5                                                              |
-| `workspaceStats`          | One row per workspace     | 3 permanent failures and 64 measured retries                                 | Widen to 32 deterministic signed-delta stripes                                        |
-| `workspaceAnalyticsDaily` | One row per workspace/day | 12 permanent failures and 23,000+ measured retries                           | Widen to 32 deterministic signed-delta stripes                                        |
-| `workspaceAgentOpsDaily`  | One row per workspace/day | 85 permanent failures and 10,000+ measured retries                           | Widen to 32 deterministic signed-delta stripes                                        |
-| Provider budget state     | One row per provider      | Deliberate serialization enforces exact request spacing                      | Keep; existing action-level bounded OCC retry is appropriate                          |
-| Provider circuit state    | One row per provider      | Healthy calls caused unnecessary writes                                      | Fixed by writing only state transitions                                               |
-| Action Retrier            | Component-owned run rows  | Automatic cleanup permanently exceeds bytes read at 1,040 large rows         | Upgrade to 0.3.1 and schedule per-run cleanup after terminal state is safely observed |
-| Scheduler resume          | One lane + queued range   | Two permanent conflicts while enqueue traffic continued                      | Fixed by durable, idempotent reconciliation outside the caller transaction            |
-| Memory RAG ID hydration   | Up to 64 indexed reads    | Stale component IDs failed strict canonical-ID argument validation           | Widen reader; resolve through the existing workspace-scoped legacy-ID index           |
+| State                     | Write shape               | Finding                                                              | Decision                                                                              |
+| ------------------------- | ------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `prospectSummaries`       | One row per prospect      | Naturally partitioned; multi-row retries amplified heavyweight reads | Keep; one prospect per idempotent transaction with bounded OCC retry                  |
+| `workspaceStats`          | One row per workspace     | 3 permanent failures and 64 measured retries                         | Widen to 32 deterministic signed-delta stripes                                        |
+| `workspaceAnalyticsDaily` | One row per workspace/day | 12 permanent failures and 23,000+ measured retries                   | Widen to 32 deterministic signed-delta stripes                                        |
+| `workspaceAgentOpsDaily`  | One row per workspace/day | 85 permanent failures and 10,000+ measured retries                   | Widen to 32 deterministic signed-delta stripes                                        |
+| Provider budget state     | One row per provider      | Deliberate serialization enforces exact request spacing              | Keep; existing action-level bounded OCC retry is appropriate                          |
+| Provider circuit state    | One row per provider      | Healthy calls caused unnecessary writes                              | Fixed by writing only state transitions                                               |
+| Action Retrier            | Component-owned run rows  | Automatic cleanup permanently exceeds bytes read at 1,040 large rows | Upgrade to 0.3.1 and schedule per-run cleanup after terminal state is safely observed |
+| Scheduler resume          | One lane + queued range   | Two permanent conflicts while enqueue traffic continued              | Fixed by durable, idempotent reconciliation outside the caller transaction            |
+| Memory RAG ID hydration   | Up to 64 indexed reads    | Stale component IDs failed strict canonical-ID argument validation   | Widen reader; resolve through the existing workspace-scoped legacy-ID index           |
 
 Aggregate is a good fit for the exact fit-score histogram: it can namespace by
 workspace/filter scope and count ten bounded score bins without reading every
@@ -408,6 +452,31 @@ event is newer than the pre-fix incident window.
   internal and validates the component run ID with the package validator.
 - Realtime behavior is preserved because the public readers remain reactive
   Convex queries; they now subscribe to both baseline and stripe index ranges.
+
+### Focused stabilization verification — 2026-08-28
+
+- Full Convex suite: 108 files and 546 tests passed. New coverage uses a 250 KB
+  provider payload, proves stable actor identity makes an uncertain repeat
+  converge on one prospect, rejects multi-row persistence, verifies 100 durable
+  queued jobs behind one lane-ready marker, reports the real bounded queue count,
+  and repairs a stale ready marker.
+- The observed 219-job production burst is below the pure rate-budget
+  one-minute gate after initial capacity; A=100/B=C=1 and 10/50/100-lane
+  fairness coverage remains green.
+- TypeScript, strict Oxlint, changed-file ESLint, `git diff --check`, and the
+  production Next.js build with all 74 static/PPR pages passed.
+- Convex review found no unbounded collection added: persistence is one row,
+  activation reads zero rows for an already-ready/paused lane and at most one
+  queued row otherwise, repair samples at most 100 queued jobs and 100 ready
+  lanes, and the authenticated status query caps each indexed job range at
+  1,001 rows.
+- Security review found no new public write or authorization surface. The only
+  changed public query retains `requireOwnedWorkspace`; scheduler and
+  persistence writes remain internal, scheduled targets remain internal, and
+  the provider `v.any()` payload is pre-existing and inaccessible to clients.
+- No React/TSX or schema file changed in this focused hotfix. The production
+  build is the proportionate React verification; no migration or backfill is
+  required for deployment.
 
 ## Cleanup candidates — no deletion in this phase
 


### PR DESCRIPTION
## Summary

- persist one prospect per transaction, remove the repeated full capacity scan from the save hot path, and add bounded idempotent OCC recovery
- replace full same-lane activation scans with an O(1) ready marker while preserving durable queue ordering, pause/resume semantics, and bounded repair
- let a single active workspace use the existing global 240 starts/minute budget while retaining slot-based cross-workspace fairness
- add production-shaped persistence, burst, queue-status, stale-marker, and rate-budget coverage
- record the Aug 28 production evidence and stabilization decisions in the reliability runbook

## Production evidence addressed

- createProspectsBatch bytes-read failures reached 126 after the earlier five-row mitigation
- activateLaneInternal accumulated about 4,007 tenantJobLanes OCC retries and 2,524 tenantJobs range retries
- one workspace reached 219 queued jobs with free execution slots; the recovered incident retained p50 about 122s, p95 about 439s, and max about 474s admission latency

## Verification

- pnpm test:convex: 108 files / 546 tests passed
- pnpm exec tsc --noEmit
- pnpm lint:strict
- changed-file ESLint
- pnpm build: 74 static/PPR pages
- Convex performance, reviewer, and security checks

## Rollout

No schema migration or backfill is required. After merge/deploy, monitor new createProspectsBatch bytes-read failures, prospect/summary/stripe permanent OCC, activation OCC, queue age, admission p50/p95/max, expired leases, and pool/slot drift before resuming the deferred fit-score Aggregate phase.
