### PR TITLE
Fix realtime Usage while a workspace is deleting

### DIFF
--- a/convex/lib/workspaceSetup.ts
+++ b/convex/lib/workspaceSetup.ts
@@ -8,6 +8,8 @@ type WorkspaceSetupCompletionFields = Pick<
   Doc<"workspaces">,
   "setupCompletedAt"
 >;
+type ReportableWorkspaceFields = WorkspaceSetupCompletionFields &
+  Pick<Doc<"workspaces">, "deletionWorkflowId">;
 
 type WorkspaceWithRequiredAgentData<T extends WorkspaceAgentSetupFields> = T & {
   improvedDescription: string;
@@ -32,6 +34,14 @@ export function filterCompletedWorkspaces<
   return workspaces.filter(
     (workspace): workspace is WorkspaceWithCompletedSetup<T> =>
       isWorkspaceSetupCompleted(workspace)
+  );
+}
+
+export function filterReportableWorkspaces<T extends ReportableWorkspaceFields>(
+  workspaces: readonly T[]
+): Array<WorkspaceWithCompletedSetup<T>> {
+  return filterCompletedWorkspaces(workspaces).filter(
+    (workspace) => workspace.deletionWorkflowId === undefined
   );
 }
 

--- a/convex/usage.ts
+++ b/convex/usage.ts
@@ -24,7 +24,7 @@ import {
   sortUsageWorkspaceRows,
 } from "./lib/usageDashboardCore";
 import { getUserFromIdentity } from "./lib/userUtils";
-import { filterCompletedWorkspaces } from "./lib/workspaceSetup";
+import { filterReportableWorkspaces } from "./lib/workspaceSetup";
 import { shouldCountQualifiedProspectUsageInWindow } from "./lib/planQualifiedUsageCore";
 import type { UserPlan } from "./lib/planConstants";
 import { getWorkspaceReportingMetricSums } from "./lib/workspaceReportingAggregate";
@@ -129,7 +129,7 @@ export const getUsageDashboardSnapshot = action({
       tier: context.plan.tier,
       subscription: context.subscription,
     });
-    const completedWorkspaces = filterCompletedWorkspaces(context.workspaces);
+    const completedWorkspaces = filterReportableWorkspaces(context.workspaces);
     const cycleOptions = dedupeUsageCycleWindows([
       { ...currentWindow, isCurrent: true },
       ...context.cycleRows.map((row) => ({
@@ -284,7 +284,7 @@ export const getUsageDashboard = query({
       tier: plan.tier,
       subscription,
     });
-    const completedWorkspaces = filterCompletedWorkspaces(workspaces);
+    const completedWorkspaces = filterReportableWorkspaces(workspaces);
     const reportingReady = await Promise.all(
       completedWorkspaces.map((workspace) =>
         isWorkspaceReportingAggregateReady(ctx.db, workspace._id)

--- a/convex/workspaceReporting.ts
+++ b/convex/workspaceReporting.ts
@@ -4,7 +4,7 @@ import { requireOwnedWorkspace, requireUser } from "./lib/accessHelpers";
 import { getWorkspaceReportingRollout } from "./lib/workspaceReportingRollout";
 import { WORKSPACE_REPORTING_AGGREGATE_VERSION } from "./lib/workspaceReportingAggregate";
 import { getUserByIdentity } from "./lib/accessHelpers";
-import { filterCompletedWorkspaces } from "./lib/workspaceSetup";
+import { filterReportableWorkspaces } from "./lib/workspaceSetup";
 
 export const getWorkspaceReportingStatus = query({
   args: { workspaceId: v.id("workspaces") },
@@ -39,7 +39,7 @@ export const getUserWorkspaceReportingStatus = query({
     if (!identity) return { ready: false, workspaceCount: 0 };
     const user = await getUserByIdentity(ctx, identity);
     if (!user) return { ready: false, workspaceCount: 0 };
-    const workspaces = filterCompletedWorkspaces(
+    const workspaces = filterReportableWorkspaces(
       await ctx.db
         .query("workspaces")
         .withIndex("by_user_id", (q) => q.eq("userId", user._id))

--- a/convex/workspaceReportingAggregate.integration.test.ts
+++ b/convex/workspaceReportingAggregate.integration.test.ts
@@ -64,6 +64,16 @@ describe("workspace reporting Aggregate", () => {
         prospectingWorkflowStatus: "paused",
         updatedAt: getCurrentUTCTimestamp(),
       });
+      await ctx.db.insert("workspaces", {
+        userId,
+        name: "Deleting workspace",
+        description: "Should not block account-wide realtime reporting",
+        isDefault: false,
+        setupCompletedAt: getCurrentUTCTimestamp(),
+        deletionWorkflowId: "deleting-workspace-workflow",
+        deletionStartedAt: getCurrentUTCTimestamp(),
+        updatedAt: getCurrentUTCTimestamp(),
+      });
       await ctx.db.insert("userPlans", {
         userId,
         tier: "pro",
@@ -172,6 +182,9 @@ describe("workspace reporting Aggregate", () => {
     });
 
     const owner = t.withIdentity({ subject: "reporting-aggregate-owner" });
+    await expect(
+      owner.query(api.workspaceReporting.getUserWorkspaceReportingStatus, {})
+    ).resolves.toEqual({ ready: true, workspaceCount: 1 });
     const queryArgs = {
       workspaceId: seeded.workspaceId,
       range: "7d" as const,


### PR DESCRIPTION
## Summary
- exclude deleting workspaces from the account-wide realtime reporting readiness gate
- exclude deleting workspaces from both reactive and snapshot Usage data
- add a regression proving a deleting workspace cannot block realtime Usage or appear in Usage rows

## Why
The production rollout verified all 31 non-deleting workspaces, but the one workspace already in durable deletion was still counted by Usage readiness. That kept account-wide Usage on the snapshot path even though the workspace is hidden everywhere else.

## Verification
- Prettier 3.8.4 check: pass
- focused workspace reporting integration: 4/4 pass
- full Convex suite: 118 files, 595 tests pass
- TypeScript: pass
- strict oxlint: pass
- production Next.js build: pass
- Convex dev deploy/typecheck: pass
- CodeRabbit CLI: 0 issues
- production migration audit: 31/31 non-deleting workspaces verified; exact final-workspace Analytics, Agent Ops, and Usage parity