### PR TITLE
fix(reporting): reconcile memory inventory mirrors

### DIFF
--- a/convex/lib/agentMemoryCore.ts
+++ b/convex/lib/agentMemoryCore.ts
@@ -819,6 +819,17 @@ export async function ensureWorkspaceAgentMemoryInventoryRecord(
     return false;
   }
 
+  await insertWorkspaceAgentMemoryInventoryRecord(db, args);
+  return true;
+}
+
+async function insertWorkspaceAgentMemoryInventoryRecord(
+  db: MemoryDbWriter,
+  args: {
+    workspaceId: Id<"workspaces">;
+    record: WorkspaceAgentMemoryInventoryRecord;
+  }
+) {
   const prospectId = args.record.prospectId
     ? (db.normalizeId("prospects", args.record.prospectId) ?? undefined)
     : undefined;
@@ -838,8 +849,6 @@ export async function ensureWorkspaceAgentMemoryInventoryRecord(
     evidenceCount: args.record.evidenceCount,
     prospectId,
   });
-
-  return true;
 }
 
 export async function ensureWorkspaceAgentMemoryInventoryRecords(
@@ -849,22 +858,77 @@ export async function ensureWorkspaceAgentMemoryInventoryRecords(
     records: WorkspaceAgentMemoryInventoryRecord[];
   }
 ): Promise<{ inserted: number; existing: number }> {
+  const existingRows = await Promise.all(
+    args.records.map((record) =>
+      db
+        .query("workspaceAgentMemoryInventory")
+        .withIndex("by_memory_id", (q) => q.eq("memoryId", record.memoryId))
+        .first()
+    )
+  );
   let inserted = 0;
   let existing = 0;
+  const seenMemoryIds = new Set<string>();
 
-  for (const record of args.records) {
-    const created = await ensureWorkspaceAgentMemoryInventoryRecord(db, {
+  for (const [index, record] of args.records.entries()) {
+    if (existingRows[index] || seenMemoryIds.has(record.memoryId)) {
+      existing += 1;
+      continue;
+    }
+    seenMemoryIds.add(record.memoryId);
+    await insertWorkspaceAgentMemoryInventoryRecord(db, {
       workspaceId: args.workspaceId,
       record,
     });
-    if (created) {
-      inserted += 1;
-    } else {
-      existing += 1;
-    }
+    inserted += 1;
   }
 
   return { inserted, existing };
+}
+
+export async function reconcileWorkspaceAgentMemoryInventoryPage(
+  db: MemoryDbWriter,
+  args: {
+    workspaceId: Id<"workspaces">;
+    cursor: string | null;
+    limit: number;
+  }
+): Promise<{
+  continueCursor: string;
+  isDone: boolean;
+  scanned: number;
+  deleted: number;
+  deletedMemoryIds: string[];
+}> {
+  const page = await db
+    .query("workspaceAgentMemoryInventory")
+    .withIndex("by_workspace_created_at", (q) =>
+      q.eq("workspaceId", args.workspaceId)
+    )
+    .paginate({
+      cursor: args.cursor,
+      numItems: Math.max(1, args.limit),
+    });
+  const sourceRows = await Promise.all(
+    page.page.map((row) => getBuiltInAgentMemoryRowById(db, row.memoryId))
+  );
+  const deletedMemoryIds: string[] = [];
+
+  for (const [index, row] of page.page.entries()) {
+    if (sourceRows[index]) {
+      continue;
+    }
+    await db.delete(row._id);
+    deletedMemoryIds.push(row.memoryId);
+  }
+
+  return {
+    continueCursor: page.continueCursor,
+    isDone: page.isDone,
+    scanned: page.page.length,
+    deleted: deletedMemoryIds.length,
+    deletedMemoryIds,
+  };
 }
 
 export async function listWorkspaceAgentMemoryInventoryInWindow(

--- a/convex/memory.ts
+++ b/convex/memory.ts
@@ -1,4 +1,5 @@
 import { v } from "convex/values";
+import { paginationOptsValidator } from "convex/server";
 import type { Doc, Id } from "./_generated/dataModel";
 import type { ActionCtx as ConvexActionCtx } from "./_generated/server";
 import { internal } from "./_generated/api";
@@ -34,6 +35,7 @@ import {
   listWorkspaceAgentMemoriesByCategory,
   listWorkspaceAgentMemoriesBySource,
   promoteAgentMemory,
+  reconcileWorkspaceAgentMemoryInventoryPage,
   type ParsedAgentMemory,
   type WorkspaceMemoryCategory,
   type WorkspaceMemorySource,
@@ -85,6 +87,8 @@ const MAX_LIST_LIMIT = 200;
 const DISCOVERY_CONTEXT_LIMIT = 6;
 const DISCOVERY_SEMANTIC_DUPLICATE_THRESHOLD = 0.92;
 const MEMORY_INVENTORY_BACKFILL_PAGE_SIZE = 100;
+const MEMORY_INVENTORY_RECONCILIATION_PAGE_SIZE = 100;
+const MAX_REPORTED_ORPHANED_MEMORY_IDS = 100;
 const memoryLogger = logger.withScope("Memory");
 
 type WorkspaceSemanticMatch = {
@@ -741,6 +745,65 @@ export const ensureWorkspaceAgentMemoryInventoryBatchInternal =
       });
     },
   });
+
+export const reconcileWorkspaceAgentMemoryInventoryBatchInternal =
+  internalMutation({
+    args: {
+      workspaceId: v.id("workspaces"),
+      paginationOpts: paginationOptsValidator,
+    },
+    handler: async (ctx, args) => {
+      return await reconcileWorkspaceAgentMemoryInventoryPage(ctx.db, {
+        workspaceId: args.workspaceId,
+        cursor: args.paginationOpts.cursor,
+        limit: args.paginationOpts.numItems,
+      });
+    },
+  });
+
+export const reconcileWorkspaceAgentMemoryInventoryInternal = internalAction({
+  args: {
+    workspaceId: v.id("workspaces"),
+  },
+  handler: async (ctx, args) => {
+    let cursor: string | null = null;
+    let scanned = 0;
+    let deleted = 0;
+    const deletedMemoryIds: string[] = [];
+
+    while (true) {
+      const result: {
+        continueCursor: string;
+        isDone: boolean;
+        scanned: number;
+        deleted: number;
+        deletedMemoryIds: string[];
+      } = await ctx.runMutation(
+        internal.memory.reconcileWorkspaceAgentMemoryInventoryBatchInternal,
+        {
+          workspaceId: args.workspaceId,
+          paginationOpts: {
+            cursor,
+            numItems: MEMORY_INVENTORY_RECONCILIATION_PAGE_SIZE,
+          },
+        }
+      );
+      scanned += result.scanned;
+      deleted += result.deleted;
+      deletedMemoryIds.push(
+        ...result.deletedMemoryIds.slice(
+          0,
+          MAX_REPORTED_ORPHANED_MEMORY_IDS - deletedMemoryIds.length
+        )
+      );
+
+      if (result.isDone) {
+        return { scanned, deleted, deletedMemoryIds };
+      }
+      cursor = result.continueCursor;
+    }
+  },
+});
 
 export const backfillWorkspaceAgentMemoryInventoryInternal = internalAction({
   args: {

--- a/convex/workspaceMemory.integration.test.ts
+++ b/convex/workspaceMemory.integration.test.ts
@@ -45,6 +45,60 @@ describe("canonical workspace memory", () => {
     ).toEqual(["operator_instruction"]);
   });
 
+  test("reconciles orphaned inventory rows without deleting valid memories", async () => {
+    const t = convexTest(schema, modules);
+    const seeded = await seedWorkspace(t);
+
+    const valid = await t.run(async (ctx) => {
+      const promoted = await promoteAgentMemory(ctx.db, {
+        userId: String(seeded.userId),
+        workspaceId: String(seeded.workspaceId),
+        source: "qualification",
+        category: "qualification_win_pattern",
+        namespace: "wins",
+        title: "Valid memory",
+        summary: "This memory still has a source record.",
+        confidence: 0.9,
+        impactScore: 0.8,
+      });
+      await ctx.db.insert("workspaceAgentMemoryInventory", {
+        workspaceId: seeded.workspaceId,
+        memoryId: "missing-agent-memory",
+        createdAt: 2,
+        createdDayStartUtcMs: 0,
+        title: "Orphaned memory",
+        summary: "Its Agent memory no longer exists.",
+        source: "style_analysis",
+        category: "writing_style_profile_twitter",
+        confidence: 0.96,
+        impactScore: 0.95,
+        relatedQueriesCount: 0,
+        evidenceCount: 0,
+      });
+      return promoted.memoryId;
+    });
+
+    const reconciliation = await t.action(
+      internal.memory.reconcileWorkspaceAgentMemoryInventoryInternal,
+      { workspaceId: seeded.workspaceId }
+    );
+    expect(reconciliation).toEqual({
+      scanned: 2,
+      deleted: 1,
+      deletedMemoryIds: ["missing-agent-memory"],
+    });
+
+    const remaining = await t.run((ctx) =>
+      ctx.db
+        .query("workspaceAgentMemoryInventory")
+        .withIndex("by_workspace_created_at", (q) =>
+          q.eq("workspaceId", seeded.workspaceId)
+        )
+        .collect()
+    );
+    expect(remaining.map((row) => row.memoryId)).toEqual([valid]);
+  });
+
   test("is idempotent and a newer correction supersedes the prior value", async () => {
     const t = convexTest(schema, modules);
     const seeded = await seedWorkspace(t);
@@ -175,20 +229,21 @@ describe("canonical workspace memory", () => {
     const t = convexTest(schema, modules);
     const seeded = await seedWorkspace(t);
 
-    const canonical = await t.run(async (ctx) =>
-      await upsertCanonicalWorkspaceMemory(ctx.db, {
-        ...seeded,
-        legacyMemoryId: "legacy-component-memory-id",
-        source: "qualification",
-        category: "qualification_win_pattern",
-        namespace: "wins",
-        kind: "qualification_pattern",
-        title: "Verified hiring signal",
-        summary: "Prioritize direct evidence of active hiring.",
-        canonicalContent: "Prioritize direct evidence of active hiring.",
-        confidence: 0.9,
-        impactScore: 0.8,
-      })
+    const canonical = await t.run(
+      async (ctx) =>
+        await upsertCanonicalWorkspaceMemory(ctx.db, {
+          ...seeded,
+          legacyMemoryId: "legacy-component-memory-id",
+          source: "qualification",
+          category: "qualification_win_pattern",
+          namespace: "wins",
+          kind: "qualification_pattern",
+          title: "Verified hiring signal",
+          summary: "Prioritize direct evidence of active hiring.",
+          canonicalContent: "Prioritize direct evidence of active hiring.",
+          confidence: 0.9,
+          impactScore: 0.8,
+        })
     );
     const resolved = await t.query(
       internal.memory.getCanonicalWorkspaceMemoriesByIdsInternal,

--- a/convex/workspaceReportingMigration.ts
+++ b/convex/workspaceReportingMigration.ts
@@ -499,6 +499,11 @@ export const prepareAndStartWorkspaceMigrationInternal = internalAction({
       inserted: number;
       existing: number;
     } | null;
+    inventoryReconciliation: {
+      scanned: number;
+      deleted: number;
+      deletedMemoryIds: string[];
+    } | null;
     analyticsReadModelRebuild: {
       analyticsRowsRebuilt: number;
       prospectsProcessed: number;
@@ -536,11 +541,16 @@ export const prepareAndStartWorkspaceMigrationInternal = internalAction({
         alreadyActive: true,
         prepared: false,
         inventoryBackfill: null,
+        inventoryReconciliation: null,
         analyticsReadModelRebuild: null,
         agentOpsReadModelRebuild: null,
       };
     }
 
+    const inventoryReconciliation = await ctx.runAction(
+      internal.memory.reconcileWorkspaceAgentMemoryInventoryInternal,
+      { workspaceId: args.workspaceId }
+    );
     const inventoryBackfill = await ctx.runAction(
       internal.memory.backfillWorkspaceAgentMemoryInventoryInternal,
       { workspaceId: args.workspaceId, userId: workspace.userId }
@@ -564,6 +574,7 @@ export const prepareAndStartWorkspaceMigrationInternal = internalAction({
         alreadyActive: true,
         prepared: false,
         inventoryBackfill: null,
+        inventoryReconciliation: null,
         analyticsReadModelRebuild: null,
         agentOpsReadModelRebuild: null,
       };
@@ -591,6 +602,7 @@ export const prepareAndStartWorkspaceMigrationInternal = internalAction({
       alreadyActive: false,
       prepared: true,
       inventoryBackfill,
+      inventoryReconciliation,
       analyticsReadModelRebuild: {
         analyticsRowsRebuilt: rebuilt.analytics.analyticsRowsRebuilt,
         prospectsProcessed: rebuilt.analytics.prospectsProcessed,


### PR DESCRIPTION
## Summary
- reconcile workspace memory inventory against Convex Agent memory source records before reporting migration
- delete only proven orphaned mirror rows and retain valid source-backed rows
- parallelize inventory existence checks to avoid large-workspace preparation timeouts
- report bounded reconciliation diagnostics and add regression coverage

## Production diagnosis
- exact scan: 11,093 inventory rows
- one orphan found: old X Writing Style Profile mirror (`ss737wd4dhjtt74kt9jp92vryd8dbhvb`)
- its missing source record exactly explains the Agent Ops parity delta

## Verification
- Prettier: passed
- TypeScript: passed
- strict lint: passed
- focused memory/reporting tests: 17/17 passed
- full Convex suite: 118 files, 595 tests passed sequentially
- production Next.js build: passed
- Convex dev deploy/typecheck: passed
- CodeRabbit: 0 issues