### PR TITLE
Fix memory queue enqueue generation recovery

### DIFF
--- a/convex/memoryEvaluationQueue.integration.test.ts
+++ b/convex/memoryEvaluationQueue.integration.test.ts
@@ -7,6 +7,32 @@ import type { Id } from "./_generated/dataModel";
 import schema from "./schema";
 
 const modules = import.meta.glob("./**/*.ts");
+const WORKPOOL_NAMES = [
+  "qualificationPool",
+  "enrichmentPool",
+  "previewQualificationPool",
+  "previewEnrichmentPool",
+  "outreachPlanPool",
+  "memoryEvaluationPool",
+  "tenantExecutionPool",
+] as const;
+
+async function registerSchedulerComponents(t: ReturnType<typeof convexTest>) {
+  const workpoolPath = ["@convex-dev/workpool", "test"].join("/");
+  const batchWorkerPath = ["@convex-dev/batch-worker", "test"].join("/");
+  const rateLimiterPath = ["@convex-dev/rate-limiter", "test"].join("/");
+  const [workpoolTest, batchWorkerTest, rateLimiterTest] = await Promise.all([
+    import(workpoolPath),
+    import(batchWorkerPath),
+    import(rateLimiterPath),
+  ]);
+
+  for (const name of WORKPOOL_NAMES) {
+    workpoolTest.default.register(t, name);
+  }
+  batchWorkerTest.default.register(t, "batchWorker");
+  rateLimiterTest.default.register(t, "rateLimiter");
+}
 
 async function seedWorkspace(t: ReturnType<typeof convexTest>, suffix: string) {
   return await t.run(async (ctx) => {
@@ -60,8 +86,9 @@ async function insertTenantJob(
   args: {
     workspaceId: Id<"workspaces">;
     userId: Id<"users">;
-    status: "queued" | "running" | "succeeded";
+    status: "queued" | "running" | "succeeded" | "cancelled";
     suffix: string;
+    idempotencyKey?: string;
   }
 ) {
   return await t.run(async (ctx) => {
@@ -85,14 +112,17 @@ async function insertTenantJob(
       kind: "memory_evaluation",
       status: args.status,
       priority: 50,
-      idempotencyKey: `memory-queue-job-${args.suffix}`,
+      idempotencyKey: args.idempotencyKey ?? `memory-queue-job-${args.suffix}`,
       payload: {
         kind: "memory_evaluation",
         workspaceId: args.workspaceId,
       },
       queuedAt: 1,
       startedAt: args.status === "running" ? 2 : undefined,
-      completedAt: args.status === "succeeded" ? 3 : undefined,
+      completedAt:
+        args.status === "succeeded" || args.status === "cancelled"
+          ? 3
+          : undefined,
       attemptCount: args.status === "queued" ? 0 : 1,
       updatedAt: 3,
     });
@@ -204,6 +234,7 @@ describe("memory evaluation workspace queue", () => {
       shouldEnqueue: true,
       reason: "queued",
       eventId,
+      enqueueToken: expect.any(Number),
     });
     expect(
       await t.mutation(
@@ -259,6 +290,7 @@ describe("memory evaluation workspace queue", () => {
       shouldEnqueue: false,
       reason: "running",
       eventId,
+      enqueueToken: null,
     });
     const state = await t.run(async (ctx) => ({
       queue: await ctx.db
@@ -319,6 +351,7 @@ describe("memory evaluation workspace queue", () => {
       shouldEnqueue: true,
       reason: "queued",
       eventId,
+      enqueueToken: expect.any(Number),
     });
     const state = await t.run(async (ctx) => ({
       event: await ctx.db.get("memoryWorkflowEvents", eventId),
@@ -336,5 +369,136 @@ describe("memory evaluation workspace queue", () => {
       status: "failed",
       error: "Recovered after stale memory evaluation queue work",
     });
+  });
+
+  test("creates a new scheduler job after a cancelled pointer and converges retries", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-29T00:00:00.000Z"));
+    const t = convexTest(schema, modules);
+    await registerSchedulerComponents(t);
+    const workspace = await seedWorkspace(t, "cancelled-reenqueue");
+    const eventId = await insertEvent(t, {
+      workspaceId: workspace.workspaceId,
+      suffix: "cancelled-reenqueue-event",
+      occurredAt: 1,
+    });
+    const legacyIdempotencyKey = `memory-evaluation:${String(workspace.workspaceId)}:${String(eventId)}`;
+    const cancelledJobId = await insertTenantJob(t, {
+      ...workspace,
+      status: "cancelled",
+      suffix: "cancelled-reenqueue",
+      idempotencyKey: legacyIdempotencyKey,
+    });
+    await t.run(async (ctx) => {
+      await ctx.db.insert("memoryEvaluationWorkspaceQueues", {
+        workspaceId: workspace.workspaceId,
+        status: "queued",
+        workId: String(cancelledJobId),
+        lastEnqueuedAt: 1,
+        updatedAt: 1,
+      });
+    });
+    await t.mutation(internal.tenantScheduler.setControlInternal, {
+      mode: "enforced",
+    });
+
+    const first = await t.action(
+      internal.workflows.memory.enqueueWorkspaceMemoryEvaluationInternal,
+      { workspaceId: workspace.workspaceId }
+    );
+    expect(first).toMatchObject({ enqueued: true });
+    expect(first.enqueued && first.workId).not.toBe(String(cancelledJobId));
+
+    const retry = await t.action(
+      internal.workflows.memory.enqueueWorkspaceMemoryEvaluationInternal,
+      { workspaceId: workspace.workspaceId }
+    );
+    expect(retry).toEqual({ enqueued: false, reason: "queued" });
+
+    const state = await t.run(async (ctx) => ({
+      jobs: await ctx.db.query("tenantJobs").collect(),
+      queue: await ctx.db
+        .query("memoryEvaluationWorkspaceQueues")
+        .withIndex("by_workspace", (q) =>
+          q.eq("workspaceId", workspace.workspaceId)
+        )
+        .unique(),
+    }));
+    expect(state.jobs).toHaveLength(2);
+    const replacement = state.jobs.find((job) => job._id !== cancelledJobId);
+    expect(replacement?.idempotencyKey).toBe(
+      `${legacyIdempotencyKey}:${Date.parse("2026-08-29T00:00:00.000Z")}`
+    );
+    expect(state.queue?.workId).toBe(String(replacement?._id));
+  });
+
+  test("rejects delayed attachment and execution from an older enqueue generation", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-29T00:00:00.000Z"));
+    const t = convexTest(schema, modules);
+    const workspace = await seedWorkspace(t, "generation-guard");
+    const eventId = await insertEvent(t, {
+      workspaceId: workspace.workspaceId,
+      suffix: "generation-guard-event",
+      occurredAt: 1,
+    });
+    const prepared = await t.mutation(
+      internal.workflows.memory.prepareMemoryEvaluationQueueEnqueueInternal,
+      { workspaceId: workspace.workspaceId }
+    );
+    if (prepared.enqueueToken === null) {
+      throw new Error("Expected an enqueue token");
+    }
+    const newerToken = prepared.enqueueToken + 1;
+    await t.run(async (ctx) => {
+      const queue = await ctx.db
+        .query("memoryEvaluationWorkspaceQueues")
+        .withIndex("by_workspace", (q) =>
+          q.eq("workspaceId", workspace.workspaceId)
+        )
+        .unique();
+      if (!queue) throw new Error("Expected queue row");
+      await ctx.db.patch(queue._id, { lastEnqueuedAt: newerToken });
+    });
+
+    expect(
+      await t.mutation(
+        internal.workflows.memory.setMemoryEvaluationQueueWorkIdInternal,
+        {
+          workspaceId: workspace.workspaceId,
+          workId: "old-work",
+          enqueueToken: prepared.enqueueToken,
+        }
+      )
+    ).toEqual({ attached: false });
+    expect(
+      await t.mutation(
+        internal.workflows.memory.beginMemoryEvaluationQueueWorkInternal,
+        {
+          workspaceId: workspace.workspaceId,
+          enqueueToken: prepared.enqueueToken,
+        }
+      )
+    ).toEqual({ eventId: null, workId: null });
+
+    expect(
+      await t.mutation(
+        internal.workflows.memory.setMemoryEvaluationQueueWorkIdInternal,
+        {
+          workspaceId: workspace.workspaceId,
+          workId: "new-work",
+          enqueueToken: newerToken,
+        }
+      )
+    ).toEqual({ attached: true });
+    expect(
+      await t.mutation(
+        internal.workflows.memory.beginMemoryEvaluationQueueWorkInternal,
+        {
+          workspaceId: workspace.workspaceId,
+          enqueueToken: newerToken,
+        }
+      )
+    ).toEqual({ eventId, workId: "new-work" });
   });
 });

--- a/convex/tenantScheduler.integration.test.ts
+++ b/convex/tenantScheduler.integration.test.ts
@@ -360,6 +360,7 @@ describe("tenant scheduler integration", () => {
       shouldEnqueue: true,
       reason: "queued",
       eventId,
+      enqueueToken: expect.any(Number),
     });
     expect(retry).toEqual(first);
 
@@ -375,6 +376,7 @@ describe("tenant scheduler integration", () => {
       shouldEnqueue: false,
       reason: "queued",
       eventId,
+      enqueueToken: first.enqueueToken,
     });
   });
 

--- a/convex/tenantScheduler.ts
+++ b/convex/tenantScheduler.ts
@@ -836,7 +836,13 @@ export const dispatchBatchInternal = internalMutation({
               ctx,
               internal.workflows.memory
                 .runQueuedWorkspaceMemoryEvaluationInternal,
-              { workspaceId: payload.workspaceId },
+              {
+                workspaceId: payload.workspaceId,
+                ...(payload.enqueueToken === undefined
+                  ? {}
+                  : { enqueueToken: payload.enqueueToken }),
+                workId: String(job._id),
+              },
               {
                 onComplete:
                   internal.workflows.memory

--- a/convex/validators.ts
+++ b/convex/validators.ts
@@ -1668,6 +1668,7 @@ export const tenantJobPayloadValidator = v.union(
   v.object({
     kind: v.literal("memory_evaluation"),
     workspaceId: v.id("workspaces"),
+    enqueueToken: v.optional(v.number()),
   })
 );
 

--- a/convex/workflows/memory.ts
+++ b/convex/workflows/memory.ts
@@ -111,7 +111,8 @@ async function getMemoryEvaluationQueueWorkState(
 async function recoverStaleMemoryEvaluationQueue(
   ctx: MutationCtx,
   queue: Doc<"memoryEvaluationWorkspaceQueues">,
-  now: number
+  now: number,
+  enqueueToken: number
 ) {
   if (queue.workId && !ctx.db.normalizeId("tenantJobs", queue.workId)) {
     try {
@@ -173,7 +174,7 @@ async function recoverStaleMemoryEvaluationQueue(
     workId: undefined,
     activeEventId: undefined,
     lastError: "Recovered stale memory evaluation queue work",
-    lastEnqueuedAt: now,
+    lastEnqueuedAt: enqueueToken,
     updatedAt: now,
   });
 }
@@ -186,6 +187,7 @@ async function enqueueWorkspaceMemoryEvaluation(
     shouldEnqueue: boolean;
     reason: "no_pending" | "queued" | "running";
     eventId: Id<"memoryWorkflowEvents"> | null;
+    enqueueToken: number | null;
   } = await ctx.runMutation(
     internal.workflows.memory.prepareMemoryEvaluationQueueEnqueueInternal,
     {
@@ -197,6 +199,9 @@ async function enqueueWorkspaceMemoryEvaluation(
       enqueued: false as const,
       reason: prepared.reason,
     };
+  }
+  if (!prepared.eventId || prepared.enqueueToken === null) {
+    return { enqueued: false as const, reason: "missing_event" as const };
   }
 
   const workspace = await ctx.runQuery(internal.workspaces.getById, {
@@ -211,15 +216,30 @@ async function enqueueWorkspaceMemoryEvaluation(
     userId: workspace.userId,
     class: "background",
     priority: TENANT_JOB_PRIORITY.background,
-    idempotencyKey: `memory-evaluation:${String(workspaceId)}:${String(prepared.eventId)}`,
-    payload: { kind: "memory_evaluation", workspaceId },
+    idempotencyKey: `memory-evaluation:${String(workspaceId)}:${String(prepared.eventId)}:${String(prepared.enqueueToken)}`,
+    payload: {
+      kind: "memory_evaluation",
+      workspaceId,
+      enqueueToken: prepared.enqueueToken,
+    },
   });
   if (tenantRoute.route === "enforced") {
     const schedulerWorkId = String(tenantRoute.jobId);
-    await ctx.runMutation(
+    const attachment: { attached: boolean } = await ctx.runMutation(
       internal.workflows.memory.setMemoryEvaluationQueueWorkIdInternal,
-      { workspaceId, workId: schedulerWorkId }
+      {
+        workspaceId,
+        workId: schedulerWorkId,
+        enqueueToken: prepared.enqueueToken,
+      }
     );
+    if (!attachment.attached) {
+      await ctx.runMutation(
+        internal.tenantScheduler.cancelJobByExternalIdInternal,
+        { workId: schedulerWorkId }
+      );
+      return { enqueued: false as const, reason: "queued" as const };
+    }
     return { enqueued: true as const, workId: schedulerWorkId };
   }
 
@@ -228,6 +248,7 @@ async function enqueueWorkspaceMemoryEvaluation(
     internal.workflows.memory.runQueuedWorkspaceMemoryEvaluationInternal,
     {
       workspaceId,
+      enqueueToken: prepared.enqueueToken,
     },
     {
       onComplete:
@@ -237,13 +258,19 @@ async function enqueueWorkspaceMemoryEvaluation(
     }
   );
 
-  await ctx.runMutation(
+  const attachment: { attached: boolean } = await ctx.runMutation(
     internal.workflows.memory.setMemoryEvaluationQueueWorkIdInternal,
     {
       workspaceId,
       workId: String(workId),
+      enqueueToken: prepared.enqueueToken,
     }
   );
+
+  if (!attachment.attached) {
+    await memoryEvaluationPool.cancel(ctx, workId as WorkId);
+    return { enqueued: false as const, reason: "queued" as const };
+  }
 
   return {
     enqueued: true as const,
@@ -397,6 +424,7 @@ export const prepareMemoryEvaluationQueueEnqueueInternal = internalMutation({
       v.literal("running")
     ),
     eventId: v.union(v.id("memoryWorkflowEvents"), v.null()),
+    enqueueToken: v.union(v.number(), v.null()),
   }),
   handler: async (ctx, { workspaceId }) => {
     const queue = await getWorkspaceQueueRow(ctx, workspaceId);
@@ -404,9 +432,18 @@ export const prepareMemoryEvaluationQueueEnqueueInternal = internalMutation({
     const queueWorkState = queue
       ? await getMemoryEvaluationQueueWorkState(ctx, queue, now)
       : "unattached";
+    const recoveredEnqueueToken =
+      queue && queueWorkState === "stale"
+        ? Math.max(now, (queue.lastEnqueuedAt ?? 0) + 1)
+        : null;
 
-    if (queue && queueWorkState === "stale") {
-      await recoverStaleMemoryEvaluationQueue(ctx, queue, now);
+    if (queue && recoveredEnqueueToken !== null) {
+      await recoverStaleMemoryEvaluationQueue(
+        ctx,
+        queue,
+        now,
+        recoveredEnqueueToken
+      );
     }
 
     const nextPending = await getNextPendingMemoryWorkflowEvent(
@@ -423,6 +460,7 @@ export const prepareMemoryEvaluationQueueEnqueueInternal = internalMutation({
         shouldEnqueue: false as const,
         reason: queue.status,
         eventId: queue.activeEventId ?? nextPending?._id ?? null,
+        enqueueToken: queue.lastEnqueuedAt ?? null,
       };
     }
 
@@ -441,14 +479,25 @@ export const prepareMemoryEvaluationQueueEnqueueInternal = internalMutation({
         shouldEnqueue: false as const,
         reason: "no_pending" as const,
         eventId: null,
+        enqueueToken: null,
       };
     }
 
     if (queue && (queue.status === "queued" || queueWorkState === "stale")) {
+      const enqueueToken =
+        recoveredEnqueueToken ??
+        (queue.lastEnqueuedAt === undefined ? now : queue.lastEnqueuedAt);
+      if (queue.lastEnqueuedAt !== enqueueToken) {
+        await ctx.db.patch(queue._id, {
+          lastEnqueuedAt: enqueueToken,
+          updatedAt: now,
+        });
+      }
       return {
         shouldEnqueue: true as const,
         reason: "queued" as const,
         eventId: nextPending._id,
+        enqueueToken,
       };
     }
 
@@ -478,6 +527,7 @@ export const prepareMemoryEvaluationQueueEnqueueInternal = internalMutation({
       shouldEnqueue: true as const,
       reason: "queued" as const,
       eventId: nextPending._id,
+      enqueueToken: now,
     };
   },
 });
@@ -486,47 +536,54 @@ export const setMemoryEvaluationQueueWorkIdInternal = internalMutation({
   args: {
     workspaceId: v.id("workspaces"),
     workId: v.string(),
+    enqueueToken: v.optional(v.number()),
   },
-  returns: v.null(),
-  handler: async (ctx, { workspaceId, workId }) => {
+  returns: v.object({ attached: v.boolean() }),
+  handler: async (ctx, { workspaceId, workId, enqueueToken }) => {
     const queue = await getWorkspaceQueueRow(ctx, workspaceId);
     const now = getCurrentUTCTimestamp();
 
     if (!queue) {
-      await ctx.db.insert("memoryEvaluationWorkspaceQueues", {
-        workspaceId,
-        status: "queued",
-        workId,
-        activeEventId: undefined,
-        lastError: undefined,
-        lastEnqueuedAt: now,
-        lastStartedAt: undefined,
-        lastFinishedAt: undefined,
-        updatedAt: now,
-      });
-      return null;
+      return { attached: false };
     }
 
-    await ctx.db.patch(queue._id, {
-      status: "queued",
-      workId,
-      updatedAt: now,
-    });
-    return null;
+    if (
+      (queue.status !== "queued" && queue.status !== "running") ||
+      (enqueueToken !== undefined && queue.lastEnqueuedAt !== enqueueToken) ||
+      (queue.workId !== undefined && queue.workId !== workId)
+    ) {
+      return { attached: false };
+    }
+
+    if (queue.status === "queued") {
+      await ctx.db.patch(queue._id, {
+        workId,
+        updatedAt: now,
+      });
+    }
+    return { attached: true };
   },
 });
 
 export const beginMemoryEvaluationQueueWorkInternal = internalMutation({
   args: {
     workspaceId: v.id("workspaces"),
+    enqueueToken: v.optional(v.number()),
+    workId: v.optional(v.string()),
   },
   returns: v.object({
     eventId: v.union(v.id("memoryWorkflowEvents"), v.null()),
     workId: v.union(v.string(), v.null()),
   }),
-  handler: async (ctx, { workspaceId }) => {
+  handler: async (
+    ctx,
+    { workspaceId, enqueueToken, workId: expectedWorkId }
+  ) => {
     const queue = await getWorkspaceQueueRow(ctx, workspaceId);
-    if (!queue) {
+    if (
+      !queue ||
+      (enqueueToken !== undefined && queue.lastEnqueuedAt !== enqueueToken)
+    ) {
       return {
         eventId: null,
         workId: null,
@@ -563,7 +620,9 @@ export const beginMemoryEvaluationQueueWorkInternal = internalMutation({
     }
 
     const workId =
-      queue.workId ?? `memory-eval:${workspaceId}:${nextPending._id}`;
+      queue.workId ??
+      expectedWorkId ??
+      `memory-eval:${workspaceId}:${nextPending._id}`;
 
     if (isPriorityMemoryEvaluationEvent(nextPending)) {
       console.warn("[MemoryEvaluationQueue] Prioritizing repair event", {
@@ -730,15 +789,19 @@ export const handleMemoryEvaluationQueueWorkCompletionInternal =
 export const runQueuedWorkspaceMemoryEvaluationInternal = internalAction({
   args: {
     workspaceId: v.id("workspaces"),
+    enqueueToken: v.optional(v.number()),
+    workId: v.optional(v.string()),
   },
   handler: async (
     ctx,
-    { workspaceId }
+    { workspaceId, enqueueToken, workId }
   ): Promise<MemoryEvaluationQueueRunResult> => {
     const queueWork = await ctx.runMutation(
       internal.workflows.memory.beginMemoryEvaluationQueueWorkInternal,
       {
         workspaceId,
+        enqueueToken,
+        workId,
       }
     );
 

--- a/docs/convex/reliability-program-2026-08-27.md
+++ b/docs/convex/reliability-program-2026-08-27.md
@@ -731,3 +731,32 @@ This hotfix does not close the remaining reliability program. The next focused
 phases remain: eliminate measured `prospectSummaries` batch contention, finish
 bounded Action Retrier historical cleanup, observe scheduler admission latency,
 and only then prepare a separate evidence-backed legacy cleanup PR.
+
+### Post-deployment queue gate and enqueue-generation follow-up
+
+The read-only gate after PR #47 deployed found no duplicate or running evaluator
+runs and a healthy tenant scheduler: enforced mode, an empty queue, 36/36 tenant
+slots free, no expired lease, unresolved enqueue failure, or pool drift. Convex
+Insights also showed no newer scheduler OCC, prospect-batch bytes-read,
+`prospectSummaries` OCC, or Action Retrier cleanup event than the prior snapshot.
+
+The affected workspace was not recovered, however. Its queue had been reclaimed
+and prepared again, but the scheduler idempotency key still used only workspace
+and event. Enqueue therefore returned the historical cancelled `tenantJobs` row,
+and the queue attached that terminal ID again. The failure was silent in
+evaluator-run telemetry because no evaluator action started.
+
+The local follow-up gives every prepared queue generation a stable numeric token
+stored in the existing `lastEnqueuedAt` field. Concurrent retries reuse that
+token and converge on one scheduler job; stale recovery advances it monotonically
+and therefore cannot reuse the cancelled generation. The token travels in the
+optional memory-evaluation payload for widen compatibility. Queue attachment and
+worker start compare it before changing state, so a delayed older enqueue cannot
+overwrite or execute a newer generation. A rejected duplicate is cancelled
+best-effort. No schema change or data backfill is required.
+
+Rollout remains code-only: deploy first, confirm the existing stale pointer is
+replaced by a different queued/running job, then require one evaluator run for
+the selected event and no duplicate run, scheduler failure, or new Insights
+regression. Do not start the `prospectSummaries` contention change until this
+gate passes, because combining the two fixes would make rollback ambiguous.


### PR DESCRIPTION
## Summary
- give each memory-evaluation queue generation a stable token so stale recovery cannot reuse a cancelled tenant job
- compare-and-set queue attachment and worker start so delayed older enqueue attempts cannot overwrite or execute newer work
- retain backward compatibility for already-persisted memory-evaluation payloads without a schema migration or data backfill
- document the failed post-PR #47 production gate and bounded rollout criteria

## Production evidence
After PR #47 deployed, read-only verification found a healthy drained scheduler and no duplicate/running evaluator runs, but the affected workspace queue still pointed at a cancelled tenant job. Recovery cleared the pointer, then the old workspace+event idempotency key returned the same cancelled job and reattached it.

## Verification
- `npx vitest run --config vitest.config.ts --maxWorkers=4` — 113 files, 569 tests passed
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- Prettier and `git diff --check`
- Convex reviewer/security review: internal-only entry points, strict validators, indexed workspace-scoped reads, no new public surface

## Rollout
1. Deploy code only; do not backfill.
2. Read-only verify scheduler health and the affected queue.
3. Confirm stale recovery creates a different tenant job ID and exactly one evaluator run.
4. Require no duplicate run, scheduler failure, or new Convex Insights regression before continuing to `prospectSummaries` contention work.
