### PR TITLE
Bound Action Retrier cleanup reads

### DIFF
--- a/convex/actionRetrierCleanup.integration.test.ts
+++ b/convex/actionRetrierCleanup.integration.test.ts
@@ -1,0 +1,82 @@
+/// <reference types="vite/client" />
+
+import actionRetrierTest from "@convex-dev/action-retrier/test";
+import { convexTest } from "convex-test";
+import type { FunctionReference } from "convex/server";
+import { describe, expect, test, vi } from "vitest";
+import { components } from "./_generated/api";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+
+const actionRetrierInternal = components.actionRetrier as unknown as {
+  run: {
+    cleanupExpiredRuns: FunctionReference<
+      "mutation",
+      "internal",
+      Record<string, never>,
+      null
+    >;
+  };
+};
+
+async function runExists(
+  t: ReturnType<typeof convexTest>,
+  runId: string
+): Promise<boolean> {
+  try {
+    await t.query(components.actionRetrier.public.status, { runId });
+    return true;
+  } catch (error) {
+    expect(String(error)).toContain("not found");
+    return false;
+  }
+}
+
+describe("Action Retrier cleanup", () => {
+  test("drains large historical runs in bytes-safe continuation pages", async () => {
+    vi.useFakeTimers();
+    const startedAt = Date.UTC(2026, 7, 29, 8);
+    vi.setSystemTime(startedAt);
+    const t = convexTest({
+      schema,
+      modules,
+      transactionLimits: { bytesRead: 6_000_000 },
+    });
+    actionRetrierTest.register(t);
+
+    const runIds: string[] = [];
+    const largeHistoricalArgs = { payload: "x".repeat(700_000) };
+    for (let index = 0; index < 10; index += 1) {
+      const runId = await t.mutation(components.actionRetrier.public.start, {
+        functionHandle: `historical-action-${index}`,
+        functionArgs: largeHistoricalArgs,
+        options: {
+          initialBackoffMs: 1_000,
+          base: 2,
+          maxFailures: 3,
+          logLevel: "ERROR",
+          runAt: startedAt + 30 * 24 * 60 * 60 * 1_000,
+        },
+      });
+      expect(
+        await t.mutation(components.actionRetrier.public.cancel, { runId })
+      ).toBe(true);
+      runIds.push(runId);
+    }
+
+    vi.setSystemTime(startedAt + 8 * 24 * 60 * 60 * 1_000);
+    await t.mutation(actionRetrierInternal.run.cleanupExpiredRuns, {});
+
+    const afterFirstPage = await Promise.all(
+      runIds.map((runId) => runExists(t, runId))
+    );
+    expect(afterFirstPage.filter(Boolean)).toHaveLength(6);
+
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    const afterContinuation = await Promise.all(
+      runIds.map((runId) => runExists(t, runId))
+    );
+    expect(afterContinuation.filter(Boolean)).toHaveLength(0);
+  });
+});

--- a/docs/convex/reliability-program-2026-08-27.md
+++ b/docs/convex/reliability-program-2026-08-27.md
@@ -794,3 +794,46 @@ migration. Integration coverage proves an irrelevant provider refresh advances
 the source prospect while leaving the summary and both rollup stripes byte-for-
 byte unchanged; existing transition coverage proves real status changes still
 update the striped read models.
+
+### Prospect-summary deployment gate
+
+PR #49 deployed as merge commit `2ab3aa28d34e5d455bfc3ef8ccc915b08ea64295`.
+The immediate read-only gate found no permanent `prospectSummaries` OCC or
+`createProspectsBatch` bytes-read event newer than the pre-deploy baselines
+(2026-08-28 14:40:15 UTC and 11:29:40 UTC respectively). The scheduler remained
+globally enforced with the correct 36-slot tenant pool, no override, expired
+lease, unresolved enqueue failure, or drift while new qualification traffic was
+running.
+
+The previously repaired memory queue also advanced naturally to a new
+generation. Its selected event reached the terminal `ignored` state, the
+cancelled historical pointer was not reused, and a later queue generation held
+a different work ID. No duplicate active processing was observed, and no
+production control or repair mutation was used for this gate.
+
+## Action Retrier historical cleanup follow-up — 2026-08-29
+
+The post-deploy Insights snapshot confirmed the remaining component failure was
+unchanged: `actionRetrier:cleanupExpiredRuns` had three daily failures, newest
+2026-08-28 13:13:24 UTC, each reading 16,864,513 bytes across 1,040 component
+run documents. Version 0.3.1 is still the latest published package, and its
+current upstream source still takes 1,024 expired rows in one mutation. New
+terminal runs already receive delayed per-run cleanup in app code, so this is a
+bounded historical component-state problem rather than an app-table migration.
+
+The local package patch reduces the component cleanup page to four runs and
+uses that constant for both the indexed read and continuation condition. The
+existing immediate continuation therefore drains every eligible historical row
+without a global transaction. Four is intentionally conservative because a
+delete can add transaction reads after the initial query; it remains below the
+Convex read budget even when stored action arguments or results approach the
+document-size ceiling. No app schema, component schema, public function, or
+prospect/workspace scan changes.
+
+The regression test creates ten approximately 700 KB completed component runs
+under a synthetic 6 MB transaction limit. One invocation deletes exactly four,
+and scheduled continuations delete the remaining six without exceeding the
+limit. Rollout is code-first: deploy the pinned patch, invoke or await one
+bounded component cleanup chain, verify the expired sample is empty, and require
+no new `cleanupExpiredRuns` bytes-read Insight. Do not use a direct component
+table export/import or full backup as the cleanup mechanism.

--- a/patches/@convex-dev__action-retrier@0.3.1.patch
+++ b/patches/@convex-dev__action-retrier@0.3.1.patch
@@ -1,0 +1,48 @@
+diff --git a/dist/component/run.js b/dist/component/run.js
+index 72c48564abd0e8b521f0ae9808b43f4e92403f3b..6ed78daf215df97f48d3650cff2e1538c204d6a9 100644
+--- a/dist/component/run.js
++++ b/dist/component/run.js
+@@ -238,7 +238,9 @@ function withJitter(delay) {
+     return delay * (0.5 + Math.random());
+ }
+ const CLEANUP_MIN_AGE_MS = 1000 * 60 * 60 * 24 * 7; // 1 week
+-const MAX_CLEANUP_BATCH = 1024;
++// Keep the query safely below Convex's bytes-read limit even when completed
++// actions stored unusually large return values.
++const MAX_CLEANUP_BATCH = 4;
+ export const cleanupExpiredRuns = internalMutation({
+     args: {},
+     handler: async (ctx) => {
+@@ -246,7 +248,7 @@ export const cleanupExpiredRuns = internalMutation({
+         const expired = await ctx.db
+             .query("runs")
+             .withIndex("by_state", (q) => q.eq("state.type", "completed").lt("state.completedAt", cutoff))
+-            .take(1024);
++            .take(MAX_CLEANUP_BATCH);
+         for (const doc of expired) {
+             await ctx.db.delete("runs", doc._id);
+         }
+diff --git a/src/component/run.ts b/src/component/run.ts
+index fbb562dec3b1e4dc14e98b825efbb1ce8b91f0ef..ce003ee6b3d2ba75fd2df5f447f1bb1f93c250b2 100644
+--- a/src/component/run.ts
++++ b/src/component/run.ts
+@@ -317,7 +317,9 @@ function withJitter(delay: number) {
+ }
+ 
+ const CLEANUP_MIN_AGE_MS = 1000 * 60 * 60 * 24 * 7; // 1 week
+-const MAX_CLEANUP_BATCH = 1024;
++// Keep the query safely below Convex's bytes-read limit even when completed
++// actions stored unusually large return values.
++const MAX_CLEANUP_BATCH = 4;
+ 
+ export const cleanupExpiredRuns = internalMutation({
+   args: {},
+@@ -328,7 +330,7 @@ export const cleanupExpiredRuns = internalMutation({
+       .withIndex("by_state", (q) =>
+         q.eq("state.type", "completed").lt("state.completedAt", cutoff),
+       )
+-      .take(1024);
++      .take(MAX_CLEANUP_BATCH);
+     for (const doc of expired) {
+       await ctx.db.delete("runs", doc._id);
+     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
+  "@convex-dev/action-retrier@0.3.1": af01a6695458ee18dc76cf90c91063d03322256a7122fd82ccda1d368e9f3943
   "@xdevplatform/chat-xdk@0.5.0": 65e666f277ac8bb60e3afc03d19c55bd20dd3fbb5255cee7aa9cc20ad19fc148
   next-themes@0.4.6: 9ab742790bc3284034400fc2d6422e596a9b3439e3dacdb030316992ec0bec6e
 
@@ -31,7 +32,7 @@ importers:
         version: 0.9.2(@composio/core@0.10.0(ws@8.20.1)(zod@4.4.3))(ai@6.0.207(zod@4.4.3))
       "@convex-dev/action-retrier":
         specifier: ^0.3.1
-        version: 0.3.1(convex@1.45.0(react@19.2.7))
+        version: 0.3.1(patch_hash=af01a6695458ee18dc76cf90c91063d03322256a7122fd82ccda1d368e9f3943)(convex@1.45.0(react@19.2.7))
       "@convex-dev/agent":
         specifier: ^0.6.3
         version: 0.6.3(@ai-sdk/provider-utils@4.0.30(zod@4.4.3))(ai@6.0.207(zod@4.4.3))(convex-helpers@0.1.119(@standard-schema/spec@1.1.0)(convex@1.45.0(react@19.2.7))(hono@4.12.27)(react@19.2.7)(typescript@6.0.3)(zod@4.4.3))(convex@1.45.0(react@19.2.7))(react@19.2.7)
@@ -11615,7 +11616,7 @@ snapshots:
       "@composio/core": 0.10.0(ws@8.20.1)(zod@4.4.3)
       ai: 6.0.207(zod@4.4.3)
 
-  "@convex-dev/action-retrier@0.3.1(convex@1.45.0(react@19.2.7))":
+  "@convex-dev/action-retrier@0.3.1(patch_hash=af01a6695458ee18dc76cf90c91063d03322256a7122fd82ccda1d368e9f3943)(convex@1.45.0(react@19.2.7))":
     dependencies:
       convex: 1.45.0(react@19.2.7)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,5 +6,6 @@ allowBuilds:
 minimumReleaseAgeExclude:
   - "@convex-dev/aggregate@0.3.0"
 patchedDependencies:
+  "@convex-dev/action-retrier@0.3.1": patches/@convex-dev__action-retrier@0.3.1.patch
   "@xdevplatform/chat-xdk@0.5.0": patches/@xdevplatform__chat-xdk@0.5.0.patch
   next-themes@0.4.6: patches/next-themes@0.4.6.patch


### PR DESCRIPTION
## Summary
- pin the Action Retrier component patch so expired-run cleanup processes four records per mutation instead of reading 1,024
- keep the component continuation chain so historical expired runs drain automatically in bounded pages
- add an integration stress test with ten approximately 700 KB runs under a synthetic 6 MB transaction limit
- document the production failure evidence and rollout verification steps

## Why
Production cleanup has failed daily while reading 1,040 component runs and 16,864,513 bytes. Testing showed that an eight-record page can still exceed the budget because deletion adds transaction reads; four records remained safely bounded.

## Verification
- 114 test files / 571 tests passed
- `npx tsc --noEmit`
- `npm run lint -- --deny-warnings`
- `npm run build` (74 routes)
- `pnpm install --frozen-lockfile --offline`

## Rollout
No schema change or application data migration is required. After deployment, inspect the expired component-run sample, allow or explicitly trigger the bounded cleanup chain, and verify that the historical set drains without another bytes-read Insight.

No production mutation or deployment was performed by this PR creation.