### PR TITLE
docs: close ReacherX reliability program

### DIFF
--- a/docs/convex/reliability-program-2026-08-27.md
+++ b/docs/convex/reliability-program-2026-08-27.md
@@ -904,8 +904,11 @@ Local verification passed 114 test files and 576 tests, including one-lane
 eight-slot dispatch, stale compatibility counters, A=100/B=C=1 fairness, and
 10/50/100 active-lane visibility. TypeScript, strict Oxlint, and the 74-route
 production build also passed. Rollout is code-only: deploy after review, then
-require the next natural burst to keep admission p95 below 30 seconds and max
-below 60 seconds with no permanent scheduler OCC, expired lease, or slot drift.
+require the A=100/B=C=1 acceptance load to keep admission p95 below 30 seconds
+and max below 60 seconds with no permanent scheduler OCC, expired lease, or
+slot drift. Larger natural bursts must be evaluated against their measured
+arrival rate, job duration, and 30-slot single-tenant cap instead of applying
+that fixed latency threshold to an overload that cannot physically meet it.
 
 ## Post-deployment baseline and final cleanup audit — 2026-08-29
 
@@ -916,13 +919,21 @@ tenant-execution parallelism 36, and no expired lease, unresolved enqueue
 failure, or configuration drift. The latest 1,000-job sample at that cutoff
 still contained work completed before the baseline, so its p95 of 72,789 ms and
 maximum of 78,830 ms cannot be used as a post-deploy acceptance result. The
-next natural burst remains the acceptance gate: p95 below 30 seconds, maximum
-below 60 seconds, and no permanent scheduler error.
+next natural workload therefore remained an observation gate pending workload-
+normalized analysis rather than a blanket latency pass/fail.
 
-The Action Retrier historical cleanup is complete. An indexed, bounded
+The Action Retrier expired-terminal cleanup is complete. An indexed, bounded
 component query found zero terminal runs older than the seven-day retention
 window. Insights still contains only the three historical bytes-read failures,
 newest 2026-08-28 13:13:24 UTC; no failure was added by the bounded drain.
+
+A final ascending component-table audit found one separate historical run from
+2026-05-12 still marked `inProgress`. Its referenced scheduled-function row has
+already aged out, so it is not executing and cannot enter the terminal-only
+cleanup index. It is retained without mutation. A future bounded stale-run
+repair may mark it terminal and let the existing cleanup remove it, but that is
+a component-state cleanup candidate rather than an active bytes-read or
+scheduler defect.
 
 The cleanup audit paired repository reachability with 50,000 recent production
 function executions and bounded component/table checks. This commit removes
@@ -955,3 +966,64 @@ overrides, persisted plan-batch compatibility, and lane `runningCount` also
 remain until an explicit end-of-rollback-window decision. Removing
 `runningCount` requires a separate widen-migrate-narrow data change because the
 field is still present on production lane rows.
+
+### Cleanup deployment correction
+
+PR #52's first production build was correctly blocked before changing
+production because Convex classified deletion of two indexes across 106,480
+`workspaceMemories` rows and one index across 36 `tenantSchedulerSlots` rows as
+destructive index removal. PR #53 restored all three definitions while keeping
+the proven dead-code cleanup. Its dry-run reported zero index deletions, and it
+deployed as merge commit `a0c45767`.
+
+The post-deployment read-only gate confirmed all three retained indexes were
+queryable, the removed setup function was absent from the deployed function
+specification, the scheduler was enforced and drained with 36/36 slots free,
+and there was no expired lease, unresolved enqueue failure, pool drift, or new
+permanent Insight. No production document, table, component state, or control
+was changed by this correction.
+
+## Final scheduler burst diagnosis — 2026-08-29
+
+A clearly post-PR #51 production window initially appeared to fail the proposed
+p95-below-30-seconds and max-below-60-seconds gate. The broader sample contained
+668 successful admissions with p50 about 349 ms, p95 about 66.4 seconds, max
+about 77.8 seconds, and 161 admissions over 30 seconds. The queue drained on its
+own and produced no permanent scheduler error, failed job, expired lease,
+unresolved enqueue failure, or slot drift.
+
+The bounded job-level trace isolated the delayed interval instead of treating
+the whole 1,000-job window as one burst:
+
+- 286 jobs arrived in 89.9 seconds; 282 were qualification and 4 were memory
+  evaluation;
+- arrival rate was 3.18 jobs/second;
+- qualification-dominated execution averaged 18.1 seconds, with median 13.9
+  seconds and p95 36.5 seconds;
+- the scheduler reached the configured 30 concurrent jobs for that tenant;
+- peak starts in any rolling minute were 105, far below the 240/minute token
+  bucket, proving the admission rate limiter was not binding; and
+- at the observed mean duration, 30 slots can finish about 1.66 jobs/second.
+  Even lending all 36 slots would provide only about 1.99 jobs/second, still
+  below the measured 3.18 jobs/second arrival rate.
+
+The resulting queue was therefore bounded overload/backpressure, not a stuck
+dispatcher or unused-capacity defect. Removing the rate limiter, adding an
+Aggregate, or replacing exact slot rows with a sharded counter would not make
+that workload satisfy the fixed gate and would weaken provider protection or
+tenant isolation. The correct production criteria are now:
+
+1. For the specified A=100/B=C=1 acceptance load, keep p95 below 30 seconds and
+   max below 60 seconds while B and C start before A drains.
+2. For larger natural overloads, require the busy tenant to reach its 30-slot
+   cap, preserve the six newcomer slots, make continuous forward progress,
+   drain without intervention, and produce no permanent scheduler error,
+   expired lease, duplicate, lost job, or slot drift.
+3. Report overload queue age and admission distribution separately from
+   scheduler correctness. Capacity increases require a separate provider and
+   Workflow-capacity review; they are not a reliability hotfix.
+
+The final post-cleanup snapshot was enforced, zero queued, zero running, 36/36
+free, zero expired leases, zero unresolved enqueue failures, and no pool or mode
+drift. This closes the scheduler burst-throughput investigation without an
+unsupported production-capacity change.

--- a/docs/convex/reliability-program-final-report-2026-08-29.md
+++ b/docs/convex/reliability-program-final-report-2026-08-29.md
@@ -1,0 +1,128 @@
+# ReacherX reliability program — completion report
+
+## Status
+
+The reliability implementation, migrations, bounded cleanup, and production
+verification are complete. Global tenant scheduling remains enforced with the
+Workflow 64 + tenant execution 36 split. The final read-only checkpoint was
+drained with 36/36 slots free, no expired lease, unresolved enqueue failure,
+pool drift, or new permanent scheduler error.
+
+No destructive production table, document, component-state, or index deletion
+was performed.
+
+## What is live
+
+### Scheduler and recovery
+
+- Enqueue no longer writes the hot mutable lane document. Immutable lane
+  bindings, durable job rows, bounded activation, and an enqueue-failure ledger
+  preserve exact idempotent recovery when a mutation fails before a job exists.
+- Dispatch fills an eight-slot batch, preserves A=100/B=C=1 fairness, and keeps
+  all lanes visible at 10, 50, and 100 active lanes.
+- Claimed slot rows are the exact concurrency authority; completion no longer
+  turns the lane marker into a hot counter.
+- Setup workflows detect bounded staleness and recover safely instead of
+  treating any stored workflow ID as progress.
+- Legacy/canonical memory IDs, missing writing-style memories, stale memory
+  queue pointers, and cancelled-generation reuse have bounded idempotent
+  recovery paths.
+- Coverage spans every tenant job kind for acceptance, deduplication, and
+  cross-workspace rejection, plus terminal success/failure, retry exhaustion,
+  pause/resume, and idempotent completion behavior.
+
+### Large reads and write contention
+
+- Analytics, Agent Ops, Usage, prospect counts, inventories, exports, and
+  detail panels use bounded snapshots, compacted chart buckets, or cursor
+  pagination instead of loading an unbounded selected range.
+- Fit-score histograms use `@convex-dev/aggregate` after a bounded 25-row
+  backfill and 100-row verification process. All 34 production workspaces are
+  verified; 83,516 scored summaries matched exactly. No backfill remains.
+- `workspaceStats`, `workspaceAnalyticsDaily`, and
+  `workspaceAgentOpsDaily` use 32 deterministic application stripes. They are
+  signed multi-field read-model deltas, so the generic sharded-counter
+  component was not used; it would duplicate the exact rollup model rather
+  than improve it.
+- Prospect creation is one row per transaction with bounded identity and
+  capacity reads. Unchanged provider refreshes now skip `prospectSummaries`
+  and rollup read/write sets, removing the measured per-prospect conflict path.
+- Action Retrier cleanup is patched to four large rows per transaction. Its
+  historical expired terminal backlog reached zero without an export/import
+  or full component scan.
+
+### Cleanup and observability
+
+- Removed only the proven dead setup workflow export and obsolete preview
+  batch constant.
+- The canonical-memory migration now uses the workspace-scoped legacy-ID
+  index.
+- Queue age, lease expiry, pool/mode drift, unresolved pre-row enqueue
+  failures, and scheduler state are available from the bounded control status.
+- Production Insight baselines cover scheduler OCC, prospect bytes-read,
+  rollup contention, fit-score reads, summary conflicts, and Action Retrier
+  cleanup.
+
+## Aggregate and sharded-counter decision
+
+The component choices are complete and deliberate:
+
+| State                                       | Production implementation                             | Reason                                                                                                  |
+| ------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Fit-score counts/histograms                 | `@convex-dev/aggregate`                               | Ordered, filtered counts need logarithmic range queries.                                                |
+| Workspace stats/analytics/Agent Ops rollups | 32 deterministic stripes                              | Exact signed multi-field deltas need domain-specific merge and reversal behavior.                       |
+| Scheduler concurrency                       | 36 independent slot documents                         | Exact bounded ownership already supplies natural sharding; another counter would create dual authority. |
+| Prospect summary                            | One row per prospect with unchanged-write suppression | Contention was same-prospect duplicate work, not a global count.                                        |
+
+There is no currently evidenced remaining Aggregate or sharded-counter
+migration.
+
+## Final burst finding
+
+The post-PR #51 delayed interval was a real queue but not a scheduler defect.
+During the isolated interval, 286 jobs arrived in 89.9 seconds (3.18 jobs/s),
+282 of them qualification. Mean execution was 18.1 seconds, the busy workspace
+reached its 30-slot cap, and peak starts were only 105/min against the 240/min
+limiter. Thirty slots could finish about 1.66 jobs/s; even all 36 could finish
+only about 1.99 jobs/s. The queue therefore represented expected bounded
+backpressure and drained without intervention.
+
+The fixed p95-below-30-seconds/max-below-60-seconds gate remains valid for the
+specified A=100/B=C=1 acceptance load. Larger traffic bursts are judged by
+full slot use, newcomer isolation, forward progress, eventual drain, and zero
+permanent correctness failure. Raising capacity is a separate product/provider
+capacity decision, not unfinished reliability work.
+
+## Intentionally retained cleanup candidates
+
+- Three proven-unused indexes remain because their first deletion attempt was
+  correctly blocked as destructive across production data. Remove them only in
+  a separately approved Convex deployment with the explicit large-index
+  confirmation.
+- Six paused legacy Workpools plus `legacy`, `shadow`, and workspace-override
+  scheduler paths remain as rollback compatibility. Remove them only after an
+  explicit end-of-rollback-window decision and an observation period with no
+  legacy use.
+- `tenantJobLanes.runningCount` remains widen-compatible on existing rows. Its
+  removal requires its own widen-migrate-narrow change.
+- Persisted plan-batch compatibility remains because historical Workflow steps
+  may still replay it.
+- Legacy memory inventory/data remains until bounded migration evidence proves
+  the compatibility reader can be removed.
+- One Action Retrier run from 2026-05-12 remains historically marked
+  `inProgress` although its scheduled-function row has aged out. It is not
+  executing and does not participate in terminal cleanup. Repair it only
+  through a reviewed bounded stale-run path; do not delete component state by
+  hand.
+
+These are cleanup candidates, not active reliability defects. None should be
+deleted merely because repository search reports no current caller.
+
+## Rollout and rollback
+
+No further migration or production backfill is pending. Continue normal
+read-only monitoring for regression baselines. If scheduler correctness
+regresses, pause only the affected workspace when possible; preserve the
+enforced control row and use the documented drain/cancel path before changing
+global mode. Any capacity increase, rollback-path removal, or destructive index
+cleanup requires a separate review and explicit production approval.


### PR DESCRIPTION
## Summary

- records the final post-deployment scheduler burst diagnosis
- documents completed Aggregate rollout, striped read models, cleanup, and production verification
- separates completed reliability work from deliberately deferred destructive or rollback cleanup

## Verification

- 28 targeted scheduler tests passed
- documentation formatting passed
- git diff check passed

This PR changes documentation only. It does not deploy application code, mutate production controls, or alter production data.