### PR TITLE
Improve prospect platform avatar badges

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -40,6 +40,15 @@
   --color-input: hsl(var(--input));
   --color-ring: hsl(var(--ring));
 
+  --color-platform-twitter-badge: hsl(var(--platform-twitter-badge));
+  --color-platform-twitter-badge-foreground: hsl(
+    var(--platform-twitter-badge-foreground)
+  );
+  --color-platform-linkedin-badge: hsl(var(--platform-linkedin-badge));
+  --color-platform-linkedin-badge-foreground: hsl(
+    var(--platform-linkedin-badge-foreground)
+  );
+
   --color-chart-1: hsl(var(--chart-1));
   --color-chart-2: hsl(var(--chart-2));
   --color-chart-3: hsl(var(--chart-3));
@@ -233,6 +242,10 @@
     --border: 0 0% 89.8%;
     --input: 0 0% 89.8%;
     --ring: 0 0% 3.9%;
+    --platform-twitter-badge: 82.712 77.974% 55.49%;
+    --platform-twitter-badge-foreground: 0 0% 9%;
+    --platform-linkedin-badge: 172.455 66.008% 50.392%;
+    --platform-linkedin-badge-foreground: 0 0% 9%;
     --chart-1: 0 0% 9%;
     --chart-2: 0 0% 35%;
     --chart-3: 0 0% 55%;
@@ -271,6 +284,10 @@
     --border: 0 0% 14.9%;
     --input: 0 0% 14.9%;
     --ring: 0 0% 83.1%;
+    --platform-twitter-badge: 81.972 84.524% 67.059%;
+    --platform-twitter-badge-foreground: 0 0% 9%;
+    --platform-linkedin-badge: 170.571 76.923% 64.314%;
+    --platform-linkedin-badge-foreground: 0 0% 9%;
     --chart-1: 0 0% 98%;
     --chart-2: 0 0% 75%;
     --chart-3: 0 0% 55%;

--- a/shared/ui/components/ProspectPlatformAvatar.tsx
+++ b/shared/ui/components/ProspectPlatformAvatar.tsx
@@ -11,17 +11,53 @@ export type ProspectPlatform = "twitter" | "linkedin";
 
 /**
  * Shell diameters stay fixed (~30–35% of parent avatar in Figma). xs/sm/md use a
- * larger icon asset clipped to the same disc (`overflow-hidden`) so the glyph
- * reads bigger without growing the badge circle.
+ * larger icon asset clipped to the same tile (`overflow-hidden`) so the glyph
+ * reads bigger without growing the badge tile.
  */
 const BADGE: Record<
   "xs" | "sm" | "md" | "lg",
-  { shell: string; icon: string; clipIcon: boolean }
+  { shell: string; icon: string; radius: string; clipIcon: boolean }
 > = {
-  xs: { shell: "size-2", icon: "size-2.5", clipIcon: true },
-  sm: { shell: "size-[11px]", icon: "size-2.5", clipIcon: true },
-  md: { shell: "size-[13px]", icon: "size-2.5", clipIcon: true },
-  lg: { shell: "size-4", icon: "size-3", clipIcon: false },
+  xs: {
+    shell: "size-2",
+    icon: "size-2.5",
+    radius: "rounded-[2px]",
+    clipIcon: true,
+  },
+  sm: {
+    shell: "size-[11px]",
+    icon: "size-2.5",
+    radius: "rounded-[3px]",
+    clipIcon: true,
+  },
+  md: {
+    shell: "size-[13px]",
+    icon: "size-2.5",
+    radius: "rounded-[3px]",
+    clipIcon: true,
+  },
+  lg: {
+    shell: "size-4",
+    icon: "size-3",
+    radius: "rounded-[4px]",
+    clipIcon: false,
+  },
+};
+
+const PLATFORM_BADGE: Record<
+  ProspectPlatform,
+  { className: string; label: string }
+> = {
+  twitter: {
+    className:
+      "bg-platform-twitter-badge text-platform-twitter-badge-foreground",
+    label: "Found on X/Twitter",
+  },
+  linkedin: {
+    className:
+      "bg-platform-linkedin-badge text-platform-linkedin-badge-foreground",
+    label: "Found on LinkedIn",
+  },
 };
 
 export interface ProspectPlatformAvatarProps {
@@ -32,7 +68,7 @@ export interface ProspectPlatformAvatarProps {
   children: React.ReactNode;
 }
 
-/** Theme tokens only: `bg-muted` + `ring-border` on the disc, `ring-background` halo, `foreground` icons. */
+/** Platform-branded tile separated from the avatar by a surface-colored halo. */
 export function ProspectPlatformAvatar({
   platform,
   badgeIcon,
@@ -41,33 +77,35 @@ export function ProspectPlatformAvatar({
   children,
 }: ProspectPlatformAvatarProps) {
   const b = BADGE[badgeSize];
+  const platformBadge = platform ? PLATFORM_BADGE[platform] : null;
 
   return (
     <div className={cn("relative inline-flex shrink-0", className)}>
       {children}
-      {platform ? (
+      {platform && platformBadge ? (
         <span
           className={cn(
-            "ring-background absolute -right-0.5 -bottom-0.5 rounded-full ring-[3px]"
+            "ring-background absolute -right-0.5 -bottom-0.5 ring-[3px]",
+            b.radius
           )}
-          aria-hidden
+          role="img"
+          aria-label={platformBadge.label}
+          title={platformBadge.label}
         >
           <span
             className={cn(
-              "bg-muted ring-muted flex items-center justify-center rounded-full ring-1",
+              "flex items-center justify-center",
+              platformBadge.className,
               b.clipIcon && "overflow-hidden",
-              b.shell
+              b.shell,
+              b.radius
             )}
           >
             {badgeIcon ??
               (platform === "twitter" ? (
-                <FilledTwitterIcon
-                  className={cn("text-foreground shrink-0", b.icon)}
-                />
+                <FilledTwitterIcon className={cn("shrink-0", b.icon)} />
               ) : (
-                <FilledLinkedinIcon
-                  className={cn("text-foreground shrink-0", b.icon)}
-                />
+                <FilledLinkedinIcon className={cn("shrink-0", b.icon)} />
               ))}
           </span>
         </span>


### PR DESCRIPTION
## Summary
- distinguish X/Twitter and LinkedIn prospects with vivid semantic badge colors
- use lime for X/Twitter and teal for LinkedIn with near-black icons in both themes
- switch the shared badge to a subtly rounded square while preserving the background-matched halo
- apply the treatment through the shared avatar component across prospect cards, conversation panels, and related views

## Verification
- `npx prettier --check app/globals.css shared/ui/components/ProspectPlatformAvatar.tsx`
- `npm run lint:strict`
- `npx tsc --noEmit`
- `npx -y react-doctor@latest . --verbose --scope changed --base origin/main` (100/100)
- `npm run build`
- browser-verified light and dark rendered colors, icon contrast, rounded-square geometry, and surface halo