### PR TITLE
Fix prospect summary write contention

### DIFF
--- a/convex/lib/triggers.ts
+++ b/convex/lib/triggers.ts
@@ -27,6 +27,7 @@ import {
   type TargetedWorkspaceAgentOpsContribution,
 } from "./agentOpsReadModelHelpers";
 import { buildOutreachProgressSummary } from "./outreachProgressHelpers";
+import { buildChangedPatchWithUpdatedAt } from "./patchHelpers";
 import { getReadModelStripe } from "./readModelStripeHelpers";
 import { syncProspectFitScoreAggregate } from "./prospectFitScoreAggregate";
 
@@ -148,21 +149,42 @@ async function syncProspectSummary(
     return;
   }
 
+  const nextSummary = args.newDoc
+    ? buildProspectSummaryRecord(args.newDoc)
+    : null;
+  if (args.oldDoc && nextSummary) {
+    const previousSummary = buildProspectSummaryRecord(args.oldDoc);
+    const sourcePatch = buildChangedPatchWithUpdatedAt(
+      previousSummary as unknown as Record<string, unknown>,
+      nextSummary as unknown as Record<string, unknown>,
+      nextSummary.updatedAt
+    );
+    if (!sourcePatch) {
+      return;
+    }
+  }
+
   const existing = await db
     .query("prospectSummaries")
     .withIndex("by_prospect", (q) => q.eq("prospectId", prospectId))
     .first();
 
-  if (!args.newDoc) {
+  if (!nextSummary) {
     if (existing) {
       await db.delete(existing._id);
     }
     return;
   }
 
-  const nextSummary = buildProspectSummaryRecord(args.newDoc);
   if (existing) {
-    await db.patch(existing._id, nextSummary);
+    const patch = buildChangedPatchWithUpdatedAt(
+      existing as unknown as Record<string, unknown>,
+      nextSummary as unknown as Record<string, unknown>,
+      nextSummary.updatedAt
+    );
+    if (patch) {
+      await db.patch(existing._id, patch);
+    }
   } else {
     await db.insert("prospectSummaries", nextSummary);
   }
@@ -412,6 +434,19 @@ triggers.register("prospects", async (ctx, change) => {
     return;
   }
 
+  const oldStatsContribution = change.oldDoc
+    ? getWorkspaceStatsContributionFromProspect(change.oldDoc)
+    : null;
+  const newStatsContribution = change.newDoc
+    ? getWorkspaceStatsContributionFromProspect(change.newDoc)
+    : null;
+  const oldAnalyticsContributions = change.oldDoc
+    ? getWorkspaceAnalyticsContributionsFromProspect(change.oldDoc)
+    : [];
+  const newAnalyticsContributions = change.newDoc
+    ? getWorkspaceAnalyticsContributionsFromProspect(change.newDoc)
+    : [];
+
   await syncProspectSummary(ctx.innerDb, {
     oldDoc: change.oldDoc,
     newDoc: change.newDoc,
@@ -422,41 +457,41 @@ triggers.register("prospects", async (ctx, change) => {
     newDoc: change.newDoc,
   });
 
-  await applyWorkspaceStatsChanges(ctx.innerDb, {
-    sourceKey: String(change.id),
-    remove: change.oldDoc
-      ? [
-          {
-            workspaceId: change.oldDoc.workspaceId,
-            userId: change.oldDoc.userId,
-            contribution: getWorkspaceStatsContributionFromProspect(
-              change.oldDoc
-            ),
-          },
-        ]
-      : [],
-    add: change.newDoc
-      ? [
-          {
-            workspaceId: change.newDoc.workspaceId,
-            userId: change.newDoc.userId,
-            contribution: getWorkspaceStatsContributionFromProspect(
-              change.newDoc
-            ),
-          },
-        ]
-      : [],
-  });
+  if (!areJsonValuesEqual(oldStatsContribution, newStatsContribution)) {
+    await applyWorkspaceStatsChanges(ctx.innerDb, {
+      sourceKey: String(change.id),
+      remove:
+        change.oldDoc && oldStatsContribution
+          ? [
+              {
+                workspaceId: change.oldDoc.workspaceId,
+                userId: change.oldDoc.userId,
+                contribution: oldStatsContribution,
+              },
+            ]
+          : [],
+      add:
+        change.newDoc && newStatsContribution
+          ? [
+              {
+                workspaceId: change.newDoc.workspaceId,
+                userId: change.newDoc.userId,
+                contribution: newStatsContribution,
+              },
+            ]
+          : [],
+    });
+  }
 
-  await applyWorkspaceAnalyticsChanges(ctx.innerDb, {
-    sourceKey: String(change.id),
-    remove: change.oldDoc
-      ? getWorkspaceAnalyticsContributionsFromProspect(change.oldDoc)
-      : [],
-    add: change.newDoc
-      ? getWorkspaceAnalyticsContributionsFromProspect(change.newDoc)
-      : [],
-  });
+  if (
+    !areJsonValuesEqual(oldAnalyticsContributions, newAnalyticsContributions)
+  ) {
+    await applyWorkspaceAnalyticsChanges(ctx.innerDb, {
+      sourceKey: String(change.id),
+      remove: oldAnalyticsContributions,
+      add: newAnalyticsContributions,
+    });
+  }
 });
 
 triggers.register("prospectActivityLog", async (ctx, change) => {

--- a/convex/prospectPersistence.integration.test.ts
+++ b/convex/prospectPersistence.integration.test.ts
@@ -26,6 +26,76 @@ async function seedWorkspace(t: ReturnType<typeof convexTest>) {
 }
 
 describe("prospect persistence reliability", () => {
+  test("skips unchanged summary and rollup writes during provider refreshes", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.UTC(2026, 7, 29, 8));
+    const t = convexTest(schema, modules);
+    const workspace = await seedWorkspace(t);
+    const baseProspect = {
+      platform: "twitter" as const,
+      externalId: "provider-refresh-1",
+      data: {
+        id_str: "provider-refresh-1",
+        providerRefreshNonce: 1,
+        user: {
+          id_str: "provider-refresh-user",
+          name: "Provider Refresh Prospect",
+          screen_name: "provider_refresh",
+        },
+      },
+      discoverySource: "search_post" as const,
+    };
+
+    const created = await t.mutation(internal.prospects.createProspectsBatch, {
+      ...workspace,
+      prospects: [baseProspect],
+    });
+    const before = await t.run(async (ctx) => ({
+      prospect: await ctx.db.get("prospects", created.prospectIds[0]),
+      summary: await ctx.db
+        .query("prospectSummaries")
+        .withIndex("by_prospect", (q) =>
+          q.eq("prospectId", created.prospectIds[0])
+        )
+        .unique(),
+      stats: await ctx.db.query("workspaceStatsStripes").unique(),
+      analytics: await ctx.db.query("workspaceAnalyticsDailyStripes").unique(),
+    }));
+
+    vi.setSystemTime(Date.UTC(2026, 7, 29, 9));
+    const refreshed = await t.mutation(
+      internal.prospects.createProspectsBatch,
+      {
+        ...workspace,
+        prospects: [
+          {
+            ...baseProspect,
+            data: { ...baseProspect.data, providerRefreshNonce: 2 },
+          },
+        ],
+      }
+    );
+    const after = await t.run(async (ctx) => ({
+      prospect: await ctx.db.get("prospects", created.prospectIds[0]),
+      summary: await ctx.db
+        .query("prospectSummaries")
+        .withIndex("by_prospect", (q) =>
+          q.eq("prospectId", created.prospectIds[0])
+        )
+        .unique(),
+      stats: await ctx.db.query("workspaceStatsStripes").unique(),
+      analytics: await ctx.db.query("workspaceAnalyticsDailyStripes").unique(),
+    }));
+
+    expect(refreshed).toMatchObject({ created: 0, updated: 1 });
+    expect(after.prospect?.updatedAt).toBeGreaterThan(
+      before.prospect?.updatedAt ?? 0
+    );
+    expect(after.summary).toEqual(before.summary);
+    expect(after.stats).toEqual(before.stats);
+    expect(after.analytics).toEqual(before.analytics);
+  });
+
   test("persists one heavyweight prospect idempotently without a plan scan", async () => {
     vi.useFakeTimers();
     const t = convexTest(schema, modules);

--- a/docs/convex/reliability-program-2026-08-27.md
+++ b/docs/convex/reliability-program-2026-08-27.md
@@ -760,3 +760,37 @@ replaced by a different queued/running job, then require one evaluator run for
 the selected event and no duplicate run, scheduler failure, or new Insights
 regression. Do not start the `prospectSummaries` contention change until this
 gate passes, because combining the two fixes would make rollback ambiguous.
+
+### Bounded queue recovery gate — 2026-08-29
+
+After the generation fix deployed, the approved production operation invoked
+only `prepareMemoryEvaluationQueueEnqueueInternal` for the diagnosed workspace.
+It reclaimed the historical cancelled pointer, selected pending event
+`n575xs9f8qsx0hnrdpt9zrxrsn8d9ese`, and advanced the queue generation to
+`1787949197202`. Verification found the queue in `queued` state with no `workId`,
+no replacement tenant job, no running evaluator, and the ordinary backlog still
+intact. This closed the stale-pointer recovery gate without bulk-draining or
+otherwise processing preserved learning events. Exact-once execution remains a
+production observation gate for the next natural enqueue, not a prerequisite
+for the independent summary-contention fix.
+
+## Prospect summary contention follow-up — 2026-08-29
+
+Production Insights recorded eight permanent `createProspectsBatch` conflicts
+on `prospectSummaries`; the latest was 2026-08-28 14:40:15 UTC. Repeated failures
+targeted the same per-prospect summary IDs, and each exhausted Convex's four OCC
+retries. The source mutation was already limited to one prospect per transaction
+and its action caller already retried idempotently, so another global queue,
+Aggregate, or sharded counter would not address this per-prospect dependency.
+
+The focused fix suppresses read-model work before opening the conflicting read
+set. A provider refresh whose derived summary is unchanged now returns before
+reading or patching `prospectSummaries`. The prospect trigger also compares the
+old and new stats and daily-analytics contributions before reading or writing
+their 32-way stripes. Genuine summary, stats, and analytics transitions still
+write through the existing trigger, while raw provider payload refreshes update
+only their source prospect. There is no schema change, backfill, or rollout
+migration. Integration coverage proves an irrelevant provider refresh advances
+the source prospect while leaving the summary and both rollup stripes byte-for-
+byte unchanged; existing transition coverage proves real status changes still
+update the striped read models.


### PR DESCRIPTION
## Summary
- skip `prospectSummaries` reads and writes when a provider refresh does not change derived summary fields
- skip `workspaceStatsStripes` and `workspaceAnalyticsDailyStripes` transactions when their prospect contributions are unchanged
- document the bounded memory-queue gate and the measured summary OCC incident

## Why
Production Insights recorded 8 permanent `createProspectsBatch` OCC failures on per-prospect summary rows. The source mutation is already one prospect per transaction with idempotent caller retries. The remaining amplification came from opening summary and rollup read/write sets for raw provider refreshes whose user-visible values were unchanged.

## Verification
- `npm run test:convex` — 570/570 passed
- `npx tsc --noEmit`
- `npm run lint -- --deny-warnings`
- `npm run build` — 74 routes built
- Convex performance, reviewer, and security checklists completed

## Rollout
Code-only. No schema change, migration, backfill, deployment, or production mutation is included. After deployment, compare new permanent `createProspectsBatch` OCC events and bytes-read failures against the documented production snapshot.