### PR TITLE
Fix tenant scheduler burst throughput

### DIFF
--- a/convex/lib/tenantSchedulerCore.test.ts
+++ b/convex/lib/tenantSchedulerCore.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   DEFAULT_TENANT_BURST_SLOTS,
   TENANT_EXECUTION_POOL_MAX_PARALLELISM,
+  allocateTenantDispatchSlots,
   clampTenantBaseSlots,
   clampTenantBurstSlots,
   clampTenantSchedulerSlotCount,
@@ -76,5 +77,88 @@ describe("tenant scheduler capacity policy", () => {
 
   it("does not rate-limit the observed 219-job single-tenant burst past one minute", () => {
     expect(getTenantStartRateDrainTimeMs(219)).toBeLessThan(60_000);
+  });
+
+  it("fills one dispatcher batch for a single busy tenant", () => {
+    expect(
+      allocateTenantDispatchSlots({
+        demands: [
+          { tenantKey: "workspace:a", runningCount: 0, queuedCount: 100 },
+        ],
+        availableSlotCount: 8,
+        maxAssignments: 8,
+        totalSlotCount: 36,
+        baseSlotsPerTenant: 1,
+        burstSlotsPerTenant: 30,
+      }).allocations
+    ).toEqual([{ tenantKey: "workspace:a", dispatchCount: 8 }]);
+  });
+
+  it("fills the single-tenant burst cap in four eight-slot batches", () => {
+    let runningCount = 0;
+    let batches = 0;
+    while (runningCount < 30) {
+      const result = allocateTenantDispatchSlots({
+        demands: [
+          {
+            tenantKey: "workspace:a",
+            runningCount,
+            queuedCount: 100 - runningCount,
+          },
+        ],
+        availableSlotCount: 36 - runningCount,
+        maxAssignments: 8,
+        totalSlotCount: 36,
+        baseSlotsPerTenant: 1,
+        burstSlotsPerTenant: 30,
+      });
+      runningCount += result.allocations[0]?.dispatchCount ?? 0;
+      batches += 1;
+    }
+
+    expect(runningCount).toBe(30);
+    expect(batches).toBe(4);
+  });
+
+  it("serves newcomers before lending the rest of a batch to a busy tenant", () => {
+    expect(
+      allocateTenantDispatchSlots({
+        demands: [
+          { tenantKey: "workspace:a", runningCount: 0, queuedCount: 100 },
+          { tenantKey: "workspace:b", runningCount: 0, queuedCount: 1 },
+          { tenantKey: "workspace:c", runningCount: 0, queuedCount: 1 },
+        ],
+        availableSlotCount: 8,
+        maxAssignments: 8,
+        totalSlotCount: 36,
+        baseSlotsPerTenant: 1,
+        burstSlotsPerTenant: 30,
+      }).allocations
+    ).toEqual([
+      { tenantKey: "workspace:a", dispatchCount: 6 },
+      { tenantKey: "workspace:b", dispatchCount: 1 },
+      { tenantKey: "workspace:c", dispatchCount: 1 },
+    ]);
+  });
+
+  it("does not give a capped tenant more work after newcomers arrive", () => {
+    expect(
+      allocateTenantDispatchSlots({
+        demands: [
+          { tenantKey: "workspace:a", runningCount: 30, queuedCount: 100 },
+          { tenantKey: "workspace:b", runningCount: 0, queuedCount: 1 },
+          { tenantKey: "workspace:c", runningCount: 0, queuedCount: 1 },
+        ],
+        availableSlotCount: 8,
+        maxAssignments: 8,
+        totalSlotCount: 36,
+        baseSlotsPerTenant: 1,
+        burstSlotsPerTenant: 30,
+      }).allocations
+    ).toEqual([
+      { tenantKey: "workspace:a", dispatchCount: 0 },
+      { tenantKey: "workspace:b", dispatchCount: 1 },
+      { tenantKey: "workspace:c", dispatchCount: 1 },
+    ]);
   });
 });

--- a/convex/lib/tenantSchedulerCore.ts
+++ b/convex/lib/tenantSchedulerCore.ts
@@ -79,6 +79,72 @@ export function getTenantDispatchCap(args: {
   return Math.min(args.burstSlotsPerTenant, fairShare);
 }
 
+export type TenantDispatchDemand = {
+  tenantKey: string;
+  runningCount: number;
+  queuedCount: number;
+};
+
+/**
+ * Fill one dispatcher batch without letting a busy tenant skip a newcomer.
+ * Each active tenant receives one assignment per round until the batch, its
+ * queued demand, or its current fair-share cap is exhausted.
+ */
+export function allocateTenantDispatchSlots(args: {
+  demands: readonly TenantDispatchDemand[];
+  availableSlotCount: number;
+  maxAssignments: number;
+  totalSlotCount: number;
+  baseSlotsPerTenant: number;
+  burstSlotsPerTenant: number;
+}) {
+  const activeDemands = args.demands.filter((demand) => demand.queuedCount > 0);
+  const activeTenantCount = activeDemands.length;
+  if (activeTenantCount === 0) {
+    return { activeTenantCount, tenantCap: 0, allocations: [] };
+  }
+
+  const tenantCap = getTenantDispatchCap({
+    slotCount: args.totalSlotCount,
+    activeTenantCount,
+    baseSlotsPerTenant: args.baseSlotsPerTenant,
+    burstSlotsPerTenant: args.burstSlotsPerTenant,
+  });
+  const assignmentLimit = Math.max(
+    0,
+    Math.min(
+      Math.floor(args.availableSlotCount),
+      Math.floor(args.maxAssignments)
+    )
+  );
+  const allocations = activeDemands.map((demand) => ({
+    tenantKey: demand.tenantKey,
+    dispatchCount: 0,
+  }));
+
+  let assigned = 0;
+  while (assigned < assignmentLimit) {
+    let assignedThisRound = false;
+    for (let index = 0; index < activeDemands.length; index += 1) {
+      if (assigned >= assignmentLimit) break;
+      const demand = activeDemands[index];
+      const allocation = allocations[index];
+      if (
+        allocation.dispatchCount >= demand.queuedCount ||
+        demand.runningCount + allocation.dispatchCount >= tenantCap
+      ) {
+        continue;
+      }
+      allocation.dispatchCount += 1;
+      assigned += 1;
+      assignedThisRound = true;
+    }
+    if (!assignedThisRound) break;
+  }
+
+  return { activeTenantCount, tenantCap, allocations };
+}
+
 export function getTenantStartRateDrainTimeMs(jobCount: number) {
   const normalizedJobCount = Math.max(0, Math.floor(jobCount));
   const jobsAfterInitialCapacity = Math.max(

--- a/convex/lib/tenantSchedulerHelpers.ts
+++ b/convex/lib/tenantSchedulerHelpers.ts
@@ -98,7 +98,6 @@ export async function completeTenantJob(
   }
 
   const now = getCurrentUTCTimestamp();
-  const lane = await ctx.db.get("tenantJobLanes", job.laneId);
   const slot = job.slotId
     ? await ctx.db.get("tenantSchedulerSlots", job.slotId)
     : null;
@@ -123,20 +122,9 @@ export async function completeTenantJob(
     });
   }
 
-  if (lane) {
-    const runningCount = Math.max(0, lane.runningCount - 1);
-    await ctx.db.patch("tenantJobLanes", lane._id, {
-      runningCount,
-      state:
-        lane.state === "paused"
-          ? "paused"
-          : lane.pendingCount > 0
-            ? "ready"
-            : "idle",
-      updatedAt: now,
-    });
-  }
-
+  // Claimed slots are the live concurrency source. Completion deliberately
+  // avoids the lane document so same-tenant jobs can finish concurrently
+  // without turning that marker back into a hot write.
   await ctx.scheduler.runAfter(
     0,
     internal.tenantScheduler.wakeDispatcherInternal,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1017,7 +1017,11 @@ export default defineSchema({
     .index("by_workspace", ["workspaceId"])
     .index("by_mode", ["mode"]),
 
-  /** One independently fair lane per workspace, or per pre-workspace user. */
+  /**
+   * One independently fair lane per workspace, or per pre-workspace user.
+   * `runningCount` is retained for rollout compatibility; claimed scheduler
+   * slots are the authoritative bounded source for live concurrency.
+   */
   tenantJobLanes: defineTable({
     tenantKey: v.string(),
     workspaceId: v.optional(v.id("workspaces")),

--- a/convex/tenantScheduler.integration.test.ts
+++ b/convex/tenantScheduler.integration.test.ts
@@ -600,6 +600,22 @@ describe("tenant scheduler integration", () => {
       return jobIds;
     });
 
+    await t.run(async (ctx) => {
+      const slots = await ctx.db
+        .query("tenantSchedulerSlots")
+        .withIndex("by_status_and_slot_number", (q) => q.eq("status", "free"))
+        .take(30);
+      for (const slot of slots) {
+        await ctx.db.patch("tenantSchedulerSlots", slot._id, {
+          status: "claimed",
+          tenantKey: `workspace:${tenants[0].workspaceId}`,
+          claimedAt: 1,
+          leaseExpiresAt: 20_000,
+          updatedAt: 1,
+        });
+      }
+    });
+
     const queryResult = await t.query(
       internal.tenantScheduler.getDispatchBatchInternal,
       { name: WORKER_NAME }
@@ -704,10 +720,88 @@ describe("tenant scheduler integration", () => {
       return Object.fromEntries(entries);
     });
     expect(runningByWorkspace).toEqual({
-      [String(noisy.workspaceId)]: 1,
+      [String(noisy.workspaceId)]: 6,
       [String(newcomerB.workspaceId)]: 1,
       [String(newcomerC.workspaceId)]: 1,
     });
+  });
+
+  test("fills an eight-slot dispatcher batch from one busy tenant", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    await registerSchedulerComponents(t);
+    const tenant = await seedWorkspace(t, "single-lane-burst");
+    await t.mutation(internal.tenantScheduler.setControlInternal, {
+      mode: "enforced",
+    });
+
+    const jobIds = await t.run(async (ctx) => {
+      const tenantKey = `workspace:${tenant.workspaceId}`;
+      const laneId = await ctx.db.insert("tenantJobLanes", {
+        tenantKey,
+        workspaceId: tenant.workspaceId,
+        userId: tenant.userId,
+        state: "ready",
+        pendingCount: 1,
+        // Compatibility counters may be stale; claimed slots are authoritative.
+        runningCount: 30,
+        minPriority: 30,
+        lastDispatchedAt: 0,
+        updatedAt: 1,
+      });
+      const ids: Id<"tenantJobs">[] = [];
+      for (let index = 0; index < 100; index += 1) {
+        ids.push(
+          await ctx.db.insert("tenantJobs", {
+            tenantKey,
+            laneId,
+            workspaceId: tenant.workspaceId,
+            userId: tenant.userId,
+            class: "background",
+            kind: "memory_evaluation",
+            status: "queued",
+            priority: 30,
+            idempotencyKey: `single-lane-burst-${index}`,
+            payload: {
+              kind: "memory_evaluation",
+              workspaceId: tenant.workspaceId,
+            },
+            queuedAt: index + 1,
+            attemptCount: 0,
+            updatedAt: 1,
+          })
+        );
+      }
+      return ids;
+    });
+
+    const queryResult = await t.query(
+      internal.tenantScheduler.getDispatchBatchInternal,
+      { name: WORKER_NAME }
+    );
+    expect(queryResult.kind).toBe("work");
+    if (queryResult.kind !== "work") throw new Error("Expected dispatch work");
+    expect(queryResult.batch.candidates).toHaveLength(8);
+    expect(
+      queryResult.batch.candidates.map((candidate) => candidate.jobId)
+    ).toEqual(jobIds.slice(0, 8));
+    expect(
+      new Set(
+        queryResult.batch.candidates.map((candidate) => candidate.tenantKey)
+      )
+    ).toEqual(new Set([`workspace:${tenant.workspaceId}`]));
+
+    await t.mutation(
+      internal.tenantScheduler.dispatchBatchInternal,
+      queryResult.batch
+    );
+    expect(
+      (
+        await t.run(async (ctx) =>
+          Promise.all(jobIds.map((jobId) => ctx.db.get("tenantJobs", jobId)))
+        )
+      ).filter((job) => job?.status === "running")
+    ).toHaveLength(8);
   });
 
   test.each([10, 50, 100])(

--- a/convex/tenantScheduler.ts
+++ b/convex/tenantScheduler.ts
@@ -23,6 +23,7 @@ import {
   NESTED_WORKFLOW_LEASE_MS,
   TENANT_JOB_RETENTION_MS,
   TENANT_EXECUTION_POOL_MAX_PARALLELISM,
+  allocateTenantDispatchSlots,
   buildTenantKey,
   clampTenantBaseSlots,
   clampTenantBurstSlots,
@@ -87,6 +88,7 @@ const dispatchCandidateValidator = v.object({
   laneId: v.id("tenantJobLanes"),
   jobId: v.id("tenantJobs"),
   tenantKey: v.string(),
+  runningCount: v.number(),
   nextPriority: v.optional(v.number()),
 });
 
@@ -614,35 +616,84 @@ export const getDispatchBatchInternal = internalQuery({
       return { kind: "idle" as const, timeoutMs: 5_000 };
     }
 
-    const lanes = await ctx.db
-      .query("tenantJobLanes")
-      .withIndex("by_state_and_last_dispatched_at", (q) =>
-        q.eq("state", "ready")
-      )
-      .take(LANE_SCAN_SIZE);
+    const [lanes, claimedSlots] = await Promise.all([
+      ctx.db
+        .query("tenantJobLanes")
+        .withIndex("by_state_and_last_dispatched_at", (q) =>
+          q.eq("state", "ready")
+        )
+        .take(LANE_SCAN_SIZE),
+      ctx.db
+        .query("tenantSchedulerSlots")
+        .withIndex("by_status_and_slot_number", (q) =>
+          q.eq("status", "claimed").lt("slotNumber", control.slotCount)
+        )
+        .take(control.slotCount),
+    ]);
+    // The bounded slot set is authoritative. Reading it here avoids making
+    // every dispatch and completion contend on a mutable per-lane counter.
+    const runningCountByTenant = new Map<string, number>();
+    for (const slot of claimedSlots) {
+      if (!slot.tenantKey) continue;
+      runningCountByTenant.set(
+        slot.tenantKey,
+        (runningCountByTenant.get(slot.tenantKey) ?? 0) + 1
+      );
+    }
 
-    const candidateResults = await Promise.all(
-      lanes.map(async (lane) => {
-        const jobs = await ctx.db
-          .query("tenantJobs")
-          .withIndex("by_lane_and_status_and_priority_and_queued_at", (q) =>
-            q.eq("laneId", lane._id).eq("status", "queued")
-          )
-          .take(2);
-        return jobs[0]
-          ? {
-              laneId: lane._id,
-              jobId: jobs[0]._id,
-              tenantKey: lane.tenantKey,
-              nextPriority: jobs[1]?.priority,
-            }
-          : null;
-      })
+    const laneDemands = (
+      await Promise.all(
+        lanes.map(async (lane) => ({
+          lane,
+          runningCount: runningCountByTenant.get(lane.tenantKey) ?? 0,
+          jobs: await ctx.db
+            .query("tenantJobs")
+            .withIndex("by_lane_and_status_and_priority_and_queued_at", (q) =>
+              q.eq("laneId", lane._id).eq("status", "queued")
+            )
+            .take(DISPATCH_BATCH_SIZE + 1),
+        }))
+      )
+    ).filter((demand) => demand.jobs.length > 0);
+    const allocation = allocateTenantDispatchSlots({
+      demands: laneDemands.map((demand) => ({
+        tenantKey: demand.lane.tenantKey,
+        runningCount: demand.runningCount,
+        queuedCount: demand.jobs.length,
+      })),
+      availableSlotCount: slots.length,
+      maxAssignments: DISPATCH_BATCH_SIZE,
+      totalSlotCount: control.slotCount,
+      baseSlotsPerTenant: control.baseSlotsPerTenant,
+      burstSlotsPerTenant: control.burstSlotsPerTenant,
+    });
+    const dispatchCountByTenant = new Map(
+      allocation.allocations.map((entry) => [
+        entry.tenantKey,
+        entry.dispatchCount,
+      ])
     );
-    const candidates = candidateResults.filter(
-      (candidate): candidate is NonNullable<typeof candidate> =>
-        candidate !== null
-    );
+    const candidates: Array<Infer<typeof dispatchCandidateValidator>> = [];
+    for (let round = 0; candidates.length < slots.length; round += 1) {
+      let addedThisRound = false;
+      for (const demand of laneDemands) {
+        const dispatchCount =
+          dispatchCountByTenant.get(demand.lane.tenantKey) ?? 0;
+        if (round >= dispatchCount) continue;
+        const job = demand.jobs[round];
+        if (!job) continue;
+        candidates.push({
+          laneId: demand.lane._id,
+          jobId: job._id,
+          tenantKey: demand.lane.tenantKey,
+          runningCount: demand.runningCount,
+          nextPriority: demand.jobs[round + 1]?.priority,
+        });
+        addedThisRound = true;
+        if (candidates.length >= slots.length) break;
+      }
+      if (!addedThisRound) break;
+    }
     if (candidates.length === 0) {
       return { kind: "idle" as const, timeoutMs: 10_000 };
     }
@@ -655,9 +706,7 @@ export const getDispatchBatchInternal = internalQuery({
           slotId: slot._id,
           slotNumber: slot.slotNumber,
         })),
-        activeTenantCount: new Set(
-          candidates.map((candidate) => candidate.tenantKey)
-        ).size,
+        activeTenantCount: allocation.activeTenantCount,
       },
     };
   },
@@ -689,6 +738,14 @@ export const dispatchBatchInternal = internalMutation({
     });
     let dispatched = 0;
     let retryAfterMs = 0;
+    const runningCountByTenant = new Map<string, number>();
+    const laneUpdates = new Map<
+      string,
+      {
+        laneId: Id<"tenantJobLanes">;
+        nextPriority?: number;
+      }
+    >();
 
     for (let index = 0; index < args.slots.length; index += 1) {
       const candidate = args.candidates[index];
@@ -703,7 +760,6 @@ export const dispatchBatchInternal = internalMutation({
       if (
         !lane ||
         lane.state !== "ready" ||
-        lane.runningCount >= tenantCap ||
         !job ||
         job.status !== "queued" ||
         !slot ||
@@ -712,6 +768,9 @@ export const dispatchBatchInternal = internalMutation({
       ) {
         continue;
       }
+      const tenantRunningCount =
+        runningCountByTenant.get(candidate.tenantKey) ?? candidate.runningCount;
+      if (tenantRunningCount >= tenantCap) continue;
 
       const globalRate = await tenantSchedulerRateLimiter.limit(
         ctx,
@@ -860,7 +919,6 @@ export const dispatchBatchInternal = internalMutation({
 
       const now = getCurrentUTCTimestamp();
       const leaseExpiresAt = now + control.leaseDurationMs;
-      const hasNextQueuedJob = candidate.nextPriority !== undefined;
       await Promise.all([
         ctx.db.patch("tenantJobs", job._id, {
           status: "running",
@@ -879,16 +937,32 @@ export const dispatchBatchInternal = internalMutation({
           leaseExpiresAt,
           updatedAt: now,
         }),
-        ctx.db.patch("tenantJobLanes", lane._id, {
-          pendingCount: hasNextQueuedJob ? 1 : 0,
-          runningCount: lane.runningCount + 1,
-          minPriority: candidate.nextPriority ?? Number.MAX_SAFE_INTEGER,
-          state: hasNextQueuedJob ? "ready" : "idle",
-          lastDispatchedAt: now,
-          updatedAt: now,
-        }),
       ]);
+      runningCountByTenant.set(candidate.tenantKey, tenantRunningCount + 1);
+      laneUpdates.set(String(lane._id), {
+        laneId: lane._id,
+        nextPriority: candidate.nextPriority,
+      });
       dispatched += 1;
+    }
+
+    const now = getCurrentUTCTimestamp();
+    for (const update of laneUpdates.values()) {
+      const hasNextQueuedJob = update.nextPriority !== undefined;
+      await ctx.db.patch("tenantJobLanes", update.laneId, {
+        pendingCount: hasNextQueuedJob ? 1 : 0,
+        minPriority: update.nextPriority ?? Number.MAX_SAFE_INTEGER,
+        state: hasNextQueuedJob ? "ready" : "idle",
+        lastDispatchedAt: now,
+        updatedAt: now,
+      });
+      if (!hasNextQueuedJob) {
+        await ctx.scheduler.runAfter(
+          0,
+          internal.tenantScheduler.activateLaneInternal,
+          { laneId: update.laneId }
+        );
+      }
     }
 
     if (dispatched === 0) {

--- a/docs/convex/reliability-program-2026-08-27.md
+++ b/docs/convex/reliability-program-2026-08-27.md
@@ -837,3 +837,72 @@ limit. Rollout is code-first: deploy the pinned patch, invoke or await one
 bounded component cleanup chain, verify the expired sample is empty, and require
 no new `cleanupExpiredRuns` bytes-read Insight. Do not use a direct component
 table export/import or full backup as the cleanup mechanism.
+
+### Action Retrier deployment and drain gate
+
+PR #50 deployed as merge commit `89ad875f620f26ec21653b67b26cb07336e5d2f8`.
+The read-only pre-cleanup gate found an eligible four-row sample and no
+`cleanupExpiredRuns` bytes-read event newer than the historical 2026-08-28
+13:13:24 UTC baseline. The approved production invocation deleted exactly four
+expired terminal runs and started the component's existing continuation chain.
+Subsequent bounded samples showed the oldest eligible completion timestamp
+advancing while the failure baseline remained unchanged. Only one cleanup
+chain was started; no overlapping sweep, component export/import, app-table
+mutation, or production control change was used. The final empty-sample gate
+remains pending while that conservative four-row chain drains the multi-week
+history.
+
+## Scheduler burst throughput follow-up — 2026-08-29
+
+The latest production sample before this local change contained 1,000 started
+memory-evaluation jobs from one tenant. Typical admission was healthy (p50 434
+ms, p95 617 ms, max 5,702 ms, and zero admissions over 30 seconds), with no
+failed job, expired lease, unresolved enqueue failure, or pool drift. This is a
+healthy current checkpoint, but it does not explain away the two earlier burst
+windows that queued hundreds of jobs for several minutes while tenant slots
+remained free.
+
+A subsequent natural burst reproduced the regression before this fix could be
+deployed. Of the newest 1,000 jobs, 999 had started across 741 memory-evaluation
+and 258 qualification admissions for one tenant; 150 waited at least 30 seconds.
+The distribution moved to p50 482 ms, p95 67,632 ms, and max 85,652 ms. The
+live queue was already moving into running work, global mode and the 64 + 36
+pool split were correct, and there was no failed job, expired lease, unresolved
+enqueue failure, drift, or new permanent scheduler error. This third transient
+window fails both rollout gates and confirms that a drained snapshot or healthy
+median cannot close the burst-throughput defect.
+
+The remaining under-utilization mechanism is now reproduced in code. The
+dispatcher reads up to eight free slots but previously returned only one queued
+job per ready lane. A one-workspace burst therefore admitted one job per Batch
+Worker transaction even when seven more slots were available. Every one-job
+dispatch and every completion also wrote the same `tenantJobLanes` row. The
+72-hour Insights snapshot still showed thousands of retried conflicts on that
+lane across activation, dispatch, Workpool completion, and tenant-execution
+completion paths. They were not permanent failures, but they amplify the
+serialized dispatcher exactly when a same-tenant burst arrives.
+
+The local fix keeps the existing eight-slot batch and exact per-workspace queue
+order, but allocates those slots round-robin across active lanes. A single busy
+lane can fill all eight assignments; with A=100 and B/C=1, B and C receive one
+slot before A borrows the remaining six. Claimed `tenantSchedulerSlots` are the
+authoritative bounded source for live tenant concurrency, so completions no
+longer read or write the lane marker. Dispatch patches each participating lane
+once per batch and schedules an idempotent post-drain activation to close the
+concurrent-enqueue race. Reads remain bounded to 64 ready lanes, 36 claimed
+slots, and nine small tenant-job rows per lane; a dispatch writes at most eight
+jobs and slots.
+
+No Aggregate or sharded-counter component is introduced here. The 36
+independent slot documents already provide exact, bounded, naturally sharded
+concurrency state; another counter would duplicate that authority and create a
+new consistency problem. There is no schema or data migration. The legacy lane
+`runningCount` field remains widen-compatible but is no longer consulted for
+admission; its eventual removal belongs to the separate cleanup phase.
+
+Local verification passed 114 test files and 576 tests, including one-lane
+eight-slot dispatch, stale compatibility counters, A=100/B=C=1 fairness, and
+10/50/100 active-lane visibility. TypeScript, strict Oxlint, and the 74-route
+production build also passed. Rollout is code-only: deploy after review, then
+require the next natural burst to keep admission p95 below 30 seconds and max
+below 60 seconds with no permanent scheduler OCC, expired lease, or slot drift.


### PR DESCRIPTION
## Summary
- fill all eight dispatcher assignments from one busy lane while preserving round-robin tenant fairness
- derive live tenant concurrency from the bounded 36-slot set instead of the legacy lane counter
- patch each participating lane once per batch and stop writing the shared lane on every job completion
- add a post-drain activation so a concurrent enqueue cannot leave a lane idle
- record the newest production burst regression and rollout gates

## Production evidence
A third natural one-tenant burst reproduced the issue with otherwise healthy controls:
- p50: 482 ms
- p95: 67,632 ms
- max: 85,652 ms
- 150 of 999 started jobs waited at least 30 seconds
- no failed jobs, expired leases, unresolved enqueues, configuration drift, or new permanent scheduler errors

The dispatcher could read eight free slots but previously returned only one job per ready lane. Same-workspace bursts therefore required many serialized mutations, while dispatch and completion repeatedly contended on the same `tenantJobLanes` row.

## Correctness
- per-lane priority and queued-time ordering is unchanged
- A=100 with B/C=1 admits B and C before A borrows the remaining six assignments
- 10/50/100 active-lane visibility remains covered
- stale legacy `runningCount` values cannot block capacity because claimed slots are authoritative
- reads remain bounded to 64 lanes, 36 claimed slots, and nine small job rows per lane
- at most eight jobs/slots and one marker per participating lane are written

No Aggregate or sharded-counter component is added: the 36 independent slot documents already provide exact bounded concurrency state. No schema or data migration is required.

## Verification
- 114 test files / 576 tests passed
- `npx tsc --noEmit`
- `npm run lint -- --deny-warnings`
- Prettier and `git diff --check`
- production Next.js build passed with 74 routes

## Rollout gate
After deployment, require the next natural burst to remain below p95 30 seconds and max 60 seconds, with no permanent scheduler OCC, expired lease, unresolved enqueue failure, or slot/pool drift.

No deployment or production control mutation was performed by opening this PR.