### PR TITLE
fix: self-heal stale memory evaluation queues

### DIFF
--- a/convex/lib/memoryEvaluationQueueCore.ts
+++ b/convex/lib/memoryEvaluationQueueCore.ts
@@ -1,0 +1,34 @@
+import type { Doc } from "../_generated/dataModel";
+import { DEFAULT_TENANT_JOB_LEASE_MS } from "./tenantSchedulerCore";
+
+export const MEMORY_EVALUATION_PRIORITY_SCAN_LIMIT = 25;
+export const MEMORY_EVALUATION_LEGACY_WORK_STALE_MS =
+  DEFAULT_TENANT_JOB_LEASE_MS;
+
+type MemoryWorkflowEventQueueFields = Pick<
+  Doc<"memoryWorkflowEvents">,
+  "eventType" | "sourceId" | "status"
+>;
+
+/**
+ * Explicit repair events restore a missing product prerequisite and must not
+ * wait behind ordinary learning history. Normal events retain FIFO ordering.
+ */
+export function isPriorityMemoryEvaluationEvent(
+  event: MemoryWorkflowEventQueueFields
+) {
+  return (
+    event.status === "pending" &&
+    event.eventType === "style_content_backfill_completed" &&
+    event.sourceId.startsWith("style-repair:")
+  );
+}
+
+export function isMemoryEvaluationLegacyWorkStale(args: {
+  queueUpdatedAt: number;
+  now: number;
+}) {
+  return (
+    args.now - args.queueUpdatedAt >= MEMORY_EVALUATION_LEGACY_WORK_STALE_MS
+  );
+}

--- a/convex/memoryEvaluationQueue.integration.test.ts
+++ b/convex/memoryEvaluationQueue.integration.test.ts
@@ -1,0 +1,340 @@
+/// <reference types="vite/client" />
+
+import { convexTest } from "convex-test";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+
+async function seedWorkspace(t: ReturnType<typeof convexTest>, suffix: string) {
+  return await t.run(async (ctx) => {
+    const userId = await ctx.db.insert("users", {
+      workosUserId: `memory-queue-${suffix}`,
+      email: `${suffix}@memory-queue.test`,
+    });
+    const workspaceId = await ctx.db.insert("workspaces", {
+      userId,
+      name: `Memory queue ${suffix}`,
+      description: "Memory queue integration test",
+      isDefault: true,
+      prospectingWorkflowStatus: "running",
+      updatedAt: 1,
+    });
+    return { userId, workspaceId };
+  });
+}
+
+async function insertEvent(
+  t: ReturnType<typeof convexTest>,
+  args: {
+    workspaceId: Id<"workspaces">;
+    suffix: string;
+    occurredAt: number;
+    eventType?: "qualification_completed" | "style_content_backfill_completed";
+    sourceId?: string;
+    status?: "pending" | "processing";
+    evaluatorWorkflowId?: string;
+  }
+) {
+  return await t.run(async (ctx) =>
+    ctx.db.insert("memoryWorkflowEvents", {
+      workspaceId: args.workspaceId,
+      eventType: args.eventType ?? "qualification_completed",
+      status: args.status ?? "pending",
+      sourceType:
+        args.eventType === "style_content_backfill_completed"
+          ? "style_content"
+          : "workflow_event",
+      sourceId: args.sourceId ?? args.suffix,
+      eventKey: `memory-queue-${args.suffix}`,
+      evaluatorWorkflowId: args.evaluatorWorkflowId,
+      occurredAt: args.occurredAt,
+    })
+  );
+}
+
+async function insertTenantJob(
+  t: ReturnType<typeof convexTest>,
+  args: {
+    workspaceId: Id<"workspaces">;
+    userId: Id<"users">;
+    status: "queued" | "running" | "succeeded";
+    suffix: string;
+  }
+) {
+  return await t.run(async (ctx) => {
+    const laneId = await ctx.db.insert("tenantJobLanes", {
+      tenantKey: `workspace:${String(args.workspaceId)}`,
+      workspaceId: args.workspaceId,
+      userId: args.userId,
+      state: args.status === "queued" ? "ready" : "idle",
+      pendingCount: args.status === "queued" ? 1 : 0,
+      runningCount: args.status === "running" ? 1 : 0,
+      minPriority: 50,
+      lastDispatchedAt: 1,
+      updatedAt: 1,
+    });
+    return await ctx.db.insert("tenantJobs", {
+      tenantKey: `workspace:${String(args.workspaceId)}`,
+      laneId,
+      workspaceId: args.workspaceId,
+      userId: args.userId,
+      class: "background",
+      kind: "memory_evaluation",
+      status: args.status,
+      priority: 50,
+      idempotencyKey: `memory-queue-job-${args.suffix}`,
+      payload: {
+        kind: "memory_evaluation",
+        workspaceId: args.workspaceId,
+      },
+      queuedAt: 1,
+      startedAt: args.status === "running" ? 2 : undefined,
+      completedAt: args.status === "succeeded" ? 3 : undefined,
+      attemptCount: args.status === "queued" ? 0 : 1,
+      updatedAt: 3,
+    });
+  });
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("memory evaluation workspace queue", () => {
+  test("prioritizes a repair event over an old ordinary backlog", async () => {
+    const t = convexTest(schema, modules);
+    const workspace = await seedWorkspace(t, "priority");
+    await insertEvent(t, {
+      workspaceId: workspace.workspaceId,
+      suffix: "old-normal",
+      occurredAt: 1,
+    });
+    const repairEventId = await insertEvent(t, {
+      workspaceId: workspace.workspaceId,
+      suffix: "repair",
+      occurredAt: 100,
+      eventType: "style_content_backfill_completed",
+      sourceId: `style-repair:${String(workspace.userId)}:twitter:1`,
+    });
+    await insertEvent(t, {
+      workspaceId: workspace.workspaceId,
+      suffix: "new-normal",
+      occurredAt: 200,
+    });
+
+    const prepared = await t.mutation(
+      internal.workflows.memory.prepareMemoryEvaluationQueueEnqueueInternal,
+      { workspaceId: workspace.workspaceId }
+    );
+    expect(prepared.eventId).toBe(repairEventId);
+
+    await t.mutation(
+      internal.workflows.memory.setMemoryEvaluationQueueWorkIdInternal,
+      { workspaceId: workspace.workspaceId, workId: "priority-work" }
+    );
+    const begun = await t.mutation(
+      internal.workflows.memory.beginMemoryEvaluationQueueWorkInternal,
+      { workspaceId: workspace.workspaceId }
+    );
+    expect(begun).toEqual({
+      eventId: repairEventId,
+      workId: "priority-work",
+    });
+  });
+
+  test("keeps normal events FIFO and isolated by workspace", async () => {
+    const t = convexTest(schema, modules);
+    const workspace = await seedWorkspace(t, "fifo");
+    const otherWorkspace = await seedWorkspace(t, "fifo-other");
+    const oldestEventId = await insertEvent(t, {
+      workspaceId: workspace.workspaceId,
+      suffix: "fifo-oldest",
+      occurredAt: 1,
+    });
+    await insertEvent(t, {
+      workspaceId: workspace.workspaceId,
+      suffix: "fifo-newest",
+      occurredAt: 2,
+    });
+    await insertEvent(t, {
+      workspaceId: otherWorkspace.workspaceId,
+      suffix: "other-repair",
+      occurredAt: 3,
+      eventType: "style_content_backfill_completed",
+      sourceId: `style-repair:${String(otherWorkspace.userId)}:twitter:1`,
+    });
+
+    const prepared = await t.mutation(
+      internal.workflows.memory.prepareMemoryEvaluationQueueEnqueueInternal,
+      { workspaceId: workspace.workspaceId }
+    );
+    expect(prepared.eventId).toBe(oldestEventId);
+  });
+
+  test("reclaims a terminal tenant job pointer immediately", async () => {
+    const t = convexTest(schema, modules);
+    const workspace = await seedWorkspace(t, "terminal");
+    const eventId = await insertEvent(t, {
+      workspaceId: workspace.workspaceId,
+      suffix: "terminal-event",
+      occurredAt: 1,
+    });
+    const terminalJobId = await insertTenantJob(t, {
+      ...workspace,
+      status: "succeeded",
+      suffix: "terminal",
+    });
+    await t.run(async (ctx) => {
+      await ctx.db.insert("memoryEvaluationWorkspaceQueues", {
+        workspaceId: workspace.workspaceId,
+        status: "queued",
+        workId: String(terminalJobId),
+        updatedAt: Date.now(),
+      });
+    });
+
+    const prepared = await t.mutation(
+      internal.workflows.memory.prepareMemoryEvaluationQueueEnqueueInternal,
+      { workspaceId: workspace.workspaceId }
+    );
+    expect(prepared).toEqual({
+      shouldEnqueue: true,
+      reason: "queued",
+      eventId,
+    });
+    expect(
+      await t.mutation(
+        internal.workflows.memory.prepareMemoryEvaluationQueueEnqueueInternal,
+        { workspaceId: workspace.workspaceId }
+      )
+    ).toEqual(prepared);
+    const queue = await t.run(async (ctx) =>
+      ctx.db
+        .query("memoryEvaluationWorkspaceQueues")
+        .withIndex("by_workspace", (q) =>
+          q.eq("workspaceId", workspace.workspaceId)
+        )
+        .unique()
+    );
+    expect(queue).toMatchObject({
+      status: "queued",
+      lastError: "Recovered stale memory evaluation queue work",
+    });
+    expect(queue?.workId).toBeUndefined();
+  });
+
+  test("does not reclaim an active tenant job or clobber its processing event", async () => {
+    const t = convexTest(schema, modules);
+    const workspace = await seedWorkspace(t, "active");
+    const activeJobId = await insertTenantJob(t, {
+      ...workspace,
+      status: "running",
+      suffix: "active",
+    });
+    const eventId = await insertEvent(t, {
+      workspaceId: workspace.workspaceId,
+      suffix: "active-event",
+      occurredAt: 1,
+      status: "processing",
+      evaluatorWorkflowId: String(activeJobId),
+    });
+    await t.run(async (ctx) => {
+      await ctx.db.insert("memoryEvaluationWorkspaceQueues", {
+        workspaceId: workspace.workspaceId,
+        status: "running",
+        workId: String(activeJobId),
+        activeEventId: eventId,
+        updatedAt: 1,
+      });
+    });
+
+    const prepared = await t.mutation(
+      internal.workflows.memory.prepareMemoryEvaluationQueueEnqueueInternal,
+      { workspaceId: workspace.workspaceId }
+    );
+    expect(prepared).toEqual({
+      shouldEnqueue: false,
+      reason: "running",
+      eventId,
+    });
+    const state = await t.run(async (ctx) => ({
+      queue: await ctx.db
+        .query("memoryEvaluationWorkspaceQueues")
+        .withIndex("by_workspace", (q) =>
+          q.eq("workspaceId", workspace.workspaceId)
+        )
+        .unique(),
+      event: await ctx.db.get("memoryWorkflowEvents", eventId),
+    }));
+    expect(state.queue?.status).toBe("running");
+    expect(state.event?.status).toBe("processing");
+  });
+
+  test("requeues a processing event owned by stale legacy work", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-29T00:00:00.000Z"));
+    const t = convexTest(schema, modules);
+    const workspace = await seedWorkspace(t, "legacy-stale");
+    const staleWorkId = "legacy-memory-work";
+    const eventId = await insertEvent(t, {
+      workspaceId: workspace.workspaceId,
+      suffix: "legacy-stale-event",
+      occurredAt: 1,
+      status: "processing",
+      evaluatorWorkflowId: staleWorkId,
+    });
+    await t.run(async (ctx) => {
+      await ctx.db.insert("memoryEvaluatorRuns", {
+        workspaceId: workspace.workspaceId,
+        eventId,
+        eventKey: "memory-queue-legacy-stale-event",
+        eventType: "qualification_completed",
+        sourceType: "workflow_event",
+        sourceId: "legacy-stale-event",
+        workflowId: staleWorkId,
+        status: "running",
+        promotedMemoryCount: 0,
+        suggestedMemoryCount: 0,
+        queryPerformanceUpdateCount: 0,
+        startedAt: 1,
+        updatedAt: 1,
+      });
+      await ctx.db.insert("memoryEvaluationWorkspaceQueues", {
+        workspaceId: workspace.workspaceId,
+        status: "running",
+        workId: staleWorkId,
+        activeEventId: eventId,
+        updatedAt: 1,
+      });
+    });
+
+    const prepared = await t.mutation(
+      internal.workflows.memory.prepareMemoryEvaluationQueueEnqueueInternal,
+      { workspaceId: workspace.workspaceId }
+    );
+    expect(prepared).toEqual({
+      shouldEnqueue: true,
+      reason: "queued",
+      eventId,
+    });
+    const state = await t.run(async (ctx) => ({
+      event: await ctx.db.get("memoryWorkflowEvents", eventId),
+      run: await ctx.db
+        .query("memoryEvaluatorRuns")
+        .withIndex("by_event", (q) => q.eq("eventId", eventId))
+        .unique(),
+    }));
+    expect(state.event).toMatchObject({
+      status: "pending",
+      error: "Recovered after stale memory evaluation queue work",
+    });
+    expect(state.event?.evaluatorWorkflowId).toBeUndefined();
+    expect(state.run).toMatchObject({
+      status: "failed",
+      error: "Recovered after stale memory evaluation queue work",
+    });
+  });
+});

--- a/convex/workflows/memory.ts
+++ b/convex/workflows/memory.ts
@@ -1,5 +1,5 @@
 import { v } from "convex/values";
-import { vOnCompleteArgs } from "@convex-dev/workpool";
+import { vOnCompleteArgs, type WorkId } from "@convex-dev/workpool";
 import { internal } from "../_generated/api";
 import type { Doc, Id } from "../_generated/dataModel";
 import type { ActionCtx, MutationCtx } from "../_generated/server";
@@ -9,6 +9,11 @@ import { getCurrentUTCTimestamp } from "../../shared/lib/utils/time/timeUtils";
 import { TENANT_JOB_PRIORITY } from "../lib/tenantSchedulerCore";
 import { enqueueTenantJobWithRetry } from "../lib/tenantSchedulerEnqueue";
 import { completeTenantJob } from "../lib/tenantSchedulerHelpers";
+import {
+  isMemoryEvaluationLegacyWorkStale,
+  isPriorityMemoryEvaluationEvent,
+  MEMORY_EVALUATION_PRIORITY_SCAN_LIMIT,
+} from "../lib/memoryEvaluationQueueCore";
 
 type MemoryEvaluationEnqueueReason =
   | "missing_event"
@@ -48,6 +53,129 @@ async function getWorkspaceQueueRow(
     .query("memoryEvaluationWorkspaceQueues")
     .withIndex("by_workspace", (q) => q.eq("workspaceId", workspaceId))
     .first();
+}
+
+async function getNextPendingMemoryWorkflowEvent(
+  ctx: Pick<MutationCtx, "db">,
+  workspaceId: Id<"workspaces">
+) {
+  const recentStyleEvents = await ctx.db
+    .query("memoryWorkflowEvents")
+    .withIndex("by_workspace_event_type_occurred_at", (q) =>
+      q
+        .eq("workspaceId", workspaceId)
+        .eq("eventType", "style_content_backfill_completed")
+    )
+    .order("desc")
+    .take(MEMORY_EVALUATION_PRIORITY_SCAN_LIMIT);
+  const priorityEvent = recentStyleEvents.find(isPriorityMemoryEvaluationEvent);
+  if (priorityEvent) return priorityEvent;
+
+  return await ctx.db
+    .query("memoryWorkflowEvents")
+    .withIndex("by_workspace_status_occurred_at", (q) =>
+      q.eq("workspaceId", workspaceId).eq("status", "pending")
+    )
+    .first();
+}
+
+async function getMemoryEvaluationQueueWorkState(
+  ctx: Pick<MutationCtx, "db">,
+  queue: Doc<"memoryEvaluationWorkspaceQueues">,
+  now: number
+): Promise<"active" | "stale" | "unattached"> {
+  if (!queue.workId) {
+    return queue.status === "running" ? "stale" : "unattached";
+  }
+
+  if (queue.status === "idle") {
+    return "stale";
+  }
+
+  const tenantJobId = ctx.db.normalizeId("tenantJobs", queue.workId);
+  if (tenantJobId) {
+    const tenantJob = await ctx.db.get("tenantJobs", tenantJobId);
+    return tenantJob?.status === "queued" || tenantJob?.status === "running"
+      ? "active"
+      : "stale";
+  }
+
+  return isMemoryEvaluationLegacyWorkStale({
+    queueUpdatedAt: queue.updatedAt,
+    now,
+  })
+    ? "stale"
+    : "active";
+}
+
+async function recoverStaleMemoryEvaluationQueue(
+  ctx: MutationCtx,
+  queue: Doc<"memoryEvaluationWorkspaceQueues">,
+  now: number
+) {
+  if (queue.workId && !ctx.db.normalizeId("tenantJobs", queue.workId)) {
+    try {
+      await memoryEvaluationPool.cancel(ctx, queue.workId as WorkId);
+    } catch (error) {
+      console.warn(
+        "[MemoryEvaluationQueue] Stale pool work cancellation failed",
+        {
+          workspaceId: String(queue.workspaceId),
+          workId: queue.workId,
+          error: error instanceof Error ? error.message : String(error),
+        }
+      );
+    }
+  }
+
+  if (queue.activeEventId) {
+    const event = await ctx.db.get("memoryWorkflowEvents", queue.activeEventId);
+    if (
+      event?.status === "processing" &&
+      event.evaluatorWorkflowId === queue.workId
+    ) {
+      await ctx.db.patch("memoryWorkflowEvents", event._id, {
+        status: "pending",
+        evaluatorWorkflowId: undefined,
+        processedAt: undefined,
+        error: "Recovered after stale memory evaluation queue work",
+      });
+
+      const evaluatorRun = await ctx.db
+        .query("memoryEvaluatorRuns")
+        .withIndex("by_event", (q) => q.eq("eventId", event._id))
+        .first();
+      if (
+        evaluatorRun?.status === "running" &&
+        evaluatorRun.workflowId === queue.workId
+      ) {
+        await ctx.db.patch("memoryEvaluatorRuns", evaluatorRun._id, {
+          status: "failed",
+          error: "Recovered after stale memory evaluation queue work",
+          updatedAt: now,
+        });
+      }
+    }
+  }
+
+  console.warn("[MemoryEvaluationQueue] Recovered stale queue work", {
+    workspaceId: String(queue.workspaceId),
+    queueStatus: queue.status,
+    workId: queue.workId,
+    activeEventId: queue.activeEventId
+      ? String(queue.activeEventId)
+      : undefined,
+    queueUpdatedAt: queue.updatedAt,
+  });
+
+  await ctx.db.patch("memoryEvaluationWorkspaceQueues", queue._id, {
+    status: "queued",
+    workId: undefined,
+    activeEventId: undefined,
+    lastError: "Recovered stale memory evaluation queue work",
+    lastEnqueuedAt: now,
+    updatedAt: now,
+  });
 }
 
 async function enqueueWorkspaceMemoryEvaluation(
@@ -272,14 +400,31 @@ export const prepareMemoryEvaluationQueueEnqueueInternal = internalMutation({
   }),
   handler: async (ctx, { workspaceId }) => {
     const queue = await getWorkspaceQueueRow(ctx, workspaceId);
-    const nextPending = await ctx.db
-      .query("memoryWorkflowEvents")
-      .withIndex("by_workspace_status_occurred_at", (q) =>
-        q.eq("workspaceId", workspaceId).eq("status", "pending")
-      )
-      .first();
-
     const now = getCurrentUTCTimestamp();
+    const queueWorkState = queue
+      ? await getMemoryEvaluationQueueWorkState(ctx, queue, now)
+      : "unattached";
+
+    if (queue && queueWorkState === "stale") {
+      await recoverStaleMemoryEvaluationQueue(ctx, queue, now);
+    }
+
+    const nextPending = await getNextPendingMemoryWorkflowEvent(
+      ctx,
+      workspaceId
+    );
+
+    if (
+      queue &&
+      queueWorkState === "active" &&
+      (queue.status === "queued" || queue.status === "running")
+    ) {
+      return {
+        shouldEnqueue: false as const,
+        reason: queue.status,
+        eventId: queue.activeEventId ?? nextPending?._id ?? null,
+      };
+    }
 
     if (!nextPending) {
       if (queue && queue.status !== "idle") {
@@ -299,18 +444,7 @@ export const prepareMemoryEvaluationQueueEnqueueInternal = internalMutation({
       };
     }
 
-    if (
-      queue?.status === "running" ||
-      (queue?.status === "queued" && queue.workId)
-    ) {
-      return {
-        shouldEnqueue: false as const,
-        reason: queue.status,
-        eventId: nextPending._id,
-      };
-    }
-
-    if (queue?.status === "queued") {
+    if (queue && (queue.status === "queued" || queueWorkState === "stale")) {
       return {
         shouldEnqueue: true as const,
         reason: "queued" as const,
@@ -353,6 +487,7 @@ export const setMemoryEvaluationQueueWorkIdInternal = internalMutation({
     workspaceId: v.id("workspaces"),
     workId: v.string(),
   },
+  returns: v.null(),
   handler: async (ctx, { workspaceId, workId }) => {
     const queue = await getWorkspaceQueueRow(ctx, workspaceId);
     const now = getCurrentUTCTimestamp();
@@ -369,7 +504,7 @@ export const setMemoryEvaluationQueueWorkIdInternal = internalMutation({
         lastFinishedAt: undefined,
         updatedAt: now,
       });
-      return;
+      return null;
     }
 
     await ctx.db.patch(queue._id, {
@@ -377,6 +512,7 @@ export const setMemoryEvaluationQueueWorkIdInternal = internalMutation({
       workId,
       updatedAt: now,
     });
+    return null;
   },
 });
 
@@ -384,6 +520,10 @@ export const beginMemoryEvaluationQueueWorkInternal = internalMutation({
   args: {
     workspaceId: v.id("workspaces"),
   },
+  returns: v.object({
+    eventId: v.union(v.id("memoryWorkflowEvents"), v.null()),
+    workId: v.union(v.string(), v.null()),
+  }),
   handler: async (ctx, { workspaceId }) => {
     const queue = await getWorkspaceQueueRow(ctx, workspaceId);
     if (!queue) {
@@ -402,12 +542,10 @@ export const beginMemoryEvaluationQueueWorkInternal = internalMutation({
       };
     }
 
-    const nextPending = await ctx.db
-      .query("memoryWorkflowEvents")
-      .withIndex("by_workspace_status_occurred_at", (q) =>
-        q.eq("workspaceId", workspaceId).eq("status", "pending")
-      )
-      .first();
+    const nextPending = await getNextPendingMemoryWorkflowEvent(
+      ctx,
+      workspaceId
+    );
 
     if (!nextPending) {
       await ctx.db.patch(queue._id, {
@@ -426,6 +564,14 @@ export const beginMemoryEvaluationQueueWorkInternal = internalMutation({
 
     const workId =
       queue.workId ?? `memory-eval:${workspaceId}:${nextPending._id}`;
+
+    if (isPriorityMemoryEvaluationEvent(nextPending)) {
+      console.warn("[MemoryEvaluationQueue] Prioritizing repair event", {
+        workspaceId: String(workspaceId),
+        eventId: String(nextPending._id),
+        eventType: nextPending.eventType,
+      });
+    }
 
     await ctx.db.patch(queue._id, {
       status: "running",

--- a/docs/convex/reliability-program-2026-08-27.md
+++ b/docs/convex/reliability-program-2026-08-27.md
@@ -692,3 +692,42 @@ bounded: deploy with no data mutation, invoke the platform-specific bootstrap
 only for the diagnosed workspace, verify a canonical Twitter style memory and
 ready profile, then observe the automatic plan retry and Convex Insights before
 considering any broader repair audit.
+
+## Memory-evaluation queue follow-up — 2026-08-29
+
+The bounded Twitter repair succeeded, produced the canonical style memory, and
+allowed the failed auto-plan to recover. During that repair, a second problem
+was proven: the workspace queue still referenced old memory-evaluation work even
+though no live tenant job could make progress. The workspace also had a large
+ordinary learning-event backlog. The queue treated the stale `workId` as active,
+and FIFO selection placed the urgent style-repair event behind that backlog.
+The unrelated bulk drain was stopped; remaining learning events were preserved.
+
+The local follow-up changes queue preparation in three bounded ways:
+
+- A queue backed by a queued or running `tenantJobs` row remains active. A
+  terminal or missing tenant-job pointer is reclaimed immediately. A legacy
+  Workpool pointer is reclaimed only after the existing two-hour tenant lease
+  window, and its pending component work is cancelled before replacement when
+  possible.
+- If stale work owned a `processing` event, that event is returned to `pending`
+  only when its `evaluatorWorkflowId` exactly matches the stale queue pointer.
+  The matching running evaluator audit row is marked failed, so a new worker can
+  reuse it idempotently and the recovery remains observable.
+- Explicit `style-repair:` events are selected from a bounded 25-row indexed
+  window before the normal pending queue. All ordinary events retain oldest-first
+  order, and every lookup remains workspace-scoped.
+
+No schema field, table, index, data backfill, Aggregate migration, or global
+event scan is required. Rollout is code-only. After deployment, verify with
+read-only checks that the repaired workspace has no stale queue pointer, that a
+new bounded repair is admitted ahead of old learning history, and that no
+duplicate evaluator run or new scheduler/bytes-read Insight appears. Roll back
+the code if active work is ever reclaimed or ordinary FIFO/cross-workspace
+isolation changes; do not bulk-drain historical learning events as a rollback
+mechanism.
+
+This hotfix does not close the remaining reliability program. The next focused
+phases remain: eliminate measured `prospectSummaries` batch contention, finish
+bounded Action Retrier historical cleanup, observe scheduler admission latency,
+and only then prepare a separate evidence-backed legacy cleanup PR.


### PR DESCRIPTION
## Summary

- reclaim terminal, missing, and safely stale memory-evaluation queue pointers
- cancel stale legacy Workpool work when possible and requeue only its exactly owned processing event
- prioritize bounded style-repair events ahead of ordinary learning backlog while preserving normal FIFO and workspace isolation
- document the incident, rollout gates, and remaining reliability phases

## Migration and rollout

- code-only change; no schema migration, backfill, Aggregate change, or global scan
- deploy with no production mutation, then verify queue state, evaluator runs, scheduler health, and Convex Insights read-only

## Verification

- 113 Convex test files / 567 tests
- targeted memory-queue and tenant-scheduler integration tests
- TypeScript
- strict Oxlint
- production Next.js build, 74/74 pages
- git diff --check

Production has not been modified by this PR preparation.