### PR TITLE
fix(reporting): bound pre-migration aggregate writes

### DIFF
--- a/convex/lib/workspaceReportingAggregate.ts
+++ b/convex/lib/workspaceReportingAggregate.ts
@@ -115,7 +115,31 @@ async function syncAggregateItems(
   oldItems: Map<string, AggregateItem>,
   newItems: Map<string, AggregateItem>
 ) {
+  const workspaceIds = new Set<Id<"workspaces">>();
+  for (const item of oldItems.values()) workspaceIds.add(item.namespace[1]);
+  for (const item of newItems.values()) workspaceIds.add(item.namespace[1]);
+
+  const enabledWorkspaceIds = new Set<Id<"workspaces">>();
+  for (const workspaceId of workspaceIds) {
+    const rollout = await ctx.db
+      .query("workspaceReportingRollouts")
+      .withIndex("by_workspace", (q) => q.eq("workspaceId", workspaceId))
+      .unique();
+    if (
+      rollout?.aggregateVersion === WORKSPACE_REPORTING_AGGREGATE_VERSION &&
+      (rollout.status === "backfilling" ||
+        rollout.status === "verifying" ||
+        rollout.status === "verified")
+    ) {
+      enabledWorkspaceIds.add(workspaceId);
+    }
+  }
+
+  // Existing workspaces stay snapshot-only until their rollout starts. This
+  // also prevents preparation repairs from paying Aggregate B-tree costs for
+  // every repaired row before the resumable backfill checkpoint exists.
   for (const [mapKey, oldItem] of oldItems) {
+    if (!enabledWorkspaceIds.has(oldItem.namespace[1])) continue;
     const newItem = newItems.get(mapKey);
     if (!newItem) {
       await workspaceReportingAggregate.deleteIfExists(ctx, oldItem);
@@ -127,6 +151,7 @@ async function syncAggregateItems(
   }
 
   for (const [mapKey, newItem] of newItems) {
+    if (!enabledWorkspaceIds.has(newItem.namespace[1])) continue;
     if (!oldItems.has(mapKey)) {
       await workspaceReportingAggregate.insertIfDoesNotExist(ctx, newItem);
     }

--- a/convex/workspaceReportingAggregate.integration.test.ts
+++ b/convex/workspaceReportingAggregate.integration.test.ts
@@ -16,6 +16,7 @@ import {
   getWorkspaceAgentOpsContributionsFromKeyword,
   mergeWorkspaceAgentOpsContributions,
 } from "./lib/agentOpsReadModelHelpers";
+import { getWorkspaceReportingMetricSums } from "./lib/workspaceReportingAggregate";
 
 const modules = import.meta.glob("./**/*.ts");
 
@@ -126,6 +127,35 @@ describe("workspace reporting Aggregate", () => {
       return { userId, workspaceId };
     });
 
+    await t.mutation(internal.prospects.createProspectsBatch, {
+      userId: seeded.userId,
+      workspaceId: seeded.workspaceId,
+      prospects: [
+        {
+          platform: "linkedin",
+          origin: "workspace_discovery",
+          externalId: "reporting-pre-rollout",
+          data: {},
+          qualificationStatus: "disqualified",
+        },
+      ],
+    });
+    await expect(
+      t.run((ctx) =>
+        getWorkspaceReportingMetricSums(ctx, {
+          workspaceId: seeded.workspaceId,
+          dataset: "analytics",
+          queries: [
+            {
+              metric: "hourlyNewProspectsCounts",
+              startMs: Number.MIN_SAFE_INTEGER,
+              endMs: Number.MAX_SAFE_INTEGER,
+            },
+          ],
+        })
+      )
+    ).resolves.toEqual([0]);
+
     const migration = await t.mutation(startMigration, {
       workspaceId: seeded.workspaceId,
       batchSize: 2,
@@ -152,7 +182,8 @@ describe("workspace reporting Aggregate", () => {
       queryArgs
     );
     expect(before.status).toBe("success");
-    expect(before.data.newProspects.value).toBe(1);
+    expect(before.data.newProspects.value).toBe(2);
+    expect(before.data.processingSummary.disqualified.value).toBe(1);
     const agentOpsBefore = await owner.query(
       api.agentOps.getAgentOpsDashboard,
       {
@@ -187,11 +218,11 @@ describe("workspace reporting Aggregate", () => {
       queryArgs
     );
     expect(after.status).toBe("success");
-    expect(after.data.newProspects.value).toBe(2);
+    expect(after.data.newProspects.value).toBe(3);
     expect(after.data.platformDistribution).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ platform: "Twitter/X", count: 1 }),
-        expect.objectContaining({ platform: "LinkedIn", count: 1 }),
+        expect.objectContaining({ platform: "LinkedIn", count: 2 }),
       ])
     );
     const usageAfter = await owner.query(api.usage.getUsageDashboard, {


### PR DESCRIPTION
## Summary
- gate reporting Aggregate writes until a workspace rollout is actively backfilling, verifying, or verified
- prevent migration preparation repairs from consuming the 16 MiB Convex read budget on Aggregate B-tree maintenance
- retain dual-writes throughout backfill and live reactive writes after verification
- add a regression test proving pre-rollout source writes remain snapshot-only and are captured by the later backfill

## Production context
The first inactive-workspace canary failed safely during preparation before any rollout marker or UI cutover. No workspace is serving incomplete Aggregate data. The failure was the Convex 16 MiB bytes-read limit while repairing legacy agent-memory inventory; this patch removes the premature Aggregate work that caused the amplification.

## Verification
- Prettier 3.8.4 check: pass
- `git diff --check`: pass
- `pnpm lint:strict`: pass
- `pnpm build`: pass
- `pnpm vitest run --config vitest.config.ts --no-file-parallelism`: 118 files / 591 tests pass
- `pnpm convex dev --once`: deployment and Convex typecheck pass
- targeted Aggregate migration integration test: pass
- CodeRabbit CLI review: 0 findings

No production migration will be retried until this PR is deployed.