### PR TITLE
fix(agent): enable vision provider failover

### DIFF
--- a/convex/lib/ai.ts
+++ b/convex/lib/ai.ts
@@ -474,7 +474,7 @@ export const PINNED_VISION_PROVIDER_OPTIONS: OpenRouterProviderOptions =
     defaultModel: MODELS.KIMI_K2_6,
     defaultOptions: createOrderedProviderOptions({
       order: [OPENROUTER_PROVIDERS.BASETEN, OPENROUTER_PROVIDERS.WANDB_FP4],
-      allowFallbacks: false,
+      allowFallbacks: true,
     }),
   });
 

--- a/tests/vision-provider-routing.test.ts
+++ b/tests/vision-provider-routing.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  MODELS,
+  OPENROUTER_PROVIDERS,
+  PINNED_VISION_MODEL,
+  PINNED_VISION_PROVIDER_OPTIONS,
+} from "../convex/lib/ai";
+
+test("vision requests fail over between compatible Kimi providers", () => {
+  const provider = PINNED_VISION_PROVIDER_OPTIONS.openrouter.provider;
+
+  assert.equal(PINNED_VISION_MODEL, MODELS.KIMI_K2_6);
+  assert.deepEqual(provider.order, [
+    OPENROUTER_PROVIDERS.BASETEN,
+    OPENROUTER_PROVIDERS.WANDB_FP4,
+  ]);
+  assert.equal(provider.allow_fallbacks, true);
+  assert.equal(provider.require_parameters, true);
+  assert.equal(provider.only, undefined);
+});


### PR DESCRIPTION
## Summary

- enable OpenRouter provider fallback for Kimi vision requests
- preserve BaseTen and W&B as preferred providers while allowing compatible Kimi providers to recover failed requests
- add a regression test for the vision routing contract

## Testing

- 579/579 Convex tests passed
- 17/17 focused routing and media tests passed
- TypeScript passed
- strict lint passed with zero warnings
- Prettier passed
- production Next.js build passed
- Convex deployment and typecheck passed
- isolated browser QA passed on the reported Agent thread: image upload, correct OCR response, and zero console errors
- CodeRabbit reviewed the complete diff; no legitimate issues remained

## References

- https://openrouter.ai/docs/guides/routing/provider-selection
- https://openrouter.ai/moonshotai/kimi-k2.6