### PR TITLE
fix(reporting): repair analytics before aggregate rollout

### DIFF
--- a/convex/workspaceReportingAggregate.integration.test.ts
+++ b/convex/workspaceReportingAggregate.integration.test.ts
@@ -232,4 +232,100 @@ describe("workspace reporting Aggregate", () => {
       expect.objectContaining({ workspaceId: seeded.workspaceId, used: 2 }),
     ]);
   });
+
+  test("rebuilds stale analytics before the Aggregate migration", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.UTC(2026, 7, 30, 12, 30));
+    const t = convexTest({ schema, modules, transactionLimits: true });
+    await registerPolar(t);
+
+    const seeded = await t.run(async (ctx) => {
+      const userId = await ctx.db.insert("users", {
+        workosUserId: "reporting-stale-analytics-owner",
+        email: "reporting-stale-analytics@example.com",
+      });
+      const workspaceId = await ctx.db.insert("workspaces", {
+        userId,
+        name: "Stale analytics reporting",
+        description: "Paused stale analytics migration fixture",
+        isDefault: true,
+        setupCompletedAt: getCurrentUTCTimestamp(),
+        prospectingWorkflowStatus: "paused",
+        updatedAt: getCurrentUTCTimestamp(),
+      });
+      const firstProspectId = await ctx.db.insert("prospects", {
+        workspaceId,
+        userId,
+        platform: "twitter",
+        origin: "workspace_discovery",
+        externalId: "reporting-stale-first",
+        data: {},
+        status: "new",
+        qualificationStatus: "disqualified",
+        qualificationScore: 45,
+        disqualifiedAt: getCurrentUTCTimestamp(),
+        updatedAt: getCurrentUTCTimestamp(),
+      });
+      await ctx.db.insert("prospects", {
+        workspaceId,
+        userId,
+        platform: "twitter",
+        origin: "workspace_discovery",
+        externalId: "reporting-stale-second",
+        data: {},
+        status: "new",
+        qualificationStatus: "disqualified",
+        qualificationScore: 45,
+        disqualifiedAt: getCurrentUTCTimestamp(),
+        updatedAt: getCurrentUTCTimestamp(),
+      });
+
+      const firstProspect = await ctx.db.get("prospects", firstProspectId);
+      if (!firstProspect) throw new Error("Failed to seed stale prospect");
+      for (const targeted of getWorkspaceAnalyticsContributionsFromProspect(
+        firstProspect
+      )) {
+        await ctx.db.insert(
+          "workspaceAnalyticsDaily",
+          mergeWorkspaceAnalyticsContributions(null, {
+            workspaceId,
+            dayStartUtcMs: targeted.dayStartUtcMs,
+            add: [targeted.contribution],
+          })
+        );
+      }
+
+      return { workspaceId };
+    });
+
+    const analyticsRebuilt = await t.action(
+      internal.workspaceAnalyticsDaily.rebuildWorkspaceAnalyticsDailyInternal,
+      { workspaceId: seeded.workspaceId }
+    );
+    expect(analyticsRebuilt).toMatchObject({
+      prospectsProcessed: 2,
+    });
+
+    const migration = await t.mutation(startMigration, {
+      workspaceId: seeded.workspaceId,
+      batchSize: 2,
+    });
+
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    const rollout = await t.run((ctx) =>
+      ctx.db.get("workspaceReportingRollouts", migration.rolloutId)
+    );
+    expect(rollout).toMatchObject({
+      status: "verified",
+      expectedQualifiedUsageCount: 0,
+      aggregateQualifiedUsageCount: 0,
+    });
+    expect(rollout?.expectedAnalyticsSums).toEqual(
+      rollout?.aggregateAnalyticsSums
+    );
+    expect(rollout?.aggregateAnalyticsSums?.[0]).toBe(2);
+    expect(rollout?.aggregateAnalyticsSums?.[4]).toBe(2);
+    expect(rollout?.aggregateAnalyticsSums?.[9]).toBe(2);
+    expect(rollout?.aggregateAnalyticsSums?.[11]).toBe(2);
+  });
 });

--- a/convex/workspaceReportingMigration.ts
+++ b/convex/workspaceReportingMigration.ts
@@ -196,9 +196,10 @@ export const startWorkspaceMigrationInternal = internalMutation({
 });
 
 /**
- * Repairs the memory inventory mirror and rebuilds the current Agent Ops read
- * model before starting the exact Aggregate migration. Operators should use
- * this entry point; the mutation above remains the resumable/testable core.
+ * Repairs the memory inventory mirror and rebuilds the current Analytics and
+ * Agent Ops read models before starting the exact Aggregate migration.
+ * Operators should use this entry point; the mutation above remains the
+ * resumable/testable core.
  */
 export const prepareAndStartWorkspaceMigrationInternal = internalAction({
   args: {
@@ -219,6 +220,13 @@ export const prepareAndStartWorkspaceMigrationInternal = internalAction({
       scanned: number;
       inserted: number;
       existing: number;
+    } | null;
+    analyticsReadModelRebuild: {
+      analyticsRowsRebuilt: number;
+      prospectsProcessed: number;
+      activityLogsProcessed: number;
+      plansProcessed: number;
+      tasksProcessed: number;
     } | null;
     agentOpsReadModelRebuild: {
       agentOpsRowsRebuilt: number;
@@ -250,6 +258,7 @@ export const prepareAndStartWorkspaceMigrationInternal = internalAction({
         alreadyActive: true,
         prepared: false,
         inventoryBackfill: null,
+        analyticsReadModelRebuild: null,
         agentOpsReadModelRebuild: null,
       };
     }
@@ -258,7 +267,11 @@ export const prepareAndStartWorkspaceMigrationInternal = internalAction({
       internal.memory.backfillWorkspaceAgentMemoryInventoryInternal,
       { workspaceId: args.workspaceId, userId: workspace.userId }
     );
-    const rebuilt = await ctx.runAction(
+    const analyticsRebuilt = await ctx.runAction(
+      internal.workspaceAnalyticsDaily.rebuildWorkspaceAnalyticsDailyInternal,
+      { workspaceId: args.workspaceId }
+    );
+    const agentOpsRebuilt = await ctx.runAction(
       internal.agentOpsReadModels.rebuildWorkspaceAgentOpsReadModelsInternal,
       { workspaceId: args.workspaceId }
     );
@@ -271,9 +284,17 @@ export const prepareAndStartWorkspaceMigrationInternal = internalAction({
       ...migration,
       prepared: true,
       inventoryBackfill,
+      analyticsReadModelRebuild: {
+        analyticsRowsRebuilt: analyticsRebuilt.analyticsRowsRebuilt,
+        prospectsProcessed: analyticsRebuilt.prospectsProcessed,
+        activityLogsProcessed: analyticsRebuilt.activityLogsProcessed,
+        plansProcessed: analyticsRebuilt.plansProcessed,
+        tasksProcessed: analyticsRebuilt.tasksProcessed,
+      },
       agentOpsReadModelRebuild: {
-        agentOpsRowsRebuilt: rebuilt.agentOpsRowsRebuilt,
-        queryPerformanceRowsRebuilt: rebuilt.queryPerformanceRowsRebuilt,
+        agentOpsRowsRebuilt: agentOpsRebuilt.agentOpsRowsRebuilt,
+        queryPerformanceRowsRebuilt:
+          agentOpsRebuilt.queryPerformanceRowsRebuilt,
       },
     };
   },


### PR DESCRIPTION
## Summary
- rebuild the canonical Analytics daily read model during reporting migration preparation, alongside the existing Agent Ops rebuild
- report Analytics rebuild counts in the operator result
- add a production-shaped regression proving stale Analytics is repaired before exact Aggregate verification

## Production finding
After 23 workspaces verified successfully, a small inactive workspace failed safely because its legacy Analytics daily rows were stale: raw source had 6 Twitter/disqualified prospects, while the snapshot had only 1. Aggregate matched the raw source exactly; Agent Ops and Usage also matched. The failed rollout remains snapshot-only.

The existing paginated `rebuildWorkspaceAnalyticsDailyInternal` is the canonical repair path. This PR makes it a required preparation step so operators do not need workspace-specific manual repairs.

## Verification
- Prettier 3.8.4: pass
- `git diff --check`: pass
- `pnpm lint:strict`: pass
- `pnpm build`: pass
- `pnpm vitest run --config vitest.config.ts --no-file-parallelism`: 118 files / 592 tests pass
- targeted reporting Aggregate integration tests: 2 pass
- `pnpm convex dev --once`: deployment and Convex typecheck pass
- CodeRabbit CLI: 0 findings

Production rollout is paused until this is deployed.