### PR TITLE
fix: retain production cleanup indexes

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1116,7 +1116,8 @@ export default defineSchema({
     updatedAt: v.number(),
   })
     .index("by_slot_number", ["slotNumber"])
-    .index("by_status_and_slot_number", ["status", "slotNumber"]),
+    .index("by_status_and_slot_number", ["status", "slotNumber"])
+    .index("by_job", ["jobId"]),
 
   /**
    * Per-workspace queue state for throttled memory evaluation.
@@ -2578,6 +2579,11 @@ export default defineSchema({
       "status",
       "precedence",
     ])
+    .index("by_workspace_and_prospect_and_status", [
+      "workspaceId",
+      "prospectId",
+      "status",
+    ])
     .index("by_workspace_source_category_status", [
       "workspaceId",
       "source",
@@ -2588,6 +2594,7 @@ export default defineSchema({
       "workspaceId",
       "legacyMemoryId",
     ])
+    .index("by_legacy_memory_id", ["legacyMemoryId"])
     .index("by_status_index_retry", [
       "status",
       "indexStatus",

--- a/docs/convex/reliability-program-2026-08-27.md
+++ b/docs/convex/reliability-program-2026-08-27.md
@@ -933,11 +933,18 @@ only artifacts whose reads and writes are absent:
   production window;
 - `PREVIEW_BATCH_LIMITS.previewProspectWriteBatch` had no reader after preview
   persistence batching was centralized;
-- `tenantSchedulerSlots.by_job` and
-  `workspaceMemories.by_workspace_and_prospect_and_status` had no query site;
 - the canonical-memory migration now uses the live workspace-scoped legacy-ID
-  index, allowing the otherwise unused global `by_legacy_memory_id` index to be
-  removed without changing migration behavior.
+  index instead of the global `by_legacy_memory_id` index.
+
+The audit also proved that `tenantSchedulerSlots.by_job`,
+`workspaceMemories.by_workspace_and_prospect_and_status`, and the global
+`workspaceMemories.by_legacy_memory_id` have no remaining query site. They stay
+defined for this deployment because Convex classifies removing the two memory
+indexes across 106,480 documents as a large-index deletion requiring an
+explicit production confirmation flag. PR #52's first deployment attempt was
+therefore blocked before any production change. Index removal is deferred to a
+separate explicitly approved operation; the documents themselves are not
+cleanup candidates.
 
 No document, table, component, or rollback path is removed. Production still
 contains canonical memories with legacy IDs and legacy memory-inventory rows,


### PR DESCRIPTION
## Cause

PR #52 built successfully, but Convex blocked production deployment because removing two indexes over 106,480 workspace-memory documents requires explicit large-index deletion approval. A third 36-row scheduler-slot index was included in the same deletion set. No production change occurred.

## Fix

- restore all three indexes
- keep the safe dead-code cleanup from PR #52
- keep the canonical-memory migration on the more precise workspace-scoped legacy-ID lookup
- document that index deletion is deferred to a separate explicitly approved production operation

## Verification

- Convex production dry-run: No indexes are deleted by this push
- schema validation complete
- TypeScript and focused Oxlint
- Prettier
- 3 relevant test files / 34 tests

No production controls, documents, tables, components, or compatibility data are changed.