### PR TITLE
fix: harden qualification and LinkedIn plan recovery

### DIFF
--- a/convex/agents/outreach/tools/socialContextShared.ts
+++ b/convex/agents/outreach/tools/socialContextShared.ts
@@ -26,6 +26,11 @@ import { fetchSocialApi } from "../../../lib/socialApiFetch";
 import { hydrateTwitterProfileLinkMetadata } from "../../../lib/twitterProfileLinkResolver";
 import type { LinkedInProfilePost } from "../../../integrations/linkedin/getProfilePosts";
 import {
+  buildLinkedInProfileQueryUrnCandidates,
+  resolveLinkedInProspectProfileIdentifiers,
+} from "../../../integrations/linkedin/profileIdentity";
+import { isLinkdApiNoDataMessage } from "../../../integrations/linkedin/linkdapiClient";
+import {
   extractProspectThreadContext,
   MISSING_PROSPECT_SELECTION_MESSAGE,
 } from "./helpers";
@@ -727,33 +732,6 @@ async function fetchSocialApiJson(
   return await response.json();
 }
 
-function resolveLinkedInIdentity(prospect: ProspectDoc) {
-  const socialProfiles = isRecord(prospect.socialProfiles)
-    ? (prospect.socialProfiles as Record<string, unknown>)
-    : undefined;
-  const socialLinkedIn = isRecord(socialProfiles?.linkedin)
-    ? (socialProfiles?.linkedin as Record<string, unknown>)
-    : undefined;
-  const data = isRecord(prospect.data) ? prospect.data : undefined;
-  const author = isRecord(data?.author)
-    ? (data.author as Record<string, unknown>)
-    : undefined;
-  const profileUrl =
-    asString(socialLinkedIn?.url) ??
-    asString(author?.url) ??
-    asString(prospect.profileUrl);
-
-  return {
-    username:
-      asString(socialLinkedIn?.username) ??
-      (profileUrl ? extractLinkedInUsername(profileUrl) : undefined),
-    providerId:
-      asString(prospect.linkedinUserUrn) ??
-      asString(socialLinkedIn?.urn) ??
-      asString(author?.urn),
-  };
-}
-
 async function fetchTwitterProfile(
   ctx: ToolContext,
   username: string
@@ -994,8 +972,8 @@ async function fetchLinkedInProfile(
       currentCompany,
     };
   } catch {
-    const identity = resolveLinkedInIdentity(prospect);
-    if (!identity.username && !identity.providerId) {
+    const identity = resolveLinkedInProspectProfileIdentifiers(prospect);
+    if (!identity.username && !identity.profileUrn) {
       return null;
     }
 
@@ -1003,7 +981,7 @@ async function fetchLinkedInProfile(
       internal.integrations.linkedin.getProfile.getProfile,
       {
         username: identity.username,
-        urn: identity.providerId,
+        urn: identity.username ? undefined : identity.profileUrn,
         includeContactInfo: false,
       }
     );
@@ -1043,38 +1021,47 @@ async function fetchLinkedInPosts(
   ctx: ToolContext,
   prospect: ProspectDoc
 ): Promise<NormalizedSocialPost[]> {
-  try {
-    const result = await ctx.runAction(api.linkedin.getLinkedInProfile, {
-      prospectId: prospect._id as Id<"prospects">,
-    });
+  const identity = resolveLinkedInProspectProfileIdentifiers(prospect);
+  let liveProfileUrn: string | undefined;
+  let profileResolutionError: string | undefined;
 
-    if (!result) {
-      return [];
-    }
-
-    return dedupePosts(
-      sortPostsDescending(
-        result.recentPosts
-          .map((post: unknown) => normalizeLinkedInPost(post))
-          .filter(
-            (post: NormalizedSocialPost | null): post is NormalizedSocialPost =>
-              post !== null
-          )
-      )
-    );
-  } catch {
-    const identity = resolveLinkedInIdentity(prospect);
-    if (!identity.providerId) {
-      return [];
-    }
-
-    const result = await ctx.runAction(
-      internal.integrations.linkedin.getProfilePosts.getProfilePostsInternal,
+  if (identity.username) {
+    const profileResult = await ctx.runAction(
+      internal.integrations.linkedin.getProfile.getProfile,
       {
-        urn: identity.providerId,
-        maxPosts: 20,
+        username: identity.username,
+        includeContactInfo: false,
       }
     );
+    if (profileResult.success && profileResult.profile) {
+      liveProfileUrn = profileResult.profile.urn;
+    } else if (
+      profileResult.error &&
+      !isLinkdApiNoDataMessage(profileResult.error)
+    ) {
+      profileResolutionError = profileResult.error;
+    }
+  }
+
+  const urnCandidates = buildLinkedInProfileQueryUrnCandidates([
+    liveProfileUrn,
+    identity.profileUrn,
+  ]);
+  if (urnCandidates.length === 0) {
+    if (profileResolutionError) {
+      throw new Error(profileResolutionError);
+    }
+    return [];
+  }
+
+  for (const urn of urnCandidates) {
+    const result = await ctx.runAction(
+      internal.integrations.linkedin.getProfilePosts.getProfilePostsInternal,
+      { urn, maxPosts: 20 }
+    );
+    if (result.unavailableReason === "profile_data_unavailable") {
+      continue;
+    }
 
     return dedupePosts(
       sortPostsDescending(
@@ -1107,6 +1094,16 @@ async function fetchLinkedInPosts(
       )
     );
   }
+
+  if (profileResolutionError) {
+    throw new Error(profileResolutionError);
+  }
+
+  console.warn("[SocialContext] LinkedIn recent posts are unavailable", {
+    prospectId: String(prospect._id),
+    attemptedIdentityCount: urnCandidates.length,
+  });
+  return [];
 }
 
 async function fetchTwitterThread(

--- a/convex/autoPlanActions.ts
+++ b/convex/autoPlanActions.ts
@@ -21,6 +21,7 @@ import {
   buildAutoPlanResearchQueries,
   buildGroundedAutoPlanPrompt,
   classifyAutoPlanFailure,
+  hasVerifiedAutoPlanOutreachChannel,
   normalizeAutoPlanDraft,
   parseAutoPlanTransportDraft,
   validateAutoPlanDraftAgainstGrounding,
@@ -520,6 +521,19 @@ export const generateGroundedAutoPlanDraft = internalAction({
           }
         );
         linkedinRelationship = "unknown";
+      }
+
+      if (
+        !hasVerifiedAutoPlanOutreachChannel({
+          platform: prospect.platform,
+          recentPostCount: recentPosts.length,
+          linkedinRelationship,
+          linkedinHasExistingConversation,
+        })
+      ) {
+        throw new NonRetryableError(
+          "LinkedIn provider data unavailable: no verified recent LinkedIn posts are available and messaging eligibility could not be verified."
+        );
       }
     }
 

--- a/convex/integrations/linkedin/getProfilePosts.ts
+++ b/convex/integrations/linkedin/getProfilePosts.ts
@@ -196,8 +196,12 @@ export const getProfilePostsInternal = internalAction({
         consumer: `linkedin.getProfilePosts:${profileUrn}:${args.cursor ?? "first"}`,
       });
     } catch (error) {
-      if (args.cursor && isLinkdApiNoDataError(error)) {
-        return { posts: [], nextCursor: null };
+      if (isLinkdApiNoDataError(error)) {
+        return {
+          posts: [],
+          nextCursor: null,
+          unavailableReason: "profile_data_unavailable" as const,
+        };
       }
       throw error;
     }

--- a/convex/integrations/linkedin/linkdapiClient.ts
+++ b/convex/integrations/linkedin/linkdapiClient.ts
@@ -60,10 +60,18 @@ export function isLinkdApiNoDataError(
     return false;
   }
 
-  const message = error.message.toLowerCase();
+  return isLinkdApiNoDataMessage(error.message);
+}
+
+export function isLinkdApiNoDataMessage(message: string): boolean {
+  const normalizedMessage = message.toLowerCase();
   return (
-    message.includes("the data cannot be displayed or it doesn't exist") ||
-    message.includes("the data cannot be displayed or it does not exist")
+    normalizedMessage.includes(
+      "the data cannot be displayed or it doesn't exist"
+    ) ||
+    normalizedMessage.includes(
+      "the data cannot be displayed or it does not exist"
+    )
   );
 }
 

--- a/convex/integrations/linkedin/profileIdentity.test.ts
+++ b/convex/integrations/linkedin/profileIdentity.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
+  buildLinkedInProfileQueryUrnCandidates,
   normalizeLinkedInProfileQueryUrn,
   requireLinkedInProfileQueryUrn,
   resolveLinkedInProspectProfileIdentifiers,
@@ -42,5 +43,17 @@ describe("LinkedIn profile query URNs", () => {
       username: undefined,
       profileUrn: "ACoAA-prospect",
     });
+  });
+
+  test("builds unique canonical profile URN candidates", () => {
+    expect(
+      buildLinkedInProfileQueryUrnCandidates([
+        "urn:li:fsd_profile:ACoAA-live",
+        "ACoAA-live",
+        "urn:li:member:ACoAA-stored",
+        "urn:li:activity:123",
+        undefined,
+      ])
+    ).toEqual(["ACoAA-live", "ACoAA-stored"]);
   });
 });

--- a/convex/integrations/linkedin/profileIdentity.ts
+++ b/convex/integrations/linkedin/profileIdentity.ts
@@ -56,6 +56,19 @@ export function requireLinkedInProfileQueryUrn(value?: string | null): string {
   return profileUrn;
 }
 
+export function buildLinkedInProfileQueryUrnCandidates(
+  values: ReadonlyArray<string | null | undefined>
+): string[] {
+  const candidates = new Set<string>();
+  for (const value of values) {
+    const normalized = normalizeLinkedInProfileQueryUrn(value);
+    if (normalized) {
+      candidates.add(normalized);
+    }
+  }
+  return [...candidates];
+}
+
 export function resolveLinkedInProspectProfileIdentifiers(
   prospect: Record<string, unknown>
 ): {

--- a/convex/lib/ai.ts
+++ b/convex/lib/ai.ts
@@ -3,26 +3,28 @@
 // Docs: https://openrouter.ai/docs
 
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
-import { generateText, type JSONValue } from "ai";
+import {
+  generateText,
+  NoObjectGeneratedError,
+  Output,
+  type JSONValue,
+} from "ai";
 import { z } from "zod";
 import { logger } from "../../shared/lib/logger";
 import { getCurrentUTCTimestamp } from "../../shared/lib/utils/time/timeUtils";
 import { env } from "../_generated/server";
 import { getConfiguredModel } from "./modelConfigHelpers";
+import {
+  combineStructuredGenerationErrors,
+  getStructuredAttemptProviderOptions,
+  StructuredGenerationError,
+  type OpenRouterProviderOptions,
+  type OpenRouterProviderRouting,
+  type StructuredGenerationAttempt,
+} from "./structuredOutputCore";
 
-type OpenRouterProviderRouting = Record<string, JSONValue> & {
-  only?: string[];
-  order?: string[];
-  allow_fallbacks?: boolean;
-  require_parameters?: boolean;
-  sort?: "price" | "throughput" | "latency";
-};
-
-export type OpenRouterProviderOptions = {
-  openrouter: Record<string, JSONValue> & {
-    provider: OpenRouterProviderRouting;
-  };
-};
+export type { OpenRouterProviderOptions } from "./structuredOutputCore";
+export { StructuredGenerationError } from "./structuredOutputCore";
 
 // ============================================================================
 // Provider Factory
@@ -665,6 +667,10 @@ interface RobustGenerateObjectOptions<T> {
   initialDelayMs?: number;
   /** fast/reasoning resolve through the active local routing preset */
   routing?: ModelRouting;
+  /** Optional one-shot stronger route after the primary route is exhausted. */
+  fallbackRouting?: ModelRouting;
+  /** Ask the provider for schema-constrained output and validate it in SDK. */
+  nativeStructuredOutput?: boolean;
   /** Optional repair step before Zod validation for known provider edge cases. */
   normalizeParsed?: (value: unknown) => unknown;
   /**
@@ -689,6 +695,8 @@ export async function robustGenerateObject<T>({
   maxRetries = 2,
   initialDelayMs = 500,
   routing = "reasoning",
+  fallbackRouting,
+  nativeStructuredOutput = false,
   normalizeParsed,
   failureLogLevel = "error",
 }: RobustGenerateObjectOptions<T>): Promise<{
@@ -709,6 +717,7 @@ export async function robustGenerateObject<T>({
         maxRetries: 1,
         initialDelayMs,
         routing,
+        nativeStructuredOutput,
         normalizeParsed,
         failureLogLevel,
       });
@@ -721,7 +730,57 @@ export async function robustGenerateObject<T>({
         errorMessage
       );
 
-      return robustGenerateObject({
+      try {
+        return await robustGenerateObject({
+          operation,
+          schema,
+          system,
+          prompt,
+          temperature,
+          maxOutputTokens,
+          maxRetries: 1,
+          initialDelayMs,
+          routing: "reasoning",
+          fallbackRouting,
+          nativeStructuredOutput,
+          normalizeParsed,
+          failureLogLevel,
+        });
+      } catch (fallbackError) {
+        throw combineStructuredGenerationErrors({
+          operation,
+          errors: [error, fallbackError],
+        });
+      }
+    }
+  }
+
+  try {
+    return await generateTextWithJsonParse({
+      operation,
+      schema,
+      system,
+      prompt,
+      temperature,
+      maxOutputTokens,
+      maxRetries,
+      initialDelayMs,
+      routing,
+      nativeStructuredOutput,
+      normalizeParsed,
+      failureLogLevel,
+    });
+  } catch (error) {
+    if (!fallbackRouting || fallbackRouting === routing) {
+      throw error;
+    }
+
+    logJsonAttemptFailure(
+      failureLogLevel,
+      `[AI] ${operation} ${routing} structured generation failed; falling back to ${fallbackRouting} route`
+    );
+    try {
+      return await generateTextWithJsonParse({
         operation,
         schema,
         system,
@@ -730,26 +789,18 @@ export async function robustGenerateObject<T>({
         maxOutputTokens,
         maxRetries: 1,
         initialDelayMs,
-        routing: "reasoning",
+        routing: fallbackRouting,
+        nativeStructuredOutput,
         normalizeParsed,
         failureLogLevel,
       });
+    } catch (fallbackError) {
+      throw combineStructuredGenerationErrors({
+        operation,
+        errors: [error, fallbackError],
+      });
     }
   }
-
-  return generateTextWithJsonParse({
-    operation,
-    schema,
-    system,
-    prompt,
-    temperature,
-    maxOutputTokens,
-    maxRetries,
-    initialDelayMs,
-    routing,
-    normalizeParsed,
-    failureLogLevel,
-  });
 }
 
 /**
@@ -766,6 +817,7 @@ export async function generateTextWithJsonParse<T>({
   maxRetries = 2,
   initialDelayMs = 500,
   routing = "fast",
+  nativeStructuredOutput = false,
   normalizeParsed,
   failureLogLevel = "error",
 }: RobustGenerateObjectOptions<T>): Promise<{
@@ -777,30 +829,59 @@ export async function generateTextWithJsonParse<T>({
   const provider = createAIProvider();
   const modelConfig = getModelForRouting(routing);
   const jsonSchema = JSON.stringify(z.toJSONSchema(schema), null, 2);
-  let lastError: Error | null = null;
+  const attempts: StructuredGenerationAttempt[] = [];
 
   for (let attempt = 0; attempt < maxRetries; attempt++) {
     const startTime = getCurrentUTCTimestamp();
+    const attemptRouting = getStructuredAttemptProviderOptions({
+      providerOptions: modelConfig.providerOptions,
+      attemptIndex: attempt,
+      totalAttempts: maxRetries,
+      requireStructuredOutput: nativeStructuredOutput,
+    });
+    let resultDiagnostics:
+      | Omit<StructuredGenerationAttempt, "errorMessage" | "durationMs">
+      | undefined;
 
     try {
       const result = await generateText({
-        model: provider(modelConfig.model) as any,
+        model: provider(
+          modelConfig.model,
+          nativeStructuredOutput
+            ? { plugins: [{ id: "response-healing" }] }
+            : undefined
+        ) as any,
         system: `${system}\n\nIMPORTANT: You MUST respond with ONLY valid JSON. No markdown, no explanations, just one JSON object that validates against the provided JSON Schema.`,
         prompt: `${prompt}\n\nReturn exactly one JSON object matching this JSON Schema:\n${jsonSchema}\n\nDo not rename keys. Do not wrap the object in another property. Do not return an array unless the schema root is an array.`,
         temperature,
         ...(maxOutputTokens ? { maxOutputTokens } : {}),
-        providerOptions: modelConfig.providerOptions,
+        ...(nativeStructuredOutput
+          ? { output: Output.object({ schema }) }
+          : {}),
+        providerOptions: attemptRouting.providerOptions,
         ...(modelConfig.timeoutMs
           ? { abortSignal: AbortSignal.timeout(modelConfig.timeoutMs) }
           : {}),
       });
 
-      const parsed = JSON.parse(extractJsonPayload(result.text));
+      const usage = extractUsage(result);
+      resultDiagnostics = {
+        attemptNumber: attempt + 1,
+        routing,
+        model: modelConfig.model,
+        configuredProvider: attemptRouting.configuredProvider,
+        providerSelected: usage.providerSelected,
+        modelSelected: usage.modelSelected,
+        finishReason: result.finishReason,
+        responseLength: result.text.length,
+        outputTokens: usage.outputTokens,
+      };
+      const parsed = nativeStructuredOutput
+        ? result.output
+        : JSON.parse(extractJsonPayload(result.text));
       const validated = schema.parse(
         normalizeParsed ? normalizeParsed(parsed) : parsed
       );
-
-      const usage = extractUsage(result);
 
       return {
         object: validated,
@@ -811,15 +892,31 @@ export async function generateTextWithJsonParse<T>({
       };
     } catch (error) {
       const durationMs = getCurrentUTCTimestamp() - startTime;
-      const errorMessage =
-        error instanceof Error ? error.message : "Unknown error";
-      lastError = error instanceof Error ? error : new Error(errorMessage);
+      const errorMessage = getSafeStructuredGenerationErrorMessage(error);
+      const noObjectDiagnostics = NoObjectGeneratedError.isInstance(error)
+        ? {
+            finishReason: error.finishReason,
+            responseLength: error.text?.length,
+            outputTokens: error.usage?.outputTokens,
+            modelSelected: error.response?.modelId,
+          }
+        : undefined;
+      const attemptFailure: StructuredGenerationAttempt = {
+        attemptNumber: attempt + 1,
+        routing,
+        model: modelConfig.model,
+        configuredProvider: attemptRouting.configuredProvider,
+        durationMs,
+        errorMessage,
+        ...resultDiagnostics,
+        ...noObjectDiagnostics,
+      };
+      attempts.push(attemptFailure);
 
       logJsonAttemptFailure(
         failureLogLevel,
-        `[AI] ${operation} JSON attempt ${attempt + 1} failed on ${modelConfig.model}:`,
-        errorMessage,
-        `(${durationMs}ms)`
+        `[AI] ${operation} structured attempt failed`,
+        attemptFailure
       );
 
       if (attempt < maxRetries - 1) {
@@ -831,8 +928,29 @@ export async function generateTextWithJsonParse<T>({
 
   logJsonFailure(
     failureLogLevel,
-    `[AI] ${operation} JSON generation failed:`,
-    lastError?.message
+    `[AI] ${operation} structured generation failed`,
+    { attempts }
   );
-  throw lastError || new Error("Failed to generate structured JSON");
+  throw new StructuredGenerationError({ operation, attempts });
+}
+
+function getSafeStructuredGenerationErrorMessage(error: unknown): string {
+  if (NoObjectGeneratedError.isInstance(error)) {
+    const causeName =
+      error.cause instanceof Error ? error.cause.name : "unknown_parse_error";
+    return `${error.name}: ${causeName}`;
+  }
+  if (error instanceof z.ZodError) {
+    return "Structured output did not match the required schema";
+  }
+  if (error instanceof SyntaxError) {
+    return error.message;
+  }
+  if (error instanceof Error && error.name === "AbortError") {
+    return "Structured output request timed out";
+  }
+  if (error instanceof Error) {
+    return error.message.slice(0, 500);
+  }
+  return "Unknown structured output error";
 }

--- a/convex/lib/autoPlanCore.ts
+++ b/convex/lib/autoPlanCore.ts
@@ -80,6 +80,7 @@ export type AutoPlanFailureCode =
   | "reconnect_required"
   | "writing_style_unavailable"
   | "grounding_unavailable"
+  | "provider_data_unavailable"
   | "provider_balance_unavailable"
   | "provider_schema_unsupported"
   | "context_too_large"
@@ -138,6 +139,18 @@ function stringifyAutoPlanError(error: unknown): string {
 
 export function classifyAutoPlanFailure(error: unknown): AutoPlanFailure {
   const message = stringifyAutoPlanError(error).toLowerCase();
+
+  if (
+    message.includes("linkedin provider data unavailable") ||
+    message.includes("no verified recent linkedin posts are available")
+  ) {
+    return {
+      code: "provider_data_unavailable",
+      retryable: false,
+      userMessage:
+        "Agent couldn’t verify recent LinkedIn activity for this prospect. Refresh their profile before trying again.",
+    };
+  }
 
   if (
     message.includes("insufficient balance") ||
@@ -540,6 +553,22 @@ export function validateAutoPlanDraftAgainstGrounding(args: {
   }
 
   return errors;
+}
+
+export function hasVerifiedAutoPlanOutreachChannel(args: {
+  platform?: "twitter" | "linkedin" | string | null;
+  recentPostCount: number;
+  linkedinRelationship?: LinkedInRelationshipStatus | null;
+  linkedinHasExistingConversation?: boolean;
+}): boolean {
+  if (args.platform !== "linkedin" || args.recentPostCount > 0) {
+    return true;
+  }
+
+  return isLinkedInDmPlanAllowed(
+    args.linkedinRelationship,
+    args.linkedinHasExistingConversation
+  );
 }
 
 export function buildGroundedAutoPlanPrompt(args: {

--- a/convex/lib/qualificationCore.ts
+++ b/convex/lib/qualificationCore.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 import {
   getRoutingTelemetry,
   robustGenerateObject,
+  StructuredGenerationError,
   type ModelRouting,
 } from "./ai";
 import { runWithWorkspaceMemoryCompliance } from "./workspaceMemoryCompliance";
@@ -98,15 +99,20 @@ export class QualificationEvaluationError extends Error {
   readonly stage = "model_evaluation" as const;
   readonly provider: string;
   readonly model: string;
-  readonly attemptCount = 2;
+  readonly attemptCount: number;
   readonly originalMessage: string;
 
-  constructor(args: { message: string; provider: string; model: string }) {
+  constructor(args: {
+    message: string;
+    provider: string;
+    model: string;
+    attemptCount: number;
+  }) {
     super(
       formatQualificationModelFailure({
         provider: args.provider,
         model: args.model,
-        attemptCount: 2,
+        attemptCount: args.attemptCount,
         message: args.message,
       })
     );
@@ -114,6 +120,7 @@ export class QualificationEvaluationError extends Error {
     this.originalMessage = args.message;
     this.provider = args.provider;
     this.model = args.model;
+    this.attemptCount = args.attemptCount;
   }
 }
 
@@ -327,6 +334,8 @@ Evaluate this prospect against the ICP.`;
           ? `${prompt}\n\nThe previous candidate violated workspace policy. Regenerate the complete object with this repair: ${repairInstruction}`
           : prompt,
         routing,
+        fallbackRouting: routing === "onboarding" ? undefined : "onboarding",
+        nativeStructuredOutput: true,
       });
     const generation = await runWithWorkspaceMemoryCompliance<
       Awaited<ReturnType<typeof generateQualificationCandidate>>
@@ -377,18 +386,36 @@ Evaluate this prospect against the ICP.`;
       qualifiedAt: finalQualified ? now : undefined,
     };
   } catch (error) {
+    const structuredFailure =
+      error instanceof StructuredGenerationError ? error : undefined;
     const routingTelemetry = getRoutingTelemetry(routing);
+    const attemptedProviders = structuredFailure?.attempts.map(
+      (attempt) => attempt.providerSelected ?? attempt.configuredProvider
+    );
+    const attemptedModels = structuredFailure?.attempts.map(
+      (attempt) => attempt.modelSelected ?? attempt.model
+    );
+    const provider = attemptedProviders?.length
+      ? [...new Set(attemptedProviders)].join(" -> ")
+      : routingTelemetry.providerLabel;
+    const model = attemptedModels?.length
+      ? [...new Set(attemptedModels)].join(" -> ")
+      : routingTelemetry.model;
+    const attemptCount = structuredFailure?.attempts.length ?? 2;
     const errorMessage =
       error instanceof Error ? error.message : "Unknown model evaluation error";
     qualificationLogger.error("LLM qualification failed", {
       error: errorMessage,
-      model: routingTelemetry.model,
-      provider: routingTelemetry.providerLabel,
+      model,
+      provider,
+      attemptCount,
+      attempts: structuredFailure?.attempts,
     });
     throw new QualificationEvaluationError({
       message: errorMessage,
-      model: routingTelemetry.model,
-      provider: routingTelemetry.providerLabel,
+      model,
+      provider,
+      attemptCount,
     });
   }
 }

--- a/convex/lib/qualificationFailureCore.ts
+++ b/convex/lib/qualificationFailureCore.ts
@@ -1,5 +1,10 @@
 const MODEL_FAILURE_PREFIX = "[QUALIFICATION_MODEL_EVALUATION_FAILED]";
 
+export const QUALIFICATION_MODEL_FAILURE_CODE =
+  "qualification_model_evaluation_failed";
+export const QUALIFICATION_MODEL_RETRY_DELAY_MS = 5 * 60 * 1000;
+export const QUALIFICATION_MAX_WORKFLOW_ATTEMPTS = 2;
+
 export function formatQualificationModelFailure(args: {
   provider: string;
   model: string;

--- a/convex/lib/structuredOutputCore.ts
+++ b/convex/lib/structuredOutputCore.ts
@@ -1,0 +1,107 @@
+import type { JSONValue } from "ai";
+
+export type OpenRouterProviderRouting = Record<string, JSONValue> & {
+  only?: string[];
+  order?: string[];
+  allow_fallbacks?: boolean;
+  require_parameters?: boolean;
+  sort?: "price" | "throughput" | "latency";
+};
+
+export type OpenRouterProviderOptions = {
+  openrouter: Record<string, JSONValue> & {
+    provider: OpenRouterProviderRouting;
+  };
+};
+
+export type StructuredGenerationAttempt = {
+  attemptNumber: number;
+  routing: string;
+  model: string;
+  configuredProvider: string;
+  providerSelected?: string;
+  modelSelected?: string;
+  finishReason?: string;
+  responseLength?: number;
+  outputTokens?: number;
+  durationMs: number;
+  errorMessage: string;
+};
+
+export class StructuredGenerationError extends Error {
+  readonly operation: string;
+  readonly attempts: readonly StructuredGenerationAttempt[];
+
+  constructor(args: {
+    operation: string;
+    attempts: readonly StructuredGenerationAttempt[];
+  }) {
+    const lastAttempt = args.attempts.at(-1);
+    super(lastAttempt?.errorMessage ?? "Failed to generate structured output");
+    this.name = "StructuredGenerationError";
+    this.operation = args.operation;
+    this.attempts = args.attempts;
+  }
+}
+
+/**
+ * OpenRouter provider fallback handles request failures, but a provider can
+ * return HTTP success with malformed JSON. Pin each application-level retry to
+ * a different configured provider so a parse/schema failure gets real provider
+ * diversity instead of returning to the first provider in the order.
+ */
+export function getStructuredAttemptProviderOptions(args: {
+  providerOptions: OpenRouterProviderOptions;
+  attemptIndex: number;
+  totalAttempts: number;
+  requireStructuredOutput: boolean;
+}): {
+  providerOptions: OpenRouterProviderOptions;
+  configuredProvider: string;
+} {
+  const routing = args.providerOptions.openrouter.provider;
+  const order = routing.order ?? [];
+  const shouldPinProvider = args.totalAttempts > 1 && order.length > 1;
+  const selectedProvider = shouldPinProvider
+    ? order[args.attemptIndex % order.length]
+    : undefined;
+  const nextRouting: OpenRouterProviderRouting = {
+    ...routing,
+    ...(args.requireStructuredOutput ? { require_parameters: true } : {}),
+    ...(selectedProvider
+      ? {
+          only: [selectedProvider],
+          order: [selectedProvider],
+          allow_fallbacks: false,
+        }
+      : {}),
+  };
+
+  return {
+    providerOptions: {
+      openrouter: {
+        ...args.providerOptions.openrouter,
+        provider: nextRouting,
+      },
+    },
+    configuredProvider:
+      selectedProvider ??
+      routing.only?.join("/") ??
+      routing.order?.join("/") ??
+      "openrouter",
+  };
+}
+
+export function combineStructuredGenerationErrors(args: {
+  operation: string;
+  errors: readonly unknown[];
+}): StructuredGenerationError {
+  const attempts = args.errors.flatMap((error) =>
+    error instanceof StructuredGenerationError ? [...error.attempts] : []
+  );
+
+  return new StructuredGenerationError({
+    operation: args.operation,
+    attempts,
+  });
+}

--- a/convex/lib/structuredOutputCore.ts
+++ b/convex/lib/structuredOutputCore.ts
@@ -36,7 +36,7 @@ export class StructuredGenerationError extends Error {
     operation: string;
     attempts: readonly StructuredGenerationAttempt[];
   }) {
-    const lastAttempt = args.attempts.at(-1);
+    const lastAttempt = args.attempts[args.attempts.length - 1];
     super(lastAttempt?.errorMessage ?? "Failed to generate structured output");
     this.name = "StructuredGenerationError";
     this.operation = args.operation;

--- a/convex/qualificationFailureRecovery.integration.test.ts
+++ b/convex/qualificationFailureRecovery.integration.test.ts
@@ -1,0 +1,101 @@
+/// <reference types="vite/client" />
+
+import type { WorkflowId } from "@convex-dev/workflow";
+import { convexTest } from "convex-test";
+import { describe, expect, test, vi } from "vitest";
+import { internal } from "./_generated/api";
+import { formatQualificationModelFailure } from "./lib/qualificationFailureCore";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+
+describe("qualification model failure recovery", () => {
+  test("schedules one delayed retry and stops after the bounded second run", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-29T12:46:00.000Z"));
+    const t = convexTest(schema, modules);
+    const seeded = await t.run(async (ctx) => {
+      const userId = await ctx.db.insert("users", {
+        workosUserId: "qualification-recovery-user",
+        email: "qualification-recovery@example.test",
+      });
+      const workspaceId = await ctx.db.insert("workspaces", {
+        userId,
+        name: "Qualification recovery",
+        description: "Qualification recovery test workspace",
+        isDefault: true,
+        prospectingWorkflowStatus: "running",
+        updatedAt: 1,
+      });
+      const prospectId = await ctx.db.insert("prospects", {
+        workspaceId,
+        userId,
+        platform: "twitter",
+        origin: "workspace_discovery",
+        externalId: "qualification-recovery-prospect",
+        data: {},
+        status: "new",
+        qualificationStatus: "pending",
+        qualificationWorkflowId: "qualification-workflow-1",
+        updatedAt: 1,
+      });
+      return { prospectId, workspaceId };
+    });
+    const modelError = formatQualificationModelFailure({
+      provider: "cerebras -> groq -> openai/azure",
+      model: "openai/gpt-oss-120b -> openai/gpt-5.6-sol",
+      attemptCount: 3,
+      message: "AI_NoObjectGeneratedError: JSONParseError",
+    });
+
+    await t.mutation(
+      internal.workflows.qualification.handleQualificationComplete,
+      {
+        workflowId: "qualification-workflow-1" as WorkflowId,
+        result: { kind: "failed", error: modelError },
+        context: { prospectId: seeded.prospectId },
+      }
+    );
+
+    const firstFailure = await t.run(async (ctx) => ({
+      prospect: await ctx.db.get("prospects", seeded.prospectId),
+      scheduled: await ctx.db.system.query("_scheduled_functions").collect(),
+    }));
+    expect(firstFailure.prospect?.qualificationLastFailure).toMatchObject({
+      attemptCount: 3,
+      workflowAttemptCount: 1,
+    });
+    expect(
+      firstFailure.prospect?.qualificationLastFailure?.nextRetryAt
+    ).toBeGreaterThan(Date.now());
+    expect(
+      firstFailure.scheduled.filter((job) =>
+        job.name.includes("startQualification")
+      )
+    ).toHaveLength(1);
+
+    vi.advanceTimersByTime(1_000);
+    await t.run((ctx) =>
+      ctx.db.patch("prospects", seeded.prospectId, {
+        qualificationWorkflowId: "qualification-workflow-2",
+      })
+    );
+    await t.mutation(
+      internal.workflows.qualification.handleQualificationComplete,
+      {
+        workflowId: "qualification-workflow-2" as WorkflowId,
+        result: { kind: "failed", error: modelError },
+        context: { prospectId: seeded.prospectId },
+      }
+    );
+
+    const exhausted = await t.run((ctx) =>
+      ctx.db.get("prospects", seeded.prospectId)
+    );
+    expect(exhausted?.qualificationLastFailure).toMatchObject({
+      attemptCount: 3,
+      workflowAttemptCount: 2,
+    });
+    expect(exhausted?.qualificationLastFailure?.nextRetryAt).toBeUndefined();
+  });
+});

--- a/convex/validators.ts
+++ b/convex/validators.ts
@@ -1339,6 +1339,10 @@ export const qualificationFailureValidator = v.object({
   code: v.string(),
   message: v.string(),
   attemptCount: v.optional(v.number()),
+  /** Number of completed durable qualification runs for the same failure. */
+  workflowAttemptCount: v.optional(v.number()),
+  /** Earliest time the single bounded automatic retry may start. */
+  nextRetryAt: v.optional(v.number()),
   failedAt: v.number(),
 });
 

--- a/convex/validators.ts
+++ b/convex/validators.ts
@@ -2611,6 +2611,7 @@ export const autoPlanFailureCodeValidator = v.union(
   v.literal("reconnect_required"),
   v.literal("writing_style_unavailable"),
   v.literal("grounding_unavailable"),
+  v.literal("provider_data_unavailable"),
   v.literal("provider_balance_unavailable"),
   v.literal("provider_schema_unsupported"),
   v.literal("context_too_large"),

--- a/convex/workflows/qualification.ts
+++ b/convex/workflows/qualification.ts
@@ -21,7 +21,12 @@ import { isValidatedSetupPreviewProspect } from "../lib/setupSessionCore";
 import type { Doc, Id } from "../_generated/dataModel";
 import type { ActionCtx } from "../_generated/server";
 import { getCurrentUTCTimestamp } from "../../shared/lib/utils/time/timeUtils";
-import { parseQualificationModelFailure } from "../lib/qualificationFailureCore";
+import {
+  parseQualificationModelFailure,
+  QUALIFICATION_MAX_WORKFLOW_ATTEMPTS,
+  QUALIFICATION_MODEL_FAILURE_CODE,
+  QUALIFICATION_MODEL_RETRY_DELAY_MS,
+} from "../lib/qualificationFailureCore";
 import { TENANT_JOB_PRIORITY } from "../lib/tenantSchedulerCore";
 import { enqueueTenantJobWithRetry } from "../lib/tenantSchedulerEnqueue";
 import { completeTenantJob } from "../lib/tenantSchedulerHelpers";
@@ -672,6 +677,18 @@ export const handleQualificationComplete = internalMutation({
     const now = getCurrentUTCTimestamp();
     if (args.result.kind === "failed") {
       const modelFailure = parseQualificationModelFailure(args.result.error);
+      const previousWorkflowAttemptCount =
+        prospect.qualificationLastFailure?.code ===
+        QUALIFICATION_MODEL_FAILURE_CODE
+          ? (prospect.qualificationLastFailure.workflowAttemptCount ?? 0)
+          : 0;
+      const workflowAttemptCount = previousWorkflowAttemptCount + 1;
+      const shouldRetry =
+        Boolean(modelFailure) &&
+        workflowAttemptCount < QUALIFICATION_MAX_WORKFLOW_ATTEMPTS;
+      const nextRetryAt = shouldRetry
+        ? now + QUALIFICATION_MODEL_RETRY_DELAY_MS
+        : undefined;
       await ctx.db.patch(prospect._id, {
         qualificationWorkflowId: undefined,
         qualificationLastFailure: {
@@ -679,10 +696,12 @@ export const handleQualificationComplete = internalMutation({
           provider: modelFailure?.provider ?? "convex_workflow",
           model: modelFailure?.model,
           code: modelFailure
-            ? "qualification_model_evaluation_failed"
+            ? QUALIFICATION_MODEL_FAILURE_CODE
             : "qualification_workflow_failed",
           message: modelFailure?.message ?? args.result.error,
           attemptCount: modelFailure?.attemptCount,
+          workflowAttemptCount,
+          nextRetryAt,
           failedAt: now,
         },
         updatedAt: now,
@@ -693,6 +712,17 @@ export const handleQualificationComplete = internalMutation({
           status: "failed",
           errorMessage: args.result.error,
         });
+      }
+      if (shouldRetry && nextRetryAt !== undefined) {
+        await ctx.scheduler.runAt(
+          nextRetryAt,
+          internal.workflows.qualification.startQualification,
+          {
+            prospectId: prospect._id,
+            workspaceId: prospect.workspaceId,
+            expectedModelFailureAt: now,
+          }
+        );
       }
       return null;
     }
@@ -720,6 +750,7 @@ export const startQualification = internalAction({
   args: {
     prospectId: v.id("prospects"),
     workspaceId: v.id("workspaces"),
+    expectedModelFailureAt: v.optional(v.number()),
   },
   handler: async (ctx, args): Promise<{ workId: string }> => {
     const prospect = await ctx.runQuery(
@@ -736,6 +767,35 @@ export const startQualification = internalAction({
       typeof prospect.qualificationWorkflowId === "string"
     ) {
       return { workId: "" };
+    }
+
+    const now = getCurrentUTCTimestamp();
+    const modelFailure =
+      prospect.qualificationLastFailure?.code ===
+      QUALIFICATION_MODEL_FAILURE_CODE
+        ? prospect.qualificationLastFailure
+        : undefined;
+    if (args.expectedModelFailureAt !== undefined) {
+      if (
+        modelFailure?.failedAt !== args.expectedModelFailureAt ||
+        modelFailure.nextRetryAt === undefined ||
+        modelFailure.nextRetryAt > now ||
+        (modelFailure.workflowAttemptCount ?? 0) >=
+          QUALIFICATION_MAX_WORKFLOW_ATTEMPTS
+      ) {
+        return { workId: "" };
+      }
+    } else if (modelFailure) {
+      const retryAt =
+        modelFailure.nextRetryAt ??
+        modelFailure.failedAt + QUALIFICATION_MODEL_RETRY_DELAY_MS;
+      if (
+        retryAt > now ||
+        (modelFailure.workflowAttemptCount ?? 0) >=
+          QUALIFICATION_MAX_WORKFLOW_ATTEMPTS
+      ) {
+        return { workId: "" };
+      }
     }
 
     const limitState = await ctx.runQuery(

--- a/docs/convex/reliability-program-2026-08-27.md
+++ b/docs/convex/reliability-program-2026-08-27.md
@@ -1091,3 +1091,48 @@ reaches one terminal qualification result or the bounded exhausted state, and
 require no duplicate active workflow, retry storm, new permanent scheduler
 error, or schema/bytes-read failure. Resume the separate destructive-cleanup
 sequence only after that gate passes.
+
+### Separate LinkedIn provider-data incident
+
+The 13:03 UTC follow-up contained three additional `auto_plan` failures at
+12:49:54, 12:50:26, and 12:52:24 UTC. All three came from LinkdAPI's successful-
+HTTP no-data response during recent-post refresh: the data could not be
+displayed or did not exist and the supplied URN needed verification. The queue
+still drained with all 36 tenant slots free and no lease, pool, mode, or
+scheduler failure. This is a stale provider-identity/data-availability defect,
+not part of the qualification JSON incident and not scheduler exhaustion.
+
+The background social-context path previously called the user-authenticated
+LinkedIn profile action even though that action deliberately returns no recent
+posts. On failure it retried the stored prospect URN directly. A stale URN then
+escaped as a generic retryable auto-plan generation error, causing repeated
+paid work without changing the underlying identity.
+
+The local fix resolves the prospect through the existing canonical LinkedIn
+identity helper, refreshes the live profile by username without sending the
+stale URN, and tries the provider's canonical profile URN before the stored
+fallback. LinkdAPI's exact no-data response becomes an explicit empty recent-
+post result; authentication, rate-limit, network, and server failures still
+throw and retain transient retry behavior.
+
+An empty post result degrades only when another verified outreach channel is
+available. Connected prospects and the existing connect-first LinkedIn flow
+may receive a grounded DM plan, while the draft validator continues to reject
+invented post IDs. If neither a verified post nor an allowed messaging path is
+available, the run stops with the new terminal `provider_data_unavailable`
+code. That code is intentionally excluded from automatic recovery, preventing
+a stale-URN retry storm. No prospect identifier is rewritten and no data
+migration or backfill is required by this hotfix.
+
+After deployment, verify a diagnosed prospect once. Acceptance requires either
+a plan grounded in a provider-returned post, a valid DM/connect-first plan with
+no post reference, or one terminal provider-data notification. It must not
+create repeated auto-plan runs, invent a post, or hide transient provider
+outages. Repairing stored LinkedIn identifiers, if later justified by bounded
+evidence, remains a separate data migration.
+
+Combined local verification passed 115 Convex test files and 578 tests,
+TypeScript, strict Oxlint, changed-file formatting, and the 74-route production
+build. The production-targeted Convex dry run passed schema validation and
+reported no index deletion. No production function, control, or document was
+changed.

--- a/docs/convex/reliability-program-2026-08-27.md
+++ b/docs/convex/reliability-program-2026-08-27.md
@@ -1027,3 +1027,67 @@ The final post-cleanup snapshot was enforced, zero queued, zero running, 36/36
 free, zero expired leases, zero unresolved enqueue failures, and no pool or mode
 drift. This closes the scheduler burst-throughput investigation without an
 unsupported production-capacity change.
+
+## Qualification structured-output incident — 2026-08-29
+
+The 12:46 UTC read-only production gate found a new provider-output incident,
+not a scheduler-capacity failure. The newest 1,000 tenant jobs contained 74
+failed qualification jobs completed between 12:40:49 and 12:44:45 UTC. They
+represented 41 unique prospects in one workspace: 20 prospects had one failed
+job, 9 had two, and 12 had three. Sixty failures were `Unexpected end of JSON
+input`; the other fourteen were malformed-JSON errors such as unterminated
+strings or missing delimiters. Every failed job exhausted two model attempts on
+the configured `openai/gpt-oss-120b` Cerebras/Groq route. At the snapshot, 11
+jobs were running, zero were queued, 25/36 tenant slots were free, and there was
+no expired lease, pool drift, or scheduler-control error.
+
+A later read-only checkpoint found 241 additional completed jobs after the
+incident cutoff and no new qualification model-output failure. Scheduler state
+was enforced and drained with 36/36 slots free, zero queued/running jobs, zero
+expired leases, zero unresolved enqueue failures, and no pool drift. Three
+later failures were unrelated auto-plan jobs whose LinkedIn recent-post refresh
+received invalid/missing URNs from LinkdAPI; they are not attributed to this
+qualification incident or scheduler capacity.
+
+The application retry loop previously resent both attempts with the same
+ordered provider options. OpenRouter can fail over when a provider request
+fails, but a provider returning HTTP success with malformed JSON is an
+application-level parse failure; retrying the same order can select the same
+endpoint again. Qualification also requested JSON only through prompt text
+instead of the AI SDK's schema-constrained output contract. Finally, the
+capacity reconciler could see the prospect as pending immediately after a
+failed workflow and launch it again, explaining why 74 jobs mapped to only 41
+prospects.
+
+The local hotfix makes qualification use native schema-constrained output with
+OpenRouter response healing, while retaining final Zod validation and all
+evidence gates. It pins the first two application attempts to different
+providers (Cerebras, then Groq) and makes one bounded recovery attempt on the
+stronger onboarding model. Arbitrary truncated output is never guessed or
+accepted. Failed attempts log only safe metadata: configured/selected provider,
+model, finish reason, response length, output-token count, duration, and error
+class; prospect and model content are not logged.
+
+The failure record is widened with optional `workflowAttemptCount` and
+`nextRetryAt` fields. The first exhausted workflow schedules one retry after a
+five-minute cooldown. A second exhausted workflow records the failure and
+stops. Capacity reconciliation respects the cooldown and exhaustion marker, so
+it cannot create an unbounded retry loop. This is an additive optional-field
+change: existing documents remain valid and no scan or backfill is required.
+
+Local verification includes provider-rotation and error-chain unit tests plus a
+Convex integration test proving exactly one delayed workflow retry and no second
+schedule after exhaustion. The complete suite passed 115 test files and 577
+tests. TypeScript, strict Oxlint, formatting, the 74-route production build, and
+the production-targeted Convex dry run also passed; the dry run reported no
+index deletion. Cleanup remains paused until the hotfix deploys and the recovery
+gate passes.
+
+Rollout is code-first. After deployment, confirm no new malformed-output burst,
+then replay only the 41 unique affected prospects whose latest state is still
+pending, lease-free, and carries the diagnosed model-failure marker. Reuse the
+existing qualification enqueue idempotency contract, verify each prospect
+reaches one terminal qualification result or the bounded exhausted state, and
+require no duplicate active workflow, retry storm, new permanent scheduler
+error, or schema/bytes-read failure. Resume the separate destructive-cleanup
+sequence only after that gate passes.

--- a/tests/auto-plan-generation.test.ts
+++ b/tests/auto-plan-generation.test.ts
@@ -9,6 +9,7 @@ import {
   autoPlanDraftSchema,
   autoPlanTransportSchema,
   classifyAutoPlanFailure,
+  hasVerifiedAutoPlanOutreachChannel,
   hasAutoPlanRecoveryCapacity,
   isAutoPlanFailureRecoveryEligible,
   parseAutoPlanTransportDraft,
@@ -302,9 +303,7 @@ test("automatic plan failures distinguish terminal setup issues from transient p
       code: "writing_style_unavailable",
       retryable: false,
       userMessage:
-        "Writing style is unavailable. Refresh it from Connected accounts.",
-      actionLabel: "Reconnect",
-      targetHref: "/settings/connected-accounts",
+        "Agent is refreshing the writing style and will retry automatically.",
     }
   );
   assert.equal(
@@ -343,11 +342,61 @@ test("automatic plan failures distinguish terminal setup issues from transient p
     isAutoPlanFailureRecoveryEligible("provider_schema_unsupported"),
     false
   );
+  assert.deepEqual(
+    classifyAutoPlanFailure(
+      "LinkedIn provider data unavailable: no verified recent LinkedIn posts are available"
+    ),
+    {
+      code: "provider_data_unavailable",
+      retryable: false,
+      userMessage:
+        "Agent couldn’t verify recent LinkedIn activity for this prospect. Refresh their profile before trying again.",
+    }
+  );
+  assert.equal(
+    isAutoPlanFailureRecoveryEligible("provider_data_unavailable"),
+    false
+  );
   assert.equal(isAutoPlanFailureRecoveryEligible("context_too_large"), false);
   assert.equal(isAutoPlanFailureRecoveryEligible("reconnect_required"), false);
   assert.equal(
     isAutoPlanFailureRecoveryEligible("writing_style_unavailable"),
+    true
+  );
+});
+
+test("LinkedIn plans degrade to messaging only when that channel is verified", () => {
+  assert.equal(
+    hasVerifiedAutoPlanOutreachChannel({
+      platform: "linkedin",
+      recentPostCount: 0,
+      linkedinRelationship: "connected",
+    }),
+    true
+  );
+  assert.equal(
+    hasVerifiedAutoPlanOutreachChannel({
+      platform: "linkedin",
+      recentPostCount: 0,
+      linkedinRelationship: "not_connected",
+    }),
+    true
+  );
+  assert.equal(
+    hasVerifiedAutoPlanOutreachChannel({
+      platform: "linkedin",
+      recentPostCount: 0,
+      linkedinRelationship: "unknown",
+    }),
     false
+  );
+  assert.equal(
+    hasVerifiedAutoPlanOutreachChannel({
+      platform: "linkedin",
+      recentPostCount: 1,
+      linkedinRelationship: "unknown",
+    }),
+    true
   );
 });
 
@@ -412,7 +461,7 @@ test("automatic plan reliability prevents repeated paid work and dead notificati
     `${ROOT}/convex/socialapiMonitors.ts`,
     "utf8"
   );
-  assert.match(monitorSource, /withIndex\("by_workspace_value"/);
+  assert.match(monitorSource, /withIndex\("by_workspace_type_and_value"/);
   assert.match(monitorSource, /normalizeMemoryText\(args\.query\)/);
   assert.doesNotMatch(
     monitorSource,

--- a/tests/linkdapi-client.test.ts
+++ b/tests/linkdapi-client.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import type { ActionCtx } from "../convex/_generated/server";
 import {
   isLinkdApiNoDataError,
+  isLinkdApiNoDataMessage,
   LinkdApiRequestError,
   requestLinkdApiData,
 } from "../convex/integrations/linkedin/linkdapiClient";
@@ -98,6 +99,12 @@ test("LinkdAPI client pagination and circuit evidence", async (t) => {
                 "the data cannot be displayed or it doesn't exist, make sure the URN is correct",
               status: 200,
             })
+          ),
+          true
+        );
+        assert.equal(
+          isLinkdApiNoDataMessage(
+            "The data cannot be displayed or it does not exist; verify the URN"
           ),
           true
         );

--- a/tests/linkedin-profile-posts-ui.test.ts
+++ b/tests/linkedin-profile-posts-ui.test.ts
@@ -30,7 +30,7 @@ test("an empty cursor page ends pagination without becoming a UI error", () => {
 
   assert.match(
     source,
-    /if \(args\.cursor && isLinkdApiNoDataError\(error\)\) \{\s*return \{ posts: \[\], nextCursor: null \};/
+    /if \(isLinkdApiNoDataError\(error\)\) \{\s*return \{\s*posts: \[\],\s*nextCursor: null,\s*unavailableReason: "profile_data_unavailable" as const,\s*\};/
   );
 });
 

--- a/tests/qualification-failure-safety.test.ts
+++ b/tests/qualification-failure-safety.test.ts
@@ -14,6 +14,10 @@ const qualificationWorkflowSource = readFileSync(
   "convex/workflows/qualification.ts",
   "utf8"
 );
+const qualificationValidatorSource = readFileSync(
+  "convex/validators.ts",
+  "utf8"
+);
 
 test("model failures throw instead of becoming disqualified results", () => {
   const catchBlock = qualificationCoreSource.slice(
@@ -56,4 +60,31 @@ test("model failures retain provider, model, attempts, and original error", () =
     attemptCount: 2,
     message: "Structured response did not validate",
   });
+});
+
+test("qualification uses native structured output and a stronger fallback", () => {
+  assert.match(qualificationCoreSource, /nativeStructuredOutput:\s*true/);
+  assert.match(
+    qualificationCoreSource,
+    /fallbackRouting:\s*routing === "onboarding" \? undefined : "onboarding"/
+  );
+  assert.match(
+    qualificationCoreSource,
+    /structuredFailure\?\.attempts\.length \?\? 2/
+  );
+});
+
+test("model failures schedule only one bounded delayed workflow retry", () => {
+  const completionHandler = qualificationWorkflowSource.slice(
+    qualificationWorkflowSource.indexOf(
+      "export const handleQualificationComplete"
+    ),
+    qualificationWorkflowSource.indexOf("export const startQualification")
+  );
+  assert.match(completionHandler, /QUALIFICATION_MAX_WORKFLOW_ATTEMPTS/);
+  assert.match(completionHandler, /QUALIFICATION_MODEL_RETRY_DELAY_MS/);
+  assert.match(completionHandler, /ctx\.scheduler\.runAt/);
+  assert.match(completionHandler, /expectedModelFailureAt:\s*now/);
+  assert.match(qualificationValidatorSource, /workflowAttemptCount:/);
+  assert.match(qualificationValidatorSource, /nextRetryAt:/);
 });

--- a/tests/structured-output-reliability.test.ts
+++ b/tests/structured-output-reliability.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  combineStructuredGenerationErrors,
+  getStructuredAttemptProviderOptions,
+  StructuredGenerationError,
+  type OpenRouterProviderOptions,
+} from "../convex/lib/structuredOutputCore";
+
+const orderedProviders: OpenRouterProviderOptions = {
+  openrouter: {
+    provider: {
+      order: ["cerebras", "groq"],
+      allow_fallbacks: true,
+      require_parameters: false,
+    },
+  },
+};
+
+test("structured retries pin different providers after malformed success", () => {
+  const first = getStructuredAttemptProviderOptions({
+    providerOptions: orderedProviders,
+    attemptIndex: 0,
+    totalAttempts: 2,
+    requireStructuredOutput: true,
+  });
+  const second = getStructuredAttemptProviderOptions({
+    providerOptions: orderedProviders,
+    attemptIndex: 1,
+    totalAttempts: 2,
+    requireStructuredOutput: true,
+  });
+
+  assert.equal(first.configuredProvider, "cerebras");
+  assert.deepEqual(first.providerOptions.openrouter.provider.only, [
+    "cerebras",
+  ]);
+  assert.equal(
+    first.providerOptions.openrouter.provider.allow_fallbacks,
+    false
+  );
+  assert.equal(
+    first.providerOptions.openrouter.provider.require_parameters,
+    true
+  );
+  assert.equal(second.configuredProvider, "groq");
+  assert.deepEqual(second.providerOptions.openrouter.provider.only, ["groq"]);
+});
+
+test("one-shot recovery retains request-level provider fallback", () => {
+  const recovery = getStructuredAttemptProviderOptions({
+    providerOptions: orderedProviders,
+    attemptIndex: 0,
+    totalAttempts: 1,
+    requireStructuredOutput: true,
+  });
+
+  assert.equal(recovery.configuredProvider, "cerebras/groq");
+  assert.equal(
+    recovery.providerOptions.openrouter.provider.allow_fallbacks,
+    true
+  );
+  assert.deepEqual(recovery.providerOptions.openrouter.provider.order, [
+    "cerebras",
+    "groq",
+  ]);
+});
+
+test("fallback errors preserve every provider attempt", () => {
+  const primary = new StructuredGenerationError({
+    operation: "qualifyProspect",
+    attempts: [
+      {
+        attemptNumber: 1,
+        routing: "reasoning",
+        model: "openai/gpt-oss-120b",
+        configuredProvider: "cerebras",
+        durationMs: 100,
+        errorMessage: "Unexpected end of JSON input",
+      },
+      {
+        attemptNumber: 2,
+        routing: "reasoning",
+        model: "openai/gpt-oss-120b",
+        configuredProvider: "groq",
+        durationMs: 110,
+        errorMessage: "Unexpected end of JSON input",
+      },
+    ],
+  });
+  const recovery = new StructuredGenerationError({
+    operation: "qualifyProspect",
+    attempts: [
+      {
+        attemptNumber: 1,
+        routing: "onboarding",
+        model: "openai/gpt-5.6-sol",
+        configuredProvider: "openai/azure",
+        durationMs: 120,
+        errorMessage: "Structured output did not match the required schema",
+      },
+    ],
+  });
+
+  const combined = combineStructuredGenerationErrors({
+    operation: "qualifyProspect",
+    errors: [primary, recovery],
+  });
+
+  assert.equal(combined.attempts.length, 3);
+  assert.deepEqual(
+    combined.attempts.map((attempt) => attempt.configuredProvider),
+    ["cerebras", "groq", "openai/azure"]
+  );
+});


### PR DESCRIPTION
## Summary

- use schema-constrained qualification output with provider diversity and one bounded stronger-model fallback
- schedule at most one delayed qualification recovery and prevent immediate duplicate workflow restarts
- resolve LinkedIn post identity through the canonical username/profile path before a stored fallback can fail repeatedly
- degrade auto-plan safely to DM/connect-first when permitted; otherwise stop with terminal provider_data_unavailable instead of inventing posts or retrying indefinitely
- document both Aug 29 provider incidents and the bounded rollout gates

## Production evidence

- 74 malformed/truncated qualification JSON failures mapped to 41 unique prospects
- 3 separate auto-plan failures came from LinkdAPI no-data / verify-URN responses
- scheduler drained normally with no expired leases, pool drift, or mode drift

## Verification

- 115 Convex test files / 578 tests passed
- TypeScript passed
- strict Oxlint passed
- changed-file formatting passed
- production build passed with 74 routes
- production-targeted Convex dry run passed schema validation and reported zero index deletions
- Convex reviewer and security checks passed

## Rollout

No production replay or control mutation is included. After deployment: verify read-only, replay only the 41 diagnosed pending qualification prospects through the existing idempotent enqueue contract, then retry one diagnosed LinkedIn auto-plan and require exactly-once recovery.