### PR TITLE
fix: migrate inactive uninitialized Aggregate workspaces

### DIFF
--- a/convex/prospectFitScoreAggregate.integration.test.ts
+++ b/convex/prospectFitScoreAggregate.integration.test.ts
@@ -348,7 +348,83 @@ describe("fit-score Aggregate migration", () => {
     });
 
     await expect(t.mutation(startMigration, { workspaceId })).rejects.toThrow(
-      "requires an existing, non-deleting workspace with prospecting paused or stopped"
+      "requires an existing, non-deleting workspace that is inactive or has never started prospecting"
+    );
+  });
+
+  test("verifies a workspace that has never started prospecting", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.UTC(2026, 7, 28, 11));
+    const t = convexTest({ schema, modules, transactionLimits: true });
+    await registerAggregate(t);
+    const workspaceId = await t.run(async (ctx) => {
+      const userId = await ctx.db.insert("users", {
+        workosUserId: "fit-score-uninitialized-owner",
+        email: "fit-score-uninitialized@example.com",
+      });
+      const workspaceId = await ctx.db.insert("workspaces", {
+        userId,
+        name: "Uninitialized Aggregate migration",
+        description: "Has never started prospecting",
+        isDefault: true,
+        updatedAt: getCurrentUTCTimestamp(),
+      });
+      const prospectId = await ctx.db.insert("prospects", {
+        workspaceId,
+        userId,
+        platform: "twitter",
+        origin: "setup_preview",
+        externalId: "uninitialized-preview",
+        data: {},
+        status: "new",
+        prospectType: "individual",
+        qualificationStatus: "qualified",
+        qualificationScore: 95,
+        updatedAt: getCurrentUTCTimestamp(),
+      });
+      const prospect = await ctx.db.get("prospects", prospectId);
+      if (!prospect) throw new Error("Failed to seed preview prospect");
+      await ctx.db.insert(
+        "prospectSummaries",
+        buildProspectSummaryRecord(prospect)
+      );
+      return workspaceId;
+    });
+
+    const start = await t.mutation(startMigration, { workspaceId });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    const rollout = await t.run(async (ctx) =>
+      ctx.db.get("fitScoreAggregateRollouts", start.rolloutId)
+    );
+    expect(rollout).toMatchObject({
+      status: "verified",
+      backfilledCount: 0,
+      verifiedSourceCount: 0,
+      expectedBinCounts: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      aggregateBinCounts: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    });
+  });
+
+  test("rejects an uninitialized status with an active workflow id", async () => {
+    const t = convexTest(schema, modules);
+    await registerAggregate(t);
+    const workspaceId = await t.run(async (ctx) => {
+      const userId = await ctx.db.insert("users", {
+        workosUserId: "fit-score-inconsistent-owner",
+        email: "fit-score-inconsistent@example.com",
+      });
+      return await ctx.db.insert("workspaces", {
+        userId,
+        name: "Inconsistent workspace",
+        description: "Workflow id without a status",
+        isDefault: true,
+        prospectingWorkflowId: "active-workflow-id",
+        updatedAt: getCurrentUTCTimestamp(),
+      });
+    });
+
+    await expect(t.mutation(startMigration, { workspaceId })).rejects.toThrow(
+      "requires an existing, non-deleting workspace that is inactive or has never started prospecting"
     );
   });
 });

--- a/convex/prospectFitScoreAggregateMigration.ts
+++ b/convex/prospectFitScoreAggregateMigration.ts
@@ -51,13 +51,19 @@ function clampBatchSize(
 function isWorkspaceSafeForMigration(
   workspace: Pick<
     Doc<"workspaces">,
-    "deletionWorkflowId" | "prospectingWorkflowStatus"
+    | "deletionWorkflowId"
+    | "prospectingWorkflowId"
+    | "prospectingWorkflowStatus"
   >
 ) {
+  const hasNeverStartedProspecting =
+    workspace.prospectingWorkflowStatus === undefined &&
+    workspace.prospectingWorkflowId === undefined;
   return (
     workspace.deletionWorkflowId === undefined &&
-    workspace.prospectingWorkflowStatus !== undefined &&
-    workspace.prospectingWorkflowStatus !== "running"
+    (hasNeverStartedProspecting ||
+      (workspace.prospectingWorkflowStatus !== undefined &&
+        workspace.prospectingWorkflowStatus !== "running"))
   );
 }
 
@@ -78,7 +84,7 @@ export const startWorkspaceMigrationInternal = internalMutation({
     const workspace = await ctx.db.get("workspaces", args.workspaceId);
     if (!workspace || !isWorkspaceSafeForMigration(workspace)) {
       throw new Error(
-        "Fit-score Aggregate migration requires an existing, non-deleting workspace with prospecting paused or stopped"
+        "Fit-score Aggregate migration requires an existing, non-deleting workspace that is inactive or has never started prospecting"
       );
     }
 
@@ -180,7 +186,7 @@ export const backfillWorkspacePageInternal = internalMutation({
     if (!workspace || !isWorkspaceSafeForMigration(workspace)) {
       await ctx.db.patch(args.rolloutId, {
         status: "failed",
-        error: "Workspace started running or deletion began during backfill",
+        error: "Workspace became active or deletion began during backfill",
         updatedAt: getCurrentUTCTimestamp(),
       });
       return { status: "failed", processed: 0 };
@@ -264,8 +270,7 @@ export const verifyWorkspacePageInternal = internalMutation({
     if (!workspace || !isWorkspaceSafeForMigration(workspace)) {
       await ctx.db.patch(args.rolloutId, {
         status: "failed",
-        error:
-          "Workspace started running or deletion began during verification",
+        error: "Workspace became active or deletion began during verification",
         updatedAt: getCurrentUTCTimestamp(),
       });
       return { status: "failed", processed: 0 };

--- a/docs/convex/large-range-query-rollout.md
+++ b/docs/convex/large-range-query-rollout.md
@@ -115,3 +115,30 @@ gate before step 5 is authorized.
 8. Handle legacy tables, indexes, compatibility endpoints, and component state
    only in the separately approved cleanup phase after proving reads and writes
    are absent.
+
+### Production Aggregate rollout — 2026-08-28
+
+The cursor-pagination production gate passed before the first Aggregate row was
+created. The workspace-scoped rollout then verified 12 of 34 production
+workspaces with 25-row backfill transactions and 100-row verification
+transactions. Every migrated workspace reached exact source/Aggregate bin
+parity; the largest workspace verified 61,247 eligible summaries without a
+global prospect scan.
+
+The only originally running workspace was paused for maintenance, its active
+workflow and six queued race-window jobs were cancelled, and its 28 monitors
+were paused before migration. After exact verification, a new workflow was
+started, all 28 monitors were resumed, and the scheduler returned to enforced
+mode with 36/36 free slots, no queue, expired lease, drift, or unresolved
+enqueue failure. Workspaces that were already paused remained paused.
+
+The remaining 22 workspaces have never started prospecting and therefore have
+no workflow status or workflow ID. Seventeen are empty; five contain 70 legacy
+or setup-summary rows in total, with zero eligible scored summaries. The
+deployed migration correctly rejected this previously unhandled state instead
+of mutating the workspace status. The follow-up widens only the migration
+eligibility check: a non-deleting workspace with neither a workflow status nor
+a workflow ID may run the same bounded migration, while running workspaces and
+inconsistent workflow-ID-without-status rows remain rejected. Production
+rollout of those 22 workspaces remains pending deployment of that reviewed
+follow-up.


### PR DESCRIPTION
## Summary

- allow the bounded fit-score Aggregate migration for non-deleting workspaces that have never started prospecting and have no workflow ID
- continue rejecting running workspaces and inconsistent workflow-ID-without-status rows
- add regression coverage for empty/setup-preview-only uninitialized workspaces
- record the production rollout evidence and remaining 22-workspace gate

## Production state

- 12 of 34 production workspaces are already verified
- 83,516 Aggregate items were backfilled with exact source/bin parity
- the originally running workspace was safely paused, drained, migrated, verified, and restored
- the remaining 22 workspaces are uninitialized; 17 are empty and 5 contain 70 non-eligible setup/legacy summaries total
- this PR does not run the remaining production migration

## Verification

- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm vitest run` — 111 files / 556 tests
- `pnpm build`
- Convex review and security review: no blocking findings
