### PR TITLE
fix: cursor paginate Agent Ops memory inventory

### DIFF
--- a/convex/agentOps.ts
+++ b/convex/agentOps.ts
@@ -31,6 +31,10 @@ import {
   matchesAgentOpsMemoryInventoryFilters,
 } from "./lib/agentOpsCore";
 import {
+  decodeAgentOpsMemoryInventoryCursor,
+  encodeAgentOpsMemoryInventoryCursor,
+} from "./lib/agentOpsInventoryCursor";
+import {
   type WorkspaceAgentMemoryInventoryRecord,
   WORKSPACE_MEMORY_CATEGORIES,
   getWorkspaceAgentMemoryById,
@@ -48,6 +52,8 @@ import { buildQueryCandidateCanonicalRecord } from "./lib/memoryHelpers";
 const AGENT_OPS_ACTIVITY_MEMORY_LIMIT = 80;
 const AGENT_OPS_MEMORY_PAGE_SIZE_MAX = 100;
 const AGENT_OPS_MEMORY_SCAN_BATCH_SIZE = 250;
+const AGENT_OPS_MEMORY_CURSOR_SCAN_LIMIT = 5_000;
+const AGENT_OPS_MEMORY_EXPORT_PAGE_SIZE_MAX = 500;
 const UTC_DAY_MS = 24 * 60 * 60 * 1000;
 
 async function requireOwnedWorkspaceContext(
@@ -148,20 +154,153 @@ async function loadMemoryInventoryChunk(
     limit: number;
   }
 ): Promise<MemoryInventoryChunkResult> {
-  const result: MemoryInventoryChunkResult = await ctx.runQuery(
-    internal.agentOpsReadModels
-      .listWorkspaceAgentMemoryInventoryRecentPageInternal,
-    {
-      workspaceId: args.workspaceId,
-      startMs: args.window.startMs,
-      endMs: args.window.endMs,
-      paginationOpts: {
-        cursor: args.cursor,
-        numItems: args.limit,
-      },
-    }
-  );
+  const paginationOpts = {
+    cursor: args.cursor,
+    numItems: args.limit,
+  };
+  const result: MemoryInventoryChunkResult =
+    args.sort === "impact_desc"
+      ? await ctx.runQuery(
+          internal.agentOpsReadModels
+            .listWorkspaceAgentMemoryInventoryImpactPageInternal,
+          { workspaceId: args.workspaceId, paginationOpts }
+        )
+      : args.sort === "confidence_desc"
+        ? await ctx.runQuery(
+            internal.agentOpsReadModels
+              .listWorkspaceAgentMemoryInventoryConfidencePageInternal,
+            { workspaceId: args.workspaceId, paginationOpts }
+          )
+        : await ctx.runQuery(
+            internal.agentOpsReadModels
+              .listWorkspaceAgentMemoryInventoryRecentPageInternal,
+            {
+              workspaceId: args.workspaceId,
+              startMs: args.window.startMs,
+              endMs: args.window.endMs,
+              paginationOpts,
+            }
+          );
   return result;
+}
+
+function buildMemoryInventoryCursorScopeKey(args: {
+  workspaceId: Id<"workspaces">;
+  range: string;
+  from?: number;
+  to?: number;
+  fromDate?: string;
+  toDate?: string;
+  sort: "impact_desc" | "confidence_desc" | "recent_desc";
+  search?: string;
+  category?: string;
+}) {
+  return JSON.stringify([
+    String(args.workspaceId),
+    args.range,
+    args.from ?? null,
+    args.to ?? null,
+    args.fromDate ?? null,
+    args.toDate ?? null,
+    args.sort,
+    args.search?.trim().toLowerCase() ?? "",
+    args.category ?? "all",
+  ]);
+}
+
+async function loadCursorMemoryInventoryPage(
+  ctx: Pick<ActionCtx, "runQuery">,
+  args: {
+    workspaceId: Id<"workspaces">;
+    window: TimeWindow;
+    sort: "impact_desc" | "confidence_desc" | "recent_desc";
+    search?: string;
+    category?: string;
+    cursor?: string;
+    pageSize: number;
+    scopeKey: string;
+  }
+) {
+  const state = decodeAgentOpsMemoryInventoryCursor(
+    args.cursor,
+    args.scopeKey,
+    args.window
+  );
+  const snapshotWindow = {
+    startMs: state.windowStartMs,
+    endMs: state.windowEndMs,
+  };
+  const matches: WorkspaceAgentMemoryInventoryRecord[] = [];
+  let scanned = 0;
+
+  if (state.bufferedMemoryIds.length > 0) {
+    const bufferedRows: WorkspaceAgentMemoryInventoryRecord[] =
+      await ctx.runQuery(
+        internal.agentOpsReadModels
+          .getWorkspaceAgentMemoryInventoryRowsInternal,
+        {
+          workspaceId: args.workspaceId,
+          memoryIds: state.bufferedMemoryIds,
+        }
+      );
+    matches.push(
+      ...bufferedRows.filter(
+        (row) =>
+          row.createdAt >= snapshotWindow.startMs &&
+          row.createdAt < snapshotWindow.endMs &&
+          matchesAgentOpsMemoryInventoryFilters(row, {
+            search: args.search,
+            category: args.category,
+          })
+      )
+    );
+    state.bufferedMemoryIds = [];
+  }
+
+  while (
+    matches.length < args.pageSize &&
+    !state.sourceDone &&
+    scanned < AGENT_OPS_MEMORY_CURSOR_SCAN_LIMIT
+  ) {
+    const chunk = await loadMemoryInventoryChunk(ctx, {
+      workspaceId: args.workspaceId,
+      window: snapshotWindow,
+      sort: args.sort,
+      cursor: state.sourceCursor,
+      limit: Math.min(
+        AGENT_OPS_MEMORY_SCAN_BATCH_SIZE,
+        Math.max(50, args.pageSize - matches.length)
+      ),
+    });
+    state.sourceCursor = chunk.continueCursor;
+    state.sourceDone = chunk.isDone;
+    scanned += chunk.page.length;
+    matches.push(
+      ...chunk.page.filter(
+        (row) =>
+          row.createdAt >= snapshotWindow.startMs &&
+          row.createdAt < snapshotWindow.endMs &&
+          matchesAgentOpsMemoryInventoryFilters(row, {
+            search: args.search,
+            category: args.category,
+          })
+      )
+    );
+  }
+
+  const pageRows = matches.slice(0, args.pageSize);
+  state.bufferedMemoryIds = matches
+    .slice(args.pageSize)
+    .map((row) => row.memoryId);
+  const continueCursor = encodeAgentOpsMemoryInventoryCursor(state);
+
+  return {
+    rows: pageRows,
+    continueCursor,
+    isDone: continueCursor === null,
+    scanned,
+    window: snapshotWindow,
+  };
 }
 
 async function scanWindowMemoryInventoryMatches(
@@ -734,46 +873,106 @@ export const getAgentOpsMemoryInventoryPageSnapshot = action({
     sort: v.optional(agentOpsMemorySortValidator),
     page: v.optional(v.number()),
     pageSize: v.optional(v.number()),
+    cursor: v.optional(v.string()),
+    exportMode: v.optional(v.boolean()),
   },
-  handler: async (ctx, args) => {
-    const context = await ctx.runQuery(
+  handler: async (
+    ctx,
+    args
+  ): Promise<{
+    rows: ReturnType<typeof buildAgentOpsMemoryInventoryPage>["rows"];
+    page: number;
+    totalCount: number | null;
+    totalPages: number;
+    availableCategories: string[];
+    continueCursor: string | null;
+    isDone: boolean;
+    scanned: number;
+  }> => {
+    const context: { reportingTimeZone: string | null } = await ctx.runQuery(
       internal.agentOps.getAgentOpsSnapshotContextInternal,
       { workspaceId: args.workspaceId }
     );
-    const window = normalizeAnalyticsWindow({
+    const window: TimeWindow = normalizeAnalyticsWindow({
       ...args,
       timeZone: context.reportingTimeZone ?? args.timeZone,
       nowMs: getCurrentUTCTimestamp(),
     }).current;
     const requestedPage = Math.max(0, Math.floor(args.page ?? 0));
+    const pageSizeMax = args.exportMode
+      ? AGENT_OPS_MEMORY_EXPORT_PAGE_SIZE_MAX
+      : AGENT_OPS_MEMORY_PAGE_SIZE_MAX;
     const pageSize = Math.min(
-      AGENT_OPS_MEMORY_PAGE_SIZE_MAX,
+      pageSizeMax,
       Math.max(1, Math.floor(args.pageSize ?? 10))
     );
-    const scanResult = await scanWindowMemoryInventoryMatches(ctx, {
+    const pageResult = await loadCursorMemoryInventoryPage(ctx, {
       workspaceId: args.workspaceId,
       window,
       sort: args.sort ?? "impact_desc",
       search: args.search,
       category: args.category,
-      matchLimit: (requestedPage + 1) * pageSize,
+      cursor: args.cursor,
+      pageSize,
+      scopeKey: buildMemoryInventoryCursorScopeKey({
+        workspaceId: args.workspaceId,
+        range: args.range,
+        from: args.from,
+        to: args.to,
+        fromDate: args.fromDate,
+        toDate: args.toDate,
+        sort: args.sort ?? "impact_desc",
+        search: args.search,
+        category: args.category,
+      }),
     });
-    const totalPages = Math.max(
-      1,
-      Math.ceil(scanResult.totalMatchedCount / pageSize)
-    );
-    const page = Math.min(totalPages - 1, requestedPage);
-    const startIndex = page * pageSize;
-    return buildAgentOpsMemoryInventoryPage({
-      rows: scanResult.matches.slice(startIndex, startIndex + pageSize),
-      page,
-      totalCount: scanResult.totalMatchedCount,
-      totalPages,
+    const hasDynamicFilters =
+      (args.search?.trim().length ?? 0) > 0 ||
+      (args.category !== undefined && args.category !== "all");
+    const totalCount: number | null =
+      args.exportMode || hasDynamicFilters
+        ? null
+        : await ctx.runQuery(
+            internal.agentOps.getAgentOpsMemoryInventoryCountInternal,
+            {
+              workspaceId: args.workspaceId,
+              startMs: pageResult.window.startMs,
+              endMs: pageResult.window.endMs,
+            }
+          );
+    const pageData = buildAgentOpsMemoryInventoryPage({
+      rows: pageResult.rows,
+      page: requestedPage,
+      totalCount: totalCount ?? 0,
+      totalPages:
+        totalCount === null
+          ? requestedPage + (pageResult.isDone ? 1 : 2)
+          : Math.max(1, Math.ceil(totalCount / pageSize)),
       availableCategories: [...WORKSPACE_MEMORY_CATEGORIES].sort(
         (left, right) => left.localeCompare(right)
       ),
     });
+    return {
+      ...pageData,
+      totalCount,
+      continueCursor: pageResult.continueCursor,
+      isDone: pageResult.isDone,
+      scanned: pageResult.scanned,
+    };
   },
+});
+
+export const getAgentOpsMemoryInventoryCountInternal = internalQuery({
+  args: {
+    workspaceId: v.id("workspaces"),
+    startMs: v.number(),
+    endMs: v.number(),
+  },
+  handler: async (ctx, args) =>
+    await getUnfilteredMemoryInventoryCount(ctx.db, {
+      workspaceId: args.workspaceId,
+      window: { startMs: args.startMs, endMs: args.endMs },
+    }),
 });
 
 export const getAgentOpsDashboard = query({

--- a/convex/agentOpsInventory.integration.test.ts
+++ b/convex/agentOpsInventory.integration.test.ts
@@ -1,0 +1,161 @@
+/// <reference types="vite/client" />
+
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { api } from "./_generated/api";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+
+describe("Agent Ops memory inventory pagination", () => {
+  test("advances through a large inventory without rescanning prior rows", async () => {
+    const t = convexTest(schema, modules);
+    const seeded = await t.run(async (ctx) => {
+      const userId = await ctx.db.insert("users", {
+        workosUserId: "agent-ops-inventory-owner",
+        email: "agent-ops-inventory@example.com",
+      });
+      const workspaceId = await ctx.db.insert("workspaces", {
+        userId,
+        name: "Agent Ops inventory",
+        description: "Cursor pagination test",
+        isDefault: true,
+        reportingTimeZone: "UTC",
+        updatedAt: Date.UTC(2026, 7, 28),
+      });
+
+      for (let index = 0; index < 120; index += 1) {
+        await ctx.db.insert("workspaceAgentMemoryInventory", {
+          workspaceId,
+          memoryId: `memory-${index}`,
+          createdAt: Date.UTC(2026, 7, 1) + index,
+          title: index === 117 ? "Needle memory" : `Memory ${index}`,
+          summary: `Summary ${index}`,
+          source: "qualification",
+          category: "qualification_win_pattern",
+          confidence: index / 120,
+          impactScore: index / 120,
+          relatedQueriesCount: 0,
+          evidenceCount: 1,
+        });
+      }
+
+      return { workspaceId };
+    });
+    const client = t.withIdentity({ subject: "agent-ops-inventory-owner" });
+    const baseArgs = {
+      workspaceId: seeded.workspaceId,
+      range: "custom" as const,
+      timeZone: "UTC",
+      fromDate: "2026-08-01",
+      toDate: "2026-08-28",
+      sort: "impact_desc" as const,
+      pageSize: 10,
+    };
+
+    const first = await client.action(
+      api.agentOps.getAgentOpsMemoryInventoryPageSnapshot,
+      { ...baseArgs, page: 0 }
+    );
+    expect(first.rows).toHaveLength(10);
+    expect(first.rows.map((row) => row.memoryId)).toEqual(
+      Array.from({ length: 10 }, (_, offset) => `memory-${119 - offset}`)
+    );
+    expect(first.scanned).toBe(50);
+    expect(first.isDone).toBe(false);
+    expect(first.continueCursor).not.toBeNull();
+
+    const second = await client.action(
+      api.agentOps.getAgentOpsMemoryInventoryPageSnapshot,
+      {
+        ...baseArgs,
+        page: 1,
+        cursor: first.continueCursor ?? undefined,
+      }
+    );
+    expect(second.rows).toHaveLength(10);
+    expect(second.rows.map((row) => row.memoryId)).toEqual(
+      Array.from({ length: 10 }, (_, offset) => `memory-${109 - offset}`)
+    );
+    expect(second.scanned).toBe(0);
+    expect(
+      new Set([...first.rows, ...second.rows].map((row) => row.memoryId)).size
+    ).toBe(20);
+
+    const filtered = await client.action(
+      api.agentOps.getAgentOpsMemoryInventoryPageSnapshot,
+      {
+        ...baseArgs,
+        page: 0,
+        search: "needle",
+      }
+    );
+    expect(filtered.rows.map((row) => row.memoryId)).toEqual(["memory-117"]);
+    expect(filtered.isDone).toBe(true);
+    expect(filtered.scanned).toBe(120);
+  });
+
+  test("exports each row once while advancing the same cursor", async () => {
+    const t = convexTest(schema, modules);
+    const seeded = await t.run(async (ctx) => {
+      const userId = await ctx.db.insert("users", {
+        workosUserId: "agent-ops-export-owner",
+        email: "agent-ops-export@example.com",
+      });
+      const workspaceId = await ctx.db.insert("workspaces", {
+        userId,
+        name: "Agent Ops export",
+        description: "Cursor export test",
+        isDefault: true,
+        updatedAt: Date.UTC(2026, 7, 28),
+      });
+      for (let index = 0; index < 120; index += 1) {
+        await ctx.db.insert("workspaceAgentMemoryInventory", {
+          workspaceId,
+          memoryId: `export-memory-${index}`,
+          createdAt: Date.UTC(2026, 7, 1) + index,
+          title: `Memory ${index}`,
+          summary: `Summary ${index}`,
+          source: "operator",
+          category: "operator_instruction",
+          confidence: 1,
+          impactScore: 1,
+          relatedQueriesCount: 0,
+          evidenceCount: 0,
+        });
+      }
+      return { workspaceId };
+    });
+    const client = t.withIdentity({ subject: "agent-ops-export-owner" });
+    const memoryIds: string[] = [];
+    let cursor: string | undefined;
+    let page = 0;
+
+    while (true) {
+      const result = await client.action(
+        api.agentOps.getAgentOpsMemoryInventoryPageSnapshot,
+        {
+          workspaceId: seeded.workspaceId,
+          range: "custom",
+          timeZone: "UTC",
+          fromDate: "2026-08-01",
+          toDate: "2026-08-28",
+          sort: "recent_desc",
+          page,
+          pageSize: 50,
+          exportMode: true,
+          ...(cursor ? { cursor } : {}),
+        }
+      );
+      memoryIds.push(...result.rows.map((row) => row.memoryId));
+      if (result.isDone) break;
+      expect(result.continueCursor).not.toBeNull();
+      cursor = result.continueCursor ?? undefined;
+      page += 1;
+    }
+
+    expect(page).toBe(2);
+    expect(memoryIds).toHaveLength(120);
+    expect(new Set(memoryIds).size).toBe(120);
+  });
+});

--- a/convex/agentOpsReadModels.ts
+++ b/convex/agentOpsReadModels.ts
@@ -200,6 +200,32 @@ export const listWorkspaceAgentMemoryInventoryRecentPageInternal =
     },
   });
 
+export const getWorkspaceAgentMemoryInventoryRowsInternal = internalQuery({
+  args: {
+    workspaceId: v.id("workspaces"),
+    memoryIds: v.array(v.string()),
+  },
+  handler: async (ctx, { workspaceId, memoryIds }) => {
+    const rows = await Promise.all(
+      memoryIds.slice(0, 50).map(
+        async (memoryId) =>
+          await ctx.db
+            .query("workspaceAgentMemoryInventory")
+            .withIndex("by_workspace_memory_id", (q) =>
+              q.eq("workspaceId", workspaceId).eq("memoryId", memoryId)
+            )
+            .first()
+      )
+    );
+
+    return rows
+      .filter(
+        (row): row is Doc<"workspaceAgentMemoryInventory"> => row !== null
+      )
+      .map(toWorkspaceAgentMemoryInventoryRecord);
+  },
+});
+
 export const listWorkspaceAgentMemoryInventoryImpactPageInternal =
   internalQuery({
     args: {
@@ -213,7 +239,11 @@ export const listWorkspaceAgentMemoryInventoryImpactPageInternal =
           q.eq("workspaceId", workspaceId)
         )
         .order("desc")
-        .paginate(paginationOpts);
+        .paginate({
+          ...paginationOpts,
+          maximumRowsRead: 300,
+          maximumBytesRead: 2_000_000,
+        });
 
       return {
         ...result,
@@ -260,7 +290,11 @@ export const listWorkspaceAgentMemoryInventoryConfidencePageInternal =
           q.eq("workspaceId", workspaceId)
         )
         .order("desc")
-        .paginate(paginationOpts);
+        .paginate({
+          ...paginationOpts,
+          maximumRowsRead: 300,
+          maximumBytesRead: 2_000_000,
+        });
 
       return {
         ...result,

--- a/convex/lib/agentOpsInventoryCursor.test.ts
+++ b/convex/lib/agentOpsInventoryCursor.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "vitest";
+import {
+  decodeAgentOpsMemoryInventoryCursor,
+  encodeAgentOpsMemoryInventoryCursor,
+  type AgentOpsMemoryInventoryCursorState,
+} from "./agentOpsInventoryCursor";
+
+const window = { startMs: 100, endMs: 200 };
+
+function buildState(
+  overrides: Partial<AgentOpsMemoryInventoryCursorState> = {}
+): AgentOpsMemoryInventoryCursorState {
+  return {
+    scopeKey: "scope-a",
+    sourceCursor: "source-cursor",
+    bufferedMemoryIds: ["memory-1", "memory-2"],
+    sourceDone: false,
+    windowStartMs: window.startMs,
+    windowEndMs: window.endMs,
+    ...overrides,
+  };
+}
+
+describe("Agent Ops inventory cursor", () => {
+  test("round-trips the fixed snapshot watermark and buffered IDs", () => {
+    const cursor = encodeAgentOpsMemoryInventoryCursor(buildState());
+    expect(cursor).not.toBeNull();
+    expect(
+      decodeAgentOpsMemoryInventoryCursor(cursor ?? undefined, "scope-a", {
+        startMs: 500,
+        endMs: 600,
+      })
+    ).toEqual(buildState());
+  });
+
+  test("resets a cursor when its filter scope changes", () => {
+    const cursor = encodeAgentOpsMemoryInventoryCursor(buildState());
+    expect(
+      decodeAgentOpsMemoryInventoryCursor(
+        cursor ?? undefined,
+        "scope-b",
+        window
+      )
+    ).toEqual({
+      scopeKey: "scope-b",
+      sourceCursor: null,
+      bufferedMemoryIds: [],
+      sourceDone: false,
+      windowStartMs: window.startMs,
+      windowEndMs: window.endMs,
+    });
+  });
+
+  test("rejects oversized buffers and ends without another cursor", () => {
+    const oversized = encodeAgentOpsMemoryInventoryCursor(
+      buildState({
+        bufferedMemoryIds: Array.from(
+          { length: 51 },
+          (_, index) => `memory-${index}`
+        ),
+      })
+    );
+    expect(
+      decodeAgentOpsMemoryInventoryCursor(
+        oversized ?? undefined,
+        "scope-a",
+        window
+      ).bufferedMemoryIds
+    ).toEqual([]);
+    expect(
+      encodeAgentOpsMemoryInventoryCursor(
+        buildState({
+          sourceCursor: null,
+          bufferedMemoryIds: [],
+          sourceDone: true,
+        })
+      )
+    ).toBeNull();
+  });
+});

--- a/convex/lib/agentOpsInventoryCursor.ts
+++ b/convex/lib/agentOpsInventoryCursor.ts
@@ -1,0 +1,88 @@
+const AGENT_OPS_MEMORY_CURSOR_PREFIX = "aom1:";
+const MAX_BUFFERED_MEMORY_IDS = 50;
+const MAX_MEMORY_ID_LENGTH = 128;
+const MAX_CURSOR_LENGTH = 100_000;
+
+export type AgentOpsMemoryInventoryCursorState = {
+  scopeKey: string;
+  sourceCursor: string | null;
+  bufferedMemoryIds: string[];
+  sourceDone: boolean;
+  windowStartMs: number;
+  windowEndMs: number;
+};
+
+export function encodeAgentOpsMemoryInventoryCursor(
+  state: AgentOpsMemoryInventoryCursorState
+): string | null {
+  if (state.sourceDone && state.bufferedMemoryIds.length === 0) {
+    return null;
+  }
+
+  return `${AGENT_OPS_MEMORY_CURSOR_PREFIX}${encodeURIComponent(
+    JSON.stringify(state)
+  )}`;
+}
+
+export function decodeAgentOpsMemoryInventoryCursor(
+  cursor: string | undefined,
+  scopeKey: string,
+  window: { startMs: number; endMs: number }
+): AgentOpsMemoryInventoryCursorState {
+  const initialState: AgentOpsMemoryInventoryCursorState = {
+    scopeKey,
+    sourceCursor: null,
+    bufferedMemoryIds: [],
+    sourceDone: false,
+    windowStartMs: window.startMs,
+    windowEndMs: window.endMs,
+  };
+
+  if (
+    !cursor?.startsWith(AGENT_OPS_MEMORY_CURSOR_PREFIX) ||
+    cursor.length > MAX_CURSOR_LENGTH
+  ) {
+    return initialState;
+  }
+
+  try {
+    const decoded: unknown = JSON.parse(
+      decodeURIComponent(cursor.slice(AGENT_OPS_MEMORY_CURSOR_PREFIX.length))
+    );
+    if (!decoded || typeof decoded !== "object") {
+      return initialState;
+    }
+
+    const state = decoded as Partial<AgentOpsMemoryInventoryCursorState>;
+    if (
+      state.scopeKey !== scopeKey ||
+      (state.sourceCursor !== null && typeof state.sourceCursor !== "string") ||
+      typeof state.sourceDone !== "boolean" ||
+      typeof state.windowStartMs !== "number" ||
+      !Number.isFinite(state.windowStartMs) ||
+      typeof state.windowEndMs !== "number" ||
+      !Number.isFinite(state.windowEndMs) ||
+      state.windowEndMs < state.windowStartMs ||
+      !Array.isArray(state.bufferedMemoryIds) ||
+      state.bufferedMemoryIds.length > MAX_BUFFERED_MEMORY_IDS ||
+      !state.bufferedMemoryIds.every(
+        (memoryId): memoryId is string =>
+          typeof memoryId === "string" &&
+          memoryId.length <= MAX_MEMORY_ID_LENGTH
+      )
+    ) {
+      return initialState;
+    }
+
+    return {
+      scopeKey,
+      sourceCursor: state.sourceCursor,
+      bufferedMemoryIds: state.bufferedMemoryIds,
+      sourceDone: state.sourceDone,
+      windowStartMs: state.windowStartMs,
+      windowEndMs: state.windowEndMs,
+    };
+  } catch {
+    return initialState;
+  }
+}

--- a/docs/convex/large-range-query-rollout.md
+++ b/docs/convex/large-range-query-rollout.md
@@ -5,15 +5,15 @@
 The fit-score histogram was the first measured failure, but it was not the only
 unsafe read. A production audit on 2026-08-28 found these user-facing paths:
 
-| Surface                 | Previous read shape                                     | Largest observed / projected risk                                                     | New read shape                                                                                       |
-| ----------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| Analytics               | selected + comparison ranges in one query               | 32 stripes/day makes a one-year comparison about 24,000 source rows and roughly 58 MB | point-in-time action snapshot; 31-day transactions; exact totals; daily/weekly/monthly chart buckets |
-| Agent observability     | Analytics + Agent Ops stripes in one query              | one-year comparison about 48,000 source rows and well above 16 MiB                    | two bounded 31-day reads per chunk; compact chart payload                                            |
-| Discovery inventory     | every matching `queryCandidates` row returned to React  | 5,068 rows / about 3.6 MB in the largest workspace observed                           | bounded backend scan when exact filters require it; one server page returned                         |
-| Memory inventory        | apparent UI pages backed by a full-window scan          | potentially hundreds of daily reads and an unbounded result in one query              | bounded 250-row internal pages; one server page returned                                             |
-| Usage                   | every qualified full `prospects` document per workspace | grows with all qualified prospects and reads large source documents                   | 250-row `prospectSummaries` pages with a legacy fallback only when `qualifiedAt` is absent           |
-| Prospect stage counts   | full summary iterator for each visible stage            | 61,257 prospects in `ReacherX (Leads)`                                                | bounded 250-row transactions with exact accumulated counts                                           |
-| Agent Ops detail panels | full workspace event/suggestion scans                   | hidden failure path after opening a dashboard row                                     | additive exact indexes plus bounded `take(...)` reads                                                |
+| Surface                 | Previous read shape                                     | Largest observed / projected risk                                                          | New read shape                                                                                           |
+| ----------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| Analytics               | selected + comparison ranges in one query               | 32 stripes/day makes a one-year comparison about 24,000 source rows and roughly 58 MB      | point-in-time action snapshot; 31-day transactions; exact totals; daily/weekly/monthly chart buckets     |
+| Agent observability     | Analytics + Agent Ops stripes in one query              | one-year comparison about 48,000 source rows and well above 16 MiB                         | two bounded 31-day reads per chunk; compact chart payload                                                |
+| Discovery inventory     | every matching `queryCandidates` row returned to React  | 5,068 rows / about 3.6 MB in the largest workspace observed                                | bounded backend scan when exact filters require it; one server page returned                             |
+| Memory inventory        | apparent UI pages backed by a full-window scan          | 82,400 rows; 18 seconds for a 10-row page; the old export would repeat that scan 824 times | opaque snapshot cursor; at most 250 rows per transaction; export advances once through the same snapshot |
+| Usage                   | every qualified full `prospects` document per workspace | grows with all qualified prospects and reads large source documents                        | 250-row `prospectSummaries` pages with a legacy fallback only when `qualifiedAt` is absent               |
+| Prospect stage counts   | full summary iterator for each visible stage            | 61,257 prospects in `ReacherX (Leads)`                                                     | bounded 250-row transactions with exact accumulated counts                                               |
+| Agent Ops detail panels | full workspace event/suggestion scans                   | hidden failure path after opening a dashboard row                                          | additive exact indexes plus bounded `take(...)` reads                                                    |
 
 Convex production still records one historical
 `getWorkspaceFitScoreHistogram` failure at 18,573,630 bytes / 18,163 rows.
@@ -31,8 +31,12 @@ count/histogram hotspot. It is gated per workspace and does not require a
 - Detailed record reads use 250 requested items with explicit 300-row and 2 MB
   scan limits. Actions continue from the returned cursor if Convex returns a
   partial page.
-- Exact totals are preserved. The browser receives only the requested detail
-  page, never the full inventory.
+- Exact dashboard and stage totals are preserved. Inventory pages receive only
+  the requested detail slice. Memory pagination carries a scope-bound opaque
+  cursor and fixed time-window watermark so page changes neither restart the
+  scan nor mix snapshots. An explicit CSV export advances that cursor once
+  through the matching data instead of restarting from row zero for every
+  output page.
 - Time-series presentation is daily through 31 days, weekly through 180 days,
   and monthly above 180 days. A one-year selection returns 13 chart buckets;
   the selected and comparison totals still cover every hour exactly.
@@ -66,8 +70,21 @@ against the daily source, and gated before read cutover.
 - Existing analytics and usage exactness tests still pass.
 - The full Convex suite passes with 549 tests after rebasing on deployed PR #42.
 
-Production largest-workspace verification cannot run until this code is merged
-and deployed. No production control or data was changed while preparing it.
+### Zero-opt-in production gate — 2026-08-28
+
+PR #43 deployed with zero `fitScoreAggregateRollouts` rows. Read-only checks on
+`ReacherX (Leads)` confirmed that 30-day, one-year, and all-time Analytics and
+Agent Ops dashboard snapshots succeeded; Usage, exact prospect stage counts,
+discovery inventory, query detail, and memory detail also succeeded. None of
+those checks created a new bytes-read or permanent-OCC Insight.
+
+The gate did expose a remaining implementation defect before any Aggregate
+migration: the all-time memory inventory contains 82,400 rows, and the page
+action took about 18 seconds to return 10 rows because every page restarted a
+full scan. The CSV path would have repeated that scan for 8,240 UI pages (824
+export pages at the former size of 100). Aggregate rollout therefore remains at
+zero. The cursor pagination/export fix must deploy and pass the same production
+gate before step 5 is authorized.
 
 ## Controlled rollout
 
@@ -80,7 +97,8 @@ and deployed. No production control or data was changed while preparing it.
    `fitScoreAggregateRollouts` row still absent or non-verified. The bounded
    dashboard actions and detail pagination are safe immediately and require no
    data migration.
-4. Exercise 30-day, one-year, and all-time Analytics, Agent observability,
+4. Deploy the focused cursor pagination/export fix, then exercise 30-day,
+   one-year, and all-time Analytics, Agent observability,
    Usage, Prospects counts, discovery, memory inventory, and detail panels on
    `ReacherX (Leads)` read-only. Record action duration, subquery count, bytes,
    rows, and any resource-limit event.

--- a/docs/convex/reliability-program-2026-08-27.md
+++ b/docs/convex/reliability-program-2026-08-27.md
@@ -644,3 +644,21 @@ Convex test files / 549 tests, TypeScript, strict Oxlint, changed-file ESLint,
 blocking changed-dashboard issue; the flagged sequential waits are the bounded
 transaction/export sequencing that prevents a wide report from recreating a
 read burst.
+
+### Large-range zero-opt-in production gate — 2026-08-28
+
+PR #43 deployed successfully with zero fit-score Aggregate rollout rows, so all
+checks exercised the compatibility read path without changing production data.
+On `ReacherX (Leads)`, 30-day, one-year, and all-time Analytics and Agent Ops
+snapshots succeeded. Usage, exact prospect stage counts, discovery inventory,
+query detail, and memory detail also succeeded, and the checks produced no new
+bytes-read or permanent-OCC Insight.
+
+The memory inventory gate failed on latency and read amplification: its 82,400
+rows took about 18 seconds to produce a 10-row page, while the former CSV flow
+would restart the same scan for every one of 824 export pages. No Aggregate
+backfill was started. The follow-up replaces page numbers backed by full scans
+with scope-bound opaque cursors and a fixed snapshot watermark; buffered rows
+are carried by IDs, each internal transaction is capped at 300 rows / 2 MB, and
+CSV export advances once through the snapshot. Production canary and Aggregate
+migration remain blocked until that focused follow-up is merged and deployed.

--- a/features/agent-ops/ui/AgentOpsDashboard.tsx
+++ b/features/agent-ops/ui/AgentOpsDashboard.tsx
@@ -109,6 +109,9 @@ export function AgentOpsDashboard() {
   const [memorySort, setMemorySort] =
     React.useState<AgentOpsMemorySort>("impact_desc");
   const [memoryPage, setMemoryPage] = React.useState(0);
+  const [memoryPageCursors, setMemoryPageCursors] = React.useState<
+    Record<number, string | null>
+  >({ 0: null });
   const [isExportingQueries, setIsExportingQueries] = React.useState(false);
   const [isExportingMemories, setIsExportingMemories] = React.useState(false);
   const [queryPageSize, setQueryPageSize] = React.useState(10);
@@ -278,6 +281,19 @@ export function AgentOpsDashboard() {
   const [isMemorySnapshotLoading, setIsMemorySnapshotLoading] =
     React.useState(false);
   const debouncedMemorySearch = useDebouncedValue(memorySearch, 300);
+  const memoryCursor = memoryPageCursors[memoryPage] ?? null;
+  const memoryRangeScopeKey = [
+    workspaceId ?? "",
+    params.range,
+    params.from ?? "",
+    params.to ?? "",
+    reportingTimeZone ?? "",
+  ].join(":");
+
+  React.useEffect(() => {
+    setMemoryPage(0);
+    setMemoryPageCursors({ 0: null });
+  }, [memoryRangeScopeKey]);
 
   React.useEffect(() => {
     let cancelled = false;
@@ -298,10 +314,18 @@ export function AgentOpsDashboard() {
       sort: memorySort,
       page: memoryPage,
       pageSize: memoryPageSize,
+      ...(memoryCursor ? { cursor: memoryCursor } : {}),
     })
       .then((result) => {
         if (!cancelled) {
-          setMemoryInventoryData(result as AgentOpsMemoryInventoryPageData);
+          const pageData = result as AgentOpsMemoryInventoryPageData;
+          setMemoryInventoryData(pageData);
+          setMemoryPageCursors((current) => ({
+            ...current,
+            ...(pageData.continueCursor
+              ? { [memoryPage + 1]: pageData.continueCursor }
+              : {}),
+          }));
         }
       })
       .catch((error: unknown) => {
@@ -321,6 +345,7 @@ export function AgentOpsDashboard() {
     debouncedMemorySearch,
     loadMemoryPage,
     memoryCategory,
+    memoryCursor,
     memoryPage,
     memoryPageSize,
     memorySort,
@@ -347,22 +372,34 @@ export function AgentOpsDashboard() {
     totalCount: 0,
     totalPages: 1,
     availableCategories: [],
+    continueCursor: null,
+    isDone: true,
+    scanned: 0,
+  };
+  const resetMemoryPagination = () => {
+    setMemoryPage(0);
+    setMemoryPageCursors({ 0: null });
   };
   const updateMemorySearch = (value: string) => {
-    setMemoryPage(0);
+    resetMemoryPagination();
     setMemorySearch(value);
   };
   const updateMemoryCategory = (value: string) => {
-    setMemoryPage(0);
+    resetMemoryPagination();
     setMemoryCategory(value);
   };
   const updateMemorySort = (value: AgentOpsMemorySort) => {
-    setMemoryPage(0);
+    resetMemoryPagination();
     setMemorySort(value);
   };
   const updateMemoryPageSize = (value: number) => {
-    setMemoryPage(0);
+    resetMemoryPagination();
     setMemoryPageSize(value);
+  };
+  const updateMemoryPage = (page: number) => {
+    if (page === 0 || memoryPageCursors[page] !== undefined) {
+      setMemoryPage(page);
+    }
   };
 
   const hasPanel = Boolean(params.panel);
@@ -578,52 +615,37 @@ export function AgentOpsDashboard() {
 
     setIsExportingMemories(true);
     try {
-      const exportPageSize = 100;
-      const firstPage = (await convex.action(
-        api.agentOps.getAgentOpsMemoryInventoryPageSnapshot,
-        {
-          workspaceId,
-          range: params.range,
-          timeZone: reportingTimeZone,
-          ...(params.from ? { fromDate: params.from } : {}),
-          ...(params.to ? { toDate: params.to } : {}),
-          ...(memorySearch.trim().length > 0 ? { search: memorySearch } : {}),
-          ...(memoryCategory !== "all" ? { category: memoryCategory } : {}),
-          sort: memorySort,
-          page: 0,
-          pageSize: exportPageSize,
-        }
-      )) as AgentOpsMemoryInventoryPageData;
+      const exportPageSize = 500;
+      const rows: MemoryInventoryRow[] = [];
+      let cursor: string | undefined;
+      let page = 0;
 
-      const rows = [
-        ...firstPage.rows,
-        ...(await loadRemainingExportPages({
-          nextPage: 1,
-          totalPages: firstPage.totalPages,
-          loadPage: async (page) =>
-            (
-              (await convex.action(
-                api.agentOps.getAgentOpsMemoryInventoryPageSnapshot,
-                {
-                  workspaceId,
-                  range: params.range,
-                  timeZone: reportingTimeZone,
-                  ...(params.from ? { fromDate: params.from } : {}),
-                  ...(params.to ? { toDate: params.to } : {}),
-                  ...(memorySearch.trim().length > 0
-                    ? { search: memorySearch }
-                    : {}),
-                  ...(memoryCategory !== "all"
-                    ? { category: memoryCategory }
-                    : {}),
-                  sort: memorySort,
-                  page,
-                  pageSize: exportPageSize,
-                }
-              )) as AgentOpsMemoryInventoryPageData
-            ).rows,
-        })),
-      ];
+      while (true) {
+        const pageData = (await convex.action(
+          api.agentOps.getAgentOpsMemoryInventoryPageSnapshot,
+          {
+            workspaceId,
+            range: params.range,
+            timeZone: reportingTimeZone,
+            ...(params.from ? { fromDate: params.from } : {}),
+            ...(params.to ? { toDate: params.to } : {}),
+            ...(memorySearch.trim().length > 0 ? { search: memorySearch } : {}),
+            ...(memoryCategory !== "all" ? { category: memoryCategory } : {}),
+            sort: memorySort,
+            page,
+            pageSize: exportPageSize,
+            exportMode: true,
+            ...(cursor ? { cursor } : {}),
+          }
+        )) as AgentOpsMemoryInventoryPageData;
+        rows.push(...pageData.rows);
+        if (pageData.isDone) break;
+        if (!pageData.continueCursor) {
+          throw new Error("Memory export stopped before reaching the end.");
+        }
+        cursor = pageData.continueCursor;
+        page += 1;
+      }
 
       downloadCsv(
         "agent-ops-memories.csv",
@@ -1088,17 +1110,40 @@ export function AgentOpsDashboard() {
                   totalPages={1}
                   pageSize={memoryPageSize}
                   pageSizeOptions={[5, 10, 20]}
-                  onPageChange={setMemoryPage}
+                  onPageChange={updateMemoryPage}
                   onPageSizeChange={updateMemoryPageSize}
                   size="xs"
                   disabled
                 />
               </>
             ) : filteredMemories.length === 0 ? (
-              <EmptyState
-                title="No memories yet"
-                description="Once the system captures reusable lessons in memory, they will show up here."
-              />
+              <>
+                <EmptyState
+                  title={
+                    resolvedMemoryInventoryData.isDone
+                      ? "No memories yet"
+                      : "No matching memories on this page"
+                  }
+                  description={
+                    resolvedMemoryInventoryData.isDone
+                      ? "Once the system captures reusable lessons in memory, they will show up here."
+                      : "Continue to the next page to search the remaining memories."
+                  }
+                />
+                {!resolvedMemoryInventoryData.isDone || memoryPage > 0 ? (
+                  <TablePagination
+                    page={memoryPage}
+                    totalPages={
+                      memoryPage + (resolvedMemoryInventoryData.isDone ? 1 : 2)
+                    }
+                    pageSize={memoryPageSize}
+                    pageSizeOptions={[5, 10, 20]}
+                    onPageChange={updateMemoryPage}
+                    onPageSizeChange={updateMemoryPageSize}
+                    size="xs"
+                  />
+                ) : null}
+              </>
             ) : (
               <>
                 <MemoryTable
@@ -1107,10 +1152,13 @@ export function AgentOpsDashboard() {
                 />
                 <TablePagination
                   page={resolvedMemoryInventoryData.page}
-                  totalPages={resolvedMemoryInventoryData.totalPages}
+                  totalPages={
+                    resolvedMemoryInventoryData.page +
+                    (resolvedMemoryInventoryData.isDone ? 1 : 2)
+                  }
                   pageSize={memoryPageSize}
                   pageSizeOptions={[5, 10, 20]}
-                  onPageChange={setMemoryPage}
+                  onPageChange={updateMemoryPage}
                   onPageSizeChange={updateMemoryPageSize}
                   size="xs"
                 />

--- a/features/agent-ops/ui/types.ts
+++ b/features/agent-ops/ui/types.ts
@@ -70,9 +70,12 @@ export type AgentOpsMemorySort =
 export type AgentOpsMemoryInventoryPageData = {
   rows: MemoryInventoryRow[];
   page: number;
-  totalCount: number;
+  totalCount: number | null;
   totalPages: number;
   availableCategories: string[];
+  continueCursor: string | null;
+  isDone: boolean;
+  scanned: number;
 };
 
 export type AgentOpsActivityItem = {


### PR DESCRIPTION
## Summary
- replace full-window Agent Ops memory inventory rescans with scope-bound cursor pagination
- keep a fixed time-window watermark across pages and cap each source transaction at 300 rows / 2 MB
- make CSV export advance once through the same snapshot instead of restarting for every page
- record the PR #43 zero-opt-in production gate and keep fit-score Aggregate rollout at zero

## Production evidence
- ReacherX (Leads) has 82,400 memory inventory rows
- the deployed action took about 18 seconds to return 10 rows
- the former CSV path would repeat that scan 824 times at its 100-row export page size
- Analytics, Agent Ops overview/activity, Usage, prospect stage counts, discovery inventory, and detail panels passed the zero-opt-in gate with no new bytes-read or permanent-OCC Insight

## Verification
- 111 Convex test files / 554 tests passed
- TypeScript passed
- strict Oxlint and changed-file ESLint passed
- production Next.js build passed all 74 routes
- changed-scope React Doctor found no new blocking React issue
- Convex security/reviewer audit passed: workspace ownership is checked before reads, cursor buffers are workspace-bound and capped at 50 IDs, and the action is read-only

## Rollout
1. Merge and deploy only after checks are green and approval is given.
2. Keep every fitScoreAggregateRollouts row absent/unverified.
3. Re-run the largest-workspace memory page, filter, cursor, and bounded export checks read-only.
4. Only after that gate passes, request approval for the first workspace-scoped Aggregate backfill.