### PR TITLE
Fix X/Twitter DM eligibility handling

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -275,6 +275,7 @@ import type * as lib_xChatSendCore from "../lib/xChatSendCore.js";
 import type * as lib_xConnectionStateCore from "../lib/xConnectionStateCore.js";
 import type * as lib_xConversationDiscoveryCore from "../lib/xConversationDiscoveryCore.js";
 import type * as lib_xDm from "../lib/xDm.js";
+import type * as lib_xDmEligibilityCore from "../lib/xDmEligibilityCore.js";
 import type * as lib_xPostLimits from "../lib/xPostLimits.js";
 import type * as lib_xScopes from "../lib/xScopes.js";
 import type * as lib_xdkAuth from "../lib/xdkAuth.js";
@@ -650,6 +651,7 @@ declare const fullApi: ApiFromModules<{
   "lib/xConnectionStateCore": typeof lib_xConnectionStateCore;
   "lib/xConversationDiscoveryCore": typeof lib_xConversationDiscoveryCore;
   "lib/xDm": typeof lib_xDm;
+  "lib/xDmEligibilityCore": typeof lib_xDmEligibilityCore;
   "lib/xPostLimits": typeof lib_xPostLimits;
   "lib/xScopes": typeof lib_xScopes;
   "lib/xdkAuth": typeof lib_xdkAuth;

--- a/convex/agents/outreach/tools/generatePlan.ts
+++ b/convex/agents/outreach/tools/generatePlan.ts
@@ -31,6 +31,10 @@ import {
   type LinkedInRelationshipStatus,
 } from "../../../lib/linkedinOutreachPlanCore";
 import {
+  getBlockedXDmPlanMessage,
+  hasBlockedImmediateXDmTask,
+} from "../../../lib/xDmEligibilityCore";
+import {
   attachmentRefsSchema,
   resolveTaskAttachmentReferences,
 } from "./attachmentReferences";
@@ -353,6 +357,26 @@ export const generatePlan = createTool({
         }
       }
       const planTasks = constrainedTasks.tasks;
+
+      if (
+        prospectPlatform === "twitter" &&
+        planTasks.some((task) => task.type === "dm")
+      ) {
+        const dmState = await ctx.runAction(
+          internal.x.getProspectDmStateInternal,
+          { userId, prospectId }
+        );
+        if (
+          dmState &&
+          hasBlockedImmediateXDmTask(planTasks, dmState.eligibility)
+        ) {
+          return {
+            success: false,
+            message: getBlockedXDmPlanMessage(dmState.eligibility),
+            error: `X/Twitter DM blocked: ${dmState.eligibility.reasonCode}`,
+          };
+        }
+      }
 
       const canDeferCommentTarget = allowsDeferredNextPostTarget(planTasks);
       const invalidCommentTask = planTasks.find(

--- a/convex/agents/outreach/tools/refinePlan.ts
+++ b/convex/agents/outreach/tools/refinePlan.ts
@@ -34,6 +34,10 @@ import {
   linkedInDmBlockedMessage,
   type LinkedInRelationshipStatus,
 } from "../../../lib/linkedinOutreachPlanCore";
+import {
+  getBlockedXDmPlanMessage,
+  hasBlockedImmediateXDmTask,
+} from "../../../lib/xDmEligibilityCore";
 
 // ============================================================================
 // Schema
@@ -395,6 +399,40 @@ export const refinePlan = createTool({
           }
           const candidateTasks =
             constrainedTasks?.tasks ?? repairedCandidateTasks;
+          const xDmEligibilityTasks =
+            candidateTasks ??
+            existingPlanData?.tasks.filter(
+              (task: Doc<"outreachTasks">) =>
+                task.status !== "completed" && task.status !== "skipped"
+            );
+          if (
+            xDmEligibilityTasks &&
+            prospectPlatform === "twitter" &&
+            existingPlanData &&
+            xDmEligibilityTasks.some((task) => task.type === "dm")
+          ) {
+            const dmState = await measureStage(
+              "x_dm_eligibility",
+              async () =>
+                await ctx.runAction(internal.x.getProspectDmStateInternal, {
+                  userId,
+                  prospectId: existingPlanData.plan.prospectId,
+                })
+            );
+            if (
+              dmState &&
+              hasBlockedImmediateXDmTask(
+                xDmEligibilityTasks,
+                dmState.eligibility
+              )
+            ) {
+              return {
+                success: false,
+                message: getBlockedXDmPlanMessage(dmState.eligibility),
+                error: `X/Twitter DM blocked: ${dmState.eligibility.reasonCode}`,
+              };
+            }
+          }
           const canDeferCommentTarget = candidateTasks
             ? allowsDeferredNextPostTarget(candidateTasks)
             : false;

--- a/convex/agents/outreach/tools/socialAction.ts
+++ b/convex/agents/outreach/tools/socialAction.ts
@@ -22,6 +22,7 @@ import {
   attachmentRefsSchema,
   resolveToolAttachmentMediaInput,
 } from "./attachmentReferences";
+import type { XDmEligibility } from "../../../../shared/lib/twitter/dm";
 
 const internalLinkedInApi = (internal as any).linkedin;
 
@@ -57,6 +58,7 @@ export interface SocialActionToolResult {
   approvalMode?: string;
   riskLevel?: string;
   eligibilityReasonCode?: string;
+  dmEligibility?: XDmEligibility;
   targetTweetId?: string;
   sourcePostRef?: unknown;
   sourcePostSummary?: unknown;

--- a/convex/agents/prompts.ts
+++ b/convex/agents/prompts.ts
@@ -49,6 +49,7 @@ function buildUseCaseContextBlock(useCase: WorkspaceUseCaseDefinition): string {
 ## Vocabulary Rules
 - Use "${terms.entityPlural}" and "${terms.entitySingular}" in user-facing responses instead of default customer-prospecting terms.
 - Keep internal tool names and system identifiers unchanged even if they still say "prospect" or "ICP".
+- Always write "X/Twitter" in user-facing responses. Never shorten the platform name to "X" or "Twitter", including phrases such as "X/Twitter account", "X/Twitter DM", and "X/Twitter Chat".
 - When speaking to the user, make your wording match this workspace's terminology exactly.`;
 }
 
@@ -568,6 +569,9 @@ ${CONVERSATION_MEDIA_LIMITATIONS}
   - Medium-risk actions such as reposts, follows, or LinkedIn reactions create an approval request first.
   - High-risk actions such as replies, new posts, LinkedIn messages, LinkedIn comments, or LinkedIn invitations create a reviewable draft or approval item that must be approved before execution.
 - For X DMs (\`send_dm\` / \`send_dm_in_existing_conversation\`) and LinkedIn messages (\`linkedin_send_message\` / \`linkedin_send_message_existing_conversation\`): include message text and/or \`mediaUrls\` (media-only messages are valid). Do not ask the user for numeric ids when you are already in a prospect thread; the server resolves the recipient from prospect data whenever possible.
+- Treat the structured X/Twitter DM eligibility returned by \`socialAction\`, \`generatePlan\`, or \`refinePlan\` as current platform truth. If a DM is blocked, explain the known reason using the person's name or handle and adjust the approach instead of telling the user to retry.
+- For a blocked new X/Twitter DM, reasonable alternatives include public engagement, a follow request through \`socialAction\`, waiting for the person to follow the connected account back, or switching to an eligible verified account. Following the person does not itself unlock DMs; never promise that it does. Recheck eligibility before a later DM step.
+- These are platform facts, not a scripted workflow. Choose and explain the next step based on the user's goal, the person, and the returned eligibility context. Do not invent a verification requirement unless the reason code is \`subscription_required\`.
 - Only one pending DM draft should exist per person/thread at a time. If \`socialAction\` reports that a pending X or LinkedIn DM draft already exists, ask the user whether they want to replace it.
 - Only set \`replaceExistingPending=true\` on \`socialAction\` after the user explicitly confirms replacing the existing pending DM draft.
 - When a pending social action request already exists and the user explicitly confirms it, call \`approveSocialActionRequest\`.

--- a/convex/lib/xChatProviderErrorCore.test.ts
+++ b/convex/lib/xChatProviderErrorCore.test.ts
@@ -60,4 +60,50 @@ describe("XChat provider error metadata", () => {
       remaining: 39999,
     });
   });
+
+  it("classifies X/Twitter's verification message from a top-level message field", () => {
+    expect(
+      parseXChatProviderError({
+        status: 403,
+        statusText: "Forbidden",
+        headers: new Headers(),
+        rawBody: JSON.stringify({
+          message:
+            "Get verified to message this user. Only verified users can send Direct Message requests to people that don't follow them.",
+        }),
+      })
+    ).toMatchObject({
+      status: 403,
+      code: "subscription_required",
+    });
+  });
+
+  it("classifies a nested recipient-setting restriction without inventing verification", () => {
+    expect(
+      parseXChatProviderError({
+        status: 403,
+        statusText: "Forbidden",
+        headers: new Headers(),
+        rawBody: JSON.stringify({
+          errors: [
+            { message: "This recipient is not accepting message requests." },
+          ],
+        }),
+      })
+    ).toMatchObject({
+      status: 403,
+      code: "recipient_restricted",
+    });
+  });
+
+  it("keeps an unrelated 403 as a provider error", () => {
+    expect(
+      parseXChatProviderError({
+        status: 403,
+        statusText: "Forbidden",
+        headers: new Headers(),
+        rawBody: JSON.stringify({ detail: "Policy denied the request." }),
+      }).code
+    ).toBe("provider_error");
+  });
 });

--- a/convex/lib/xChatProviderErrorCore.ts
+++ b/convex/lib/xChatProviderErrorCore.ts
@@ -3,7 +3,12 @@ import { getCurrentUTCTimestamp } from "../../shared/lib/utils/time/timeUtils";
 
 export type XChatProviderErrorDetails = {
   status: number;
-  code: "rate_limited" | "xchat_access_denied" | "provider_error";
+  code:
+    | "rate_limited"
+    | "xchat_access_denied"
+    | "subscription_required"
+    | "recipient_restricted"
+    | "provider_error";
   message: string;
   retryAt?: number;
   limit?: number;
@@ -20,7 +25,7 @@ function getProviderProblemMessage(rawBody: string): string | undefined {
   try {
     const payload: unknown = JSON.parse(rawBody);
     if (!isRecord(payload)) return undefined;
-    const direct = [payload.detail, payload.title].find(
+    const direct = [payload.detail, payload.title, payload.message].find(
       (value): value is string =>
         typeof value === "string" && value.trim().length > 0
     );
@@ -30,7 +35,7 @@ function getProviderProblemMessage(rawBody: string): string | undefined {
       : undefined;
     const nested =
       firstError &&
-      [firstError.detail, firstError.title].find(
+      [firstError.detail, firstError.title, firstError.message].find(
         (value): value is string =>
           typeof value === "string" && value.trim().length > 0
       );
@@ -70,6 +75,18 @@ export function parseXChatProviderError(args: {
     args.status === 403 &&
     typeof providerMessage === "string" &&
     /developer\s+app.+attached to a project/iu.test(providerMessage);
+  const subscriptionRequired =
+    args.status === 403 &&
+    typeof providerMessage === "string" &&
+    /get verified to message|only verified (?:users|accounts).+(?:direct message|dm|message request)|sign up for (?:twitter blue|x premium)|subscribe to (?:x )?premium.+(?:message|dm)/iu.test(
+      providerMessage
+    );
+  const recipientRestricted =
+    args.status === 403 &&
+    typeof providerMessage === "string" &&
+    /cannot (?:send|message).+(?:this user|recipient)|not accepting (?:new )?(?:direct messages|dm|message requests)|recipient.+does not follow|not allowed to (?:send|message)/iu.test(
+      providerMessage
+    );
   const retryLabel =
     rateLimited && typeof retryAt === "number"
       ? ` Retry after ${new Date(retryAt).toISOString()}.`
@@ -80,11 +97,15 @@ export function parseXChatProviderError(args: {
       ? "rate_limited"
       : xChatAccessDenied
         ? "xchat_access_denied"
-        : "provider_error",
+        : subscriptionRequired
+          ? "subscription_required"
+          : recipientRestricted
+            ? "recipient_restricted"
+            : "provider_error",
     message: rateLimited
-      ? `XChat is temporarily rate limited.${retryLabel}`
+      ? `X/Twitter Chat is temporarily rate limited.${retryLabel}`
       : (providerMessage ??
-        `XChat request failed (${args.status} ${args.statusText}).`),
+        `X/Twitter Chat request failed (${args.status} ${args.statusText}).`),
     ...(rateLimited && typeof retryAt === "number" ? { retryAt } : {}),
     ...(typeof limit === "number" ? { limit } : {}),
     ...(typeof remaining === "number" ? { remaining } : {}),

--- a/convex/lib/xDmEligibilityCore.test.ts
+++ b/convex/lib/xDmEligibilityCore.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildXDmEligibility,
+  getBlockedXDmPlanMessage,
+  hasBlockedImmediateXDmTask,
+} from "./xDmEligibilityCore";
+
+const base = {
+  isConnected: true,
+  recipientDisplayName: "Avery Stone",
+  recipientUsername: "avery",
+  recipientVerified: true,
+  senderUsername: "testing_demo",
+  senderVerified: false,
+};
+
+describe("X/Twitter DM eligibility", () => {
+  it("allows a recipient that X/Twitter says can receive the DM", () => {
+    expect(
+      buildXDmEligibility({ ...base, receivesYourDm: true })
+    ).toMatchObject({
+      enabled: true,
+      reasonCode: "eligible",
+      recipientLabel: "Avery Stone",
+      senderUsername: "@testing_demo",
+      nextSteps: [],
+    });
+  });
+
+  it("names both people when the recipient does not accept the DM", () => {
+    const eligibility = buildXDmEligibility({
+      ...base,
+      receivesYourDm: false,
+    });
+
+    expect(eligibility).toMatchObject({
+      enabled: false,
+      reasonCode: "not_allowed",
+      reasonTitle: "Can't message Avery Stone",
+      nextSteps: expect.arrayContaining([
+        "public_engagement",
+        "wait_for_follow_back",
+        "switch_account",
+      ]),
+    });
+    expect(eligibility.reasonLabel).toContain("@testing_demo");
+    expect(eligibility.reasonLabel).toContain("Avery Stone");
+    expect(eligibility.reasonLabel).not.toContain("This user");
+  });
+
+  it("uses verification copy only for an explicit subscription restriction", () => {
+    const eligibility = buildXDmEligibility({
+      ...base,
+      restriction: "subscription_required",
+    });
+
+    expect(eligibility).toMatchObject({
+      enabled: false,
+      reasonCode: "subscription_required",
+      reasonTitle: "Verification required",
+      nextSteps: ["verify_account", "switch_account", "wait_for_follow_back"],
+    });
+    expect(eligibility.reasonLabel).toContain("verified accounts");
+  });
+
+  it("keeps an explicit provider denial ahead of older positive eligibility", () => {
+    expect(
+      buildXDmEligibility({
+        ...base,
+        receivesYourDm: true,
+        restriction: "not_allowed",
+      })
+    ).toMatchObject({
+      enabled: false,
+      reasonCode: "not_allowed",
+      receivesYourDm: false,
+    });
+  });
+
+  it("keeps an omitted receives_your_dm value unknown instead of false", () => {
+    expect(buildXDmEligibility(base)).toMatchObject({
+      enabled: false,
+      reasonCode: "unknown",
+      reasonTitle: "Can't check X/Twitter DM access",
+      nextSteps: ["recheck_eligibility"],
+    });
+  });
+
+  it.each([
+    [false, undefined, "missing_connection"],
+    [true, ["dm.write"], "missing_scopes"],
+  ] as const)(
+    "reports connection and scope failures before recipient settings",
+    (isConnected, missingScopes, reasonCode) => {
+      expect(
+        buildXDmEligibility({
+          ...base,
+          isConnected,
+          missingScopes: missingScopes ? [...missingScopes] : undefined,
+          receivesYourDm: true,
+        }).reasonCode
+      ).toBe(reasonCode);
+    }
+  );
+
+  it("blocks only immediate DM plan steps and explains that following alone is insufficient", () => {
+    const eligibility = buildXDmEligibility({
+      ...base,
+      receivesYourDm: false,
+    });
+
+    expect(
+      hasBlockedImmediateXDmTask(
+        [{ type: "dm", timing: { type: "immediate" } }],
+        eligibility
+      )
+    ).toBe(true);
+    expect(
+      hasBlockedImmediateXDmTask(
+        [
+          { type: "comment", timing: { type: "immediate" } },
+          { type: "wait", timing: { type: "event" } },
+          { type: "dm", timing: { type: "event" } },
+        ],
+        eligibility
+      )
+    ).toBe(false);
+    expect(getBlockedXDmPlanMessage(eligibility)).toContain(
+      "Following Avery Stone does not unlock DMs unless they follow back"
+    );
+  });
+
+  it.each([
+    [
+      buildXDmEligibility({ ...base, isConnected: false }),
+      "Connect an X/Twitter account",
+    ],
+    [
+      buildXDmEligibility({ ...base, missingScopes: ["dm.write"] }),
+      "Reconnect X/Twitter",
+    ],
+    [buildXDmEligibility(base), "Don't plan an immediate DM"],
+  ])("gives the agent a reason-specific recovery", (eligibility, expected) => {
+    expect(getBlockedXDmPlanMessage(eligibility)).toContain(expected);
+    expect(getBlockedXDmPlanMessage(eligibility)).not.toContain(
+      "switch to an eligible X/Twitter account"
+    );
+  });
+});

--- a/convex/lib/xDmEligibilityCore.ts
+++ b/convex/lib/xDmEligibilityCore.ts
@@ -1,0 +1,145 @@
+import type { XDmEligibility } from "../../shared/lib/twitter/dm";
+
+type XDmEligibilityInput = {
+  isConnected: boolean;
+  missingScopes?: string[];
+  receivesYourDm?: boolean;
+  conversationId?: string;
+  recipientDisplayName?: string;
+  recipientUsername?: string;
+  recipientVerified?: boolean;
+  senderUsername?: string;
+  senderVerified?: boolean;
+  restriction?: "subscription_required" | "not_allowed";
+};
+
+function formatHandle(username?: string): string | undefined {
+  const normalized = username?.trim().replace(/^@/u, "");
+  return normalized ? `@${normalized}` : undefined;
+}
+
+function getRecipientLabel(args: XDmEligibilityInput): string {
+  const displayName = args.recipientDisplayName?.trim();
+  if (displayName && displayName !== "Unknown") return displayName;
+  return formatHandle(args.recipientUsername) ?? "this person";
+}
+
+export function buildXDmEligibility(args: XDmEligibilityInput): XDmEligibility {
+  const recipientLabel = getRecipientLabel(args);
+  const recipientUsername = formatHandle(args.recipientUsername);
+  const senderUsername = formatHandle(args.senderUsername);
+  const base = {
+    conversationId: args.conversationId,
+    recipientLabel,
+    recipientUsername,
+    recipientVerified: args.recipientVerified,
+    senderUsername,
+    senderVerified: args.senderVerified,
+  };
+
+  if (!args.isConnected) {
+    return {
+      ...base,
+      enabled: false,
+      reasonCode: "missing_connection",
+      reasonTitle: "Connect X/Twitter",
+      reasonLabel: `Connect an X/Twitter account to DM ${recipientLabel}.`,
+      nextSteps: ["connect_account"],
+    };
+  }
+
+  const missingScopes = new Set(args.missingScopes ?? []);
+  if (missingScopes.has("dm.read") || missingScopes.has("dm.write")) {
+    return {
+      ...base,
+      enabled: false,
+      reasonCode: "missing_scopes",
+      reasonTitle: "Reconnect X/Twitter",
+      reasonLabel: `Reconnect ${senderUsername ?? "your account"} to DM ${recipientLabel}.`,
+      nextSteps: ["reconnect_account"],
+    };
+  }
+
+  if (args.restriction === "subscription_required") {
+    const sender = senderUsername ?? "your connected account";
+    return {
+      ...base,
+      enabled: false,
+      reasonCode: "subscription_required",
+      reasonTitle: "Verification required",
+      reasonLabel: `${recipientLabel} only accepts DMs from verified accounts. Verify ${sender} or use another account.`,
+      receivesYourDm: false,
+      nextSteps: ["verify_account", "switch_account", "wait_for_follow_back"],
+    };
+  }
+
+  if (args.receivesYourDm === false || args.restriction === "not_allowed") {
+    const sender = senderUsername ?? "your connected account";
+    return {
+      ...base,
+      enabled: false,
+      reasonCode: "not_allowed",
+      reasonTitle: `Can't message ${recipientLabel}`,
+      reasonLabel: `${recipientLabel} isn't accepting DMs from ${sender}. Use another account or wait for a follow-back.`,
+      receivesYourDm: false,
+      nextSteps: [
+        "public_engagement",
+        "wait_for_follow_back",
+        "switch_account",
+        "recheck_eligibility",
+      ],
+    };
+  }
+
+  if (args.receivesYourDm === true) {
+    return {
+      ...base,
+      enabled: true,
+      reasonCode: "eligible",
+      reasonTitle: `Message ${recipientLabel}`,
+      reasonLabel: `You can DM ${recipientLabel} on X/Twitter.`,
+      receivesYourDm: true,
+      nextSteps: [],
+    };
+  }
+
+  return {
+    ...base,
+    enabled: false,
+    reasonCode: "unknown",
+    reasonTitle: "Can't check X/Twitter DM access",
+    reasonLabel: `Try again before sending a DM to ${recipientLabel}.`,
+    nextSteps: ["recheck_eligibility"],
+  };
+}
+
+export function getBlockedXDmPlanMessage(eligibility: XDmEligibility): string {
+  const recipient = eligibility.recipientLabel ?? "this person";
+  const reason = eligibility.reasonLabel;
+
+  switch (eligibility.reasonCode) {
+    case "missing_connection":
+      return `${reason} Update the plan. Connect X/Twitter, then recheck before the DM step.`;
+    case "missing_scopes":
+      return `${reason} Update the plan. Reconnect X/Twitter, then recheck before the DM step.`;
+    case "unknown":
+      return `${reason} Don't plan an immediate DM until X/Twitter confirms access.`;
+    case "subscription_required":
+    case "not_allowed":
+      return `${reason} Use public engagement, wait for a follow-back, or switch accounts. Recheck before sending. Following ${recipient} does not unlock DMs unless they follow back.`;
+    case "eligible":
+      return reason;
+  }
+}
+
+export function hasBlockedImmediateXDmTask(
+  tasks: Array<{ type: string; timing?: { type?: string } }>,
+  eligibility: Pick<XDmEligibility, "enabled">
+): boolean {
+  return (
+    !eligibility.enabled &&
+    tasks.some(
+      (task) => task.type === "dm" && task.timing?.type === "immediate"
+    )
+  );
+}

--- a/convex/lib/xdkTwitterProvider.ts
+++ b/convex/lib/xdkTwitterProvider.ts
@@ -366,6 +366,7 @@ function mapXUserToLegacyProfile(
     asString(user.username) ??
     asString(user.screenName) ??
     asString(user.handle);
+  const receivesYourDm = getLegacyUserDmEligibility(user);
 
   return {
     id: toLegacyNumberId(user.id) ?? 0,
@@ -390,17 +391,22 @@ function mapXUserToLegacyProfile(
       asString(user.profileBannerUrl) ?? asString(user.profile_banner_url),
     profile_image_url_https:
       asString(user.profileImageUrl) ?? asString(user.profile_image_url) ?? "",
-    can_dm: Boolean(
-      user.receivesYourDm ?? user.receives_your_dm ?? user.canDm ?? user.can_dm
-    ),
+    can_dm: receivesYourDm === true,
+    can_dm_known: typeof receivesYourDm === "boolean",
     entities: mapUserEntities(user),
   };
 }
 
+export function getLegacyUserDmEligibility(
+  user: Record<string, unknown>
+): boolean | undefined {
+  const value =
+    user.receivesYourDm ?? user.receives_your_dm ?? user.canDm ?? user.can_dm;
+  return typeof value === "boolean" ? value : undefined;
+}
+
 export function getLegacyUserCanDm(user: Record<string, unknown>): boolean {
-  return Boolean(
-    user.receivesYourDm ?? user.receives_your_dm ?? user.canDm ?? user.can_dm
-  );
+  return getLegacyUserDmEligibility(user) === true;
 }
 
 function mapXUserToLegacyUser(
@@ -1265,6 +1271,15 @@ export function formatXWriteActionError(error: unknown): Error {
         detail ?? "X rate limited this action. Wait a moment and try again."
       );
     case "api_policy_forbidden":
+      if (
+        /get verified to message|only verified (?:users|accounts).+(?:direct message|dm|message request)|sign up for (?:twitter blue|x premium)/iu.test(
+          failure.message
+        )
+      ) {
+        return new Error(
+          "X/Twitter requires a verified connected account for this message request."
+        );
+      }
       if (
         normalizedMessage.includes(
           "reply to this conversation is not allowed because you have not been mentioned or otherwise engaged"

--- a/convex/lib/xdkTwitterProviderDmEligibility.test.ts
+++ b/convex/lib/xdkTwitterProviderDmEligibility.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { getLegacyUserDmEligibility } from "./xdkTwitterProvider";
+
+describe("X/Twitter receives_your_dm mapping", () => {
+  it.each([
+    [{ receives_your_dm: true }, true],
+    [{ receivesYourDm: false }, false],
+    [{ can_dm: true }, true],
+  ] as const)("preserves an explicit boolean", (user, expected) => {
+    expect(getLegacyUserDmEligibility(user)).toBe(expected);
+  });
+
+  it("keeps an omitted value unknown instead of treating it as false", () => {
+    expect(getLegacyUserDmEligibility({ username: "avery" })).toBeUndefined();
+    expect(
+      getLegacyUserDmEligibility({ receives_your_dm: "false" })
+    ).toBeUndefined();
+  });
+});

--- a/convex/socialActionExecutors.ts
+++ b/convex/socialActionExecutors.ts
@@ -33,6 +33,7 @@ import {
   type ResolvedOutreachMedia,
 } from "./lib/mediaCapabilityCore";
 import { twitterMediaKindValidator } from "./validators";
+import type { XDmEligibility } from "../shared/lib/twitter/dm";
 
 const internalLinkedInApi = (internal as any).linkedin;
 const socialActionExecutorsLogger = logger.withScope("SocialActionExecutors");
@@ -57,6 +58,7 @@ type SubmitTwitterActionResult = {
   approvalMode?: string;
   riskLevel?: string;
   eligibilityReasonCode?: string;
+  dmEligibility?: XDmEligibility;
   targetTweetId?: string;
   sourcePostRef?: TwitterPostRef;
   sourcePostSummary?: TwitterPostSummary;
@@ -1141,11 +1143,12 @@ export const submitTwitterActionForThread = internalAction({
           pendingApproval: false,
           actionKey: args.actionKey,
           prospectId: String(threadContext.prospectId),
-          title: "DM unavailable",
+          title: dmState?.eligibility.reasonTitle ?? "DM unavailable",
           message: reason,
           approvalMode: metadata.approvalMode,
           riskLevel: metadata.riskLevel,
           eligibilityReasonCode: dmState?.eligibility.reasonCode,
+          dmEligibility: dmState?.eligibility,
           sourceContext: args.context,
           draftContent: args.text?.trim() || undefined,
           error: reason,
@@ -1170,12 +1173,12 @@ export const submitTwitterActionForThread = internalAction({
             prospectId: String(threadContext.prospectId),
             title: "DM unavailable",
             message:
-              "Could not resolve the prospect's X user id. Refresh enrichment or open the DM panel.",
+              "Could not resolve the prospect's X/Twitter user ID. Refresh enrichment or open the DM panel.",
             approvalMode: metadata.approvalMode,
             riskLevel: metadata.riskLevel,
             sourceContext: args.context,
             draftContent: args.text?.trim() || undefined,
-            error: "Missing X participant id for DM.",
+            error: "Missing X/Twitter participant ID for DM.",
           };
         }
       }

--- a/convex/validators.ts
+++ b/convex/validators.ts
@@ -703,7 +703,11 @@ export const xChatBrowserDecryptBundleValidator = v.union(
   }),
   v.object({
     availability: v.literal("blocked"),
-    reason: v.literal("xchat_access_denied"),
+    reason: v.union(
+      v.literal("xchat_access_denied"),
+      v.literal("subscription_required"),
+      v.literal("not_allowed")
+    ),
   }),
   v.object({
     availability: v.literal("available"),

--- a/convex/x.ts
+++ b/convex/x.ts
@@ -18,6 +18,7 @@ import {
   normalizeDmMessages,
   resolveDmMessageUrls,
 } from "./lib/xDm";
+import { buildXDmEligibility as buildDmEligibility } from "./lib/xDmEligibilityCore";
 import {
   executeCuratedTwitterAction,
   formatXWriteActionError,
@@ -329,59 +330,6 @@ async function createDirectXOutreachSentNotification(
   });
 }
 
-function buildDmEligibility(args: {
-  isConnected: boolean;
-  missingScopes?: string[];
-  receivesYourDm?: boolean;
-  conversationId?: string;
-}): XDmEligibility {
-  if (!args.isConnected) {
-    return {
-      enabled: false,
-      reasonCode: "missing_connection",
-      reasonLabel:
-        "Connect X/Twitter in Settings → Connected accounts to message this prospect.",
-    };
-  }
-
-  const missingScopes = new Set(args.missingScopes ?? []);
-  if (missingScopes.has("dm.read") || missingScopes.has("dm.write")) {
-    return {
-      enabled: false,
-      reasonCode: "missing_scopes",
-      reasonLabel:
-        "Reconnect X/Twitter in Settings → Connected accounts to message this prospect.",
-    };
-  }
-
-  if (args.receivesYourDm === true) {
-    return {
-      enabled: true,
-      reasonCode: "eligible",
-      reasonLabel: "DM available on X/Twitter.",
-      receivesYourDm: true,
-      conversationId: args.conversationId,
-    };
-  }
-
-  if (args.receivesYourDm === false) {
-    return {
-      enabled: false,
-      reasonCode: "not_allowed",
-      reasonLabel: "This user doesn’t currently accept your DMs on X/Twitter.",
-      receivesYourDm: false,
-      conversationId: args.conversationId,
-    };
-  }
-
-  return {
-    enabled: false,
-    reasonCode: "unknown",
-    reasonLabel: "DM eligibility unavailable right now.",
-    conversationId: args.conversationId,
-  };
-}
-
 function isMissingConversationError(error: unknown): boolean {
   const failure = getXExecutionFailure(error);
   return (
@@ -654,14 +602,48 @@ function buildBaseDmPanelContext(args: {
     missingScopes: args.connectionStatus.missingScopes,
     receivesYourDm: args.prospectIdentity.canDm,
     conversationId: args.cachedSnapshot?.conversation?.conversationId,
+    recipientDisplayName: args.prospectIdentity.displayName,
+    recipientUsername: args.prospectIdentity.username,
+    recipientVerified: args.prospectIdentity.verified,
+    senderUsername: args.connectionStatus.screenName,
+    senderVerified: args.connectionStatus.verified,
   });
   const canUseCachedEligibility =
     args.connectionStatus.isConnected &&
     !(args.connectionStatus.missingScopes ?? []).some(
       (scope) => scope === "dm.read" || scope === "dm.write"
-    );
+    ) &&
+    (args.cachedSnapshot?.conversation?.eligibilityReasonCode === "eligible" ||
+      args.cachedSnapshot?.conversation?.eligibilityReasonCode ===
+        "not_allowed" ||
+      args.cachedSnapshot?.conversation?.eligibilityReasonCode ===
+        "subscription_required");
+  const cachedReasonCode = normalizeCachedXDmEligibilityReason(
+    args.cachedSnapshot?.conversation?.eligibilityReasonCode
+  );
+  const cachedEligibility = buildDmEligibility({
+    isConnected: args.connectionStatus.isConnected,
+    missingScopes: args.connectionStatus.missingScopes,
+    receivesYourDm:
+      cachedReasonCode === "eligible"
+        ? true
+        : cachedReasonCode === "not_allowed"
+          ? false
+          : undefined,
+    restriction:
+      cachedReasonCode === "subscription_required"
+        ? "subscription_required"
+        : undefined,
+    conversationId: args.cachedSnapshot?.conversation?.conversationId,
+    recipientDisplayName: args.prospectIdentity.displayName,
+    recipientUsername: args.prospectIdentity.username,
+    recipientVerified: args.prospectIdentity.verified,
+    senderUsername: args.connectionStatus.screenName,
+    senderVerified: args.connectionStatus.verified,
+  });
   return {
     platform: "twitter",
+    viewerUserId: args.connectionStatus.xUserId,
     conversationId: args.cachedSnapshot?.conversation?.conversationId,
     participantUserId: args.cachedSnapshot?.conversation?.participantUserId,
     participantUsername: args.cachedSnapshot?.conversation?.participantUsername,
@@ -678,14 +660,7 @@ function buildBaseDmPanelContext(args: {
       canUseCachedEligibility &&
       args.cachedSnapshot?.conversation?.eligibilityReasonCode &&
       typeof args.cachedSnapshot?.conversation?.eligibilityEnabled === "boolean"
-        ? {
-            enabled: args.cachedSnapshot.conversation.eligibilityEnabled,
-            reasonCode: args.cachedSnapshot.conversation.eligibilityReasonCode,
-            reasonLabel:
-              args.cachedSnapshot.conversation.eligibilityReasonLabel ??
-              "DM eligibility unavailable right now.",
-            conversationId: args.cachedSnapshot.conversation.conversationId,
-          }
+        ? cachedEligibility
         : currentConnectionEligibility,
     messages: toCachedDmMessages(args.cachedSnapshot),
     history: {
@@ -715,6 +690,7 @@ function normalizeCachedXDmEligibilityReason(
     case "not_allowed":
     case "missing_connection":
     case "missing_scopes":
+    case "subscription_required":
     case "unknown":
       return reasonCode;
     default:
@@ -725,6 +701,13 @@ function normalizeCachedXDmEligibilityReason(
 function shouldPerformLiveDmSync(snapshot: any): boolean {
   const conversation = snapshot?.conversation;
   if (!conversation) {
+    return true;
+  }
+  if (
+    conversation.eligibilityReasonCode !== "eligible" &&
+    conversation.eligibilityReasonCode !== "not_allowed" &&
+    conversation.eligibilityReasonCode !== "subscription_required"
+  ) {
     return true;
   }
   if (
@@ -768,6 +751,11 @@ async function resolveLiveProspectDmEligibility(args: {
     missingScopes: args.connectionStatus.missingScopes,
     receivesYourDm: args.prospectIdentity.canDm,
     conversationId: args.cachedSnapshot?.conversation?.conversationId,
+    recipientDisplayName: args.prospectIdentity.displayName,
+    recipientUsername: args.prospectIdentity.username,
+    recipientVerified: args.prospectIdentity.verified,
+    senderUsername: args.connectionStatus.screenName,
+    senderVerified: args.connectionStatus.verified,
   });
 
   if (
@@ -805,8 +793,14 @@ async function resolveLiveProspectDmEligibility(args: {
     const eligibility = buildDmEligibility({
       isConnected: args.connectionStatus.isConnected,
       missingScopes: args.connectionStatus.missingScopes,
-      receivesYourDm: profile.can_dm,
+      receivesYourDm:
+        profile.can_dm_known === false ? undefined : profile.can_dm,
       conversationId,
+      recipientDisplayName: profile.name ?? args.prospectIdentity.displayName,
+      recipientUsername: profile.username ?? profile.screen_name,
+      recipientVerified: profile.verified,
+      senderUsername: args.connectionStatus.screenName,
+      senderVerified: args.connectionStatus.verified,
     });
     const messages = toCachedDmMessages(args.cachedSnapshot);
 
@@ -886,8 +880,13 @@ async function syncProspectDmConversationForUser(
   const eligibility = buildDmEligibility({
     isConnected: args.connectionStatus.isConnected,
     missingScopes: args.connectionStatus.missingScopes,
-    receivesYourDm: profile.can_dm,
+    receivesYourDm: profile.can_dm_known === false ? undefined : profile.can_dm,
     conversationId,
+    recipientDisplayName: profile.name ?? args.prospectIdentity.displayName,
+    recipientUsername: profile.username ?? profile.screen_name,
+    recipientVerified: profile.verified,
+    senderUsername: args.connectionStatus.screenName,
+    senderVerified: args.connectionStatus.verified,
   });
 
   let persistedMessages = args.baseContext.messages;
@@ -2466,21 +2465,38 @@ export const getXChatDecryptBundle = action({
       userId,
       requiredScopes: ["tweet.read", "users.read", "dm.read"],
     });
-    const { profileUserId } = await getHydratedProfileByUsername(
+    const { profileUserId, profile } = await getHydratedProfileByUsername(
       provider,
       identity.username
     );
+    if (profile.can_dm_known !== false && profile.can_dm === false) {
+      return {
+        availability: "blocked" as const,
+        reason: "not_allowed" as const,
+      };
+    }
     try {
       return await getXChatBrowserDecryptBundle(provider, profileUserId);
     } catch (error) {
-      if (
-        error instanceof XChatProviderRequestError &&
-        error.details.code === "xchat_access_denied"
-      ) {
-        return {
-          availability: "blocked" as const,
-          reason: "xchat_access_denied" as const,
-        };
+      if (error instanceof XChatProviderRequestError) {
+        if (error.details.code === "xchat_access_denied") {
+          return {
+            availability: "blocked" as const,
+            reason: "xchat_access_denied" as const,
+          };
+        }
+        if (error.details.code === "subscription_required") {
+          return {
+            availability: "blocked" as const,
+            reason: "subscription_required" as const,
+          };
+        }
+        if (error.details.code === "recipient_restricted") {
+          return {
+            availability: "blocked" as const,
+            reason: "not_allowed" as const,
+          };
+        }
       }
       throwXChatClientRequestError(error);
     }
@@ -2742,10 +2758,22 @@ export const submitXChatEncryptedMessage = action({
       userId,
       requiredScopes: ["tweet.read", "users.read", "dm.write"],
     });
-    const { profileUserId } = await getHydratedProfileByUsername(
+    const { profileUserId, profile } = await getHydratedProfileByUsername(
       provider,
       identity.username
     );
+    if (profile.can_dm_known !== false && profile.can_dm === false) {
+      throw new Error(
+        buildDmEligibility({
+          isConnected: true,
+          receivesYourDm: false,
+          recipientDisplayName: profile.name ?? identity.displayName,
+          recipientUsername: profile.username ?? profile.screen_name,
+          recipientVerified: profile.verified,
+          senderUsername: provider.username,
+        }).reasonLabel
+      );
+    }
     const expectedConversationId = computeOneToOneDmConversationId(
       provider.xUserId,
       profileUserId
@@ -3075,6 +3103,17 @@ async function sendDmMessageForUser(
   if (!prospect) {
     throw new Error("Prospect not found.");
   }
+  const dmState = await getProspectDmStateForUser(
+    ctx,
+    args.userId,
+    args.prospectId
+  );
+  if (!dmState) {
+    throw new Error("Prospect not found.");
+  }
+  if (!dmState.eligibility.enabled) {
+    throw new Error(dmState.eligibility.reasonLabel);
+  }
   const panelContext = await resolveProspectDmPanelContext(
     ctx,
     args.userId,
@@ -3083,16 +3122,17 @@ async function sendDmMessageForUser(
   if (!panelContext) {
     throw new Error("Prospect not found.");
   }
-  if (!panelContext.eligibility.enabled) {
-    throw new Error(panelContext.eligibility.reasonLabel);
-  }
-  const conversationId = args.conversationId ?? panelContext.conversationId;
+  const conversationId =
+    args.conversationId ??
+    dmState.conversationId ??
+    panelContext.conversationId;
   const hasExistingConversation =
     typeof conversationId === "string" && conversationId.trim().length > 0;
   const actionKey = hasExistingConversation
     ? "send_dm_in_existing_conversation"
     : "send_dm";
-  const targetUserId = panelContext.participantUserId;
+  const targetUserId =
+    dmState.participantUserId ?? panelContext.participantUserId;
   if (!hasExistingConversation && !targetUserId) {
     throw new Error(
       "DM target is unavailable right now. Refresh the profile and try again."
@@ -3188,7 +3228,7 @@ async function sendDmMessageForUser(
         participantAvatarUrl: panelContext.prospect.avatarUrl,
         participantVerified: panelContext.prospect.verified,
         eligibility: {
-          ...panelContext.eligibility,
+          ...dmState.eligibility,
           conversationId: effectiveConversationId,
         },
         messages,

--- a/features/agent/lib/xChatBrowserReply.test.ts
+++ b/features/agent/lib/xChatBrowserReply.test.ts
@@ -13,6 +13,7 @@ vi.mock("@xdevplatform/chat-xdk", async (importOriginal) => {
 
 import {
   decryptXChatInBrowser,
+  getXChatBrowserSession,
   lockXChatInBrowser,
   prepareXChatMediaMessageInBrowser,
   prepareXChatReplyMessageInBrowser,
@@ -254,5 +255,57 @@ describe("XChat signed reply encryption", () => {
       })
     );
     expect(encryptReply.mock.calls[0]?.[0]).not.toHaveProperty("replyToCkces");
+  });
+
+  it("does not cache a decrypt result after the account target changes", async () => {
+    let finishUnlock: () => void = () => {};
+    const unlockPending = new Promise<void>((resolve) => {
+      finishUnlock = resolve;
+    });
+    const chat = {
+      unlock: vi.fn(() => unlockPending),
+      isUnlocked: vi.fn(() => true),
+      updateConfig: vi.fn(),
+      setIdentity: vi.fn(),
+      setCacheKeys: vi.fn(),
+      setSigningKeys: vi.fn(),
+      setRejectUnverified: vi.fn(),
+      decryptEvents: vi.fn(() => ({
+        messages: [],
+        conversationKeys: { keys: {}, latestVersion: undefined },
+        errors: {},
+      })),
+      free: vi.fn(),
+    } as unknown as ChatWithJuicebox;
+    createChatMock.mockResolvedValue(chat);
+    let isCurrent = true;
+
+    const pending = decryptXChatInBrowser({
+      prospectId: "prospect-account-switch",
+      bundle: {
+        viewerUserId: "viewer-old",
+        participantUserId: "participant",
+        conversationId: "viewer-old-participant",
+        signingKeyVersion: "signing-v1",
+        juiceboxConfig: "{}",
+        signingKeys: [],
+        events: [],
+        eventPagesFetched: 1,
+        hasMore: false,
+      },
+      pin: "1234",
+      isCurrent: () => isCurrent,
+      getRealmAuthToken: async () => "realm-token",
+    });
+
+    await vi.waitFor(() => expect(chat.unlock).toHaveBeenCalled());
+    isCurrent = false;
+    finishUnlock();
+
+    await expect(pending).rejects.toThrow("target changed");
+    expect(
+      getXChatBrowserSession({ prospectId: "prospect-account-switch" })
+    ).toBeNull();
+    expect(chat.free).toHaveBeenCalledOnce();
   });
 });

--- a/features/agent/lib/xChatBrowserSession.test.ts
+++ b/features/agent/lib/xChatBrowserSession.test.ts
@@ -263,7 +263,7 @@ describe("getXChatUnlockErrorMessage", () => {
   it("does not expose unknown provider diagnostics", () => {
     expect(
       getXChatUnlockErrorMessage(new Error("provider_internal_code=abc123"))
-    ).toBe("We couldn't unlock XChat. Try again.");
+    ).toBe("We couldn't unlock X/Twitter Chat. Try again.");
   });
 
   it("disables PIN entry when X reports no attempts remaining", () => {

--- a/features/agent/lib/xChatBrowserSession.ts
+++ b/features/agent/lib/xChatBrowserSession.ts
@@ -63,7 +63,10 @@ export type XChatDecryptBundleResponse =
       availability: "unavailable";
       reason: "viewer_not_configured" | "participant_not_configured";
     }
-  | { availability: "blocked"; reason: "xchat_access_denied" }
+  | {
+      availability: "blocked";
+      reason: "xchat_access_denied" | "subscription_required" | "not_allowed";
+    }
   | ({ availability: "available" } & XChatDecryptBundle);
 
 const inFlightDecryptBundleRequests = new Map<
@@ -170,6 +173,10 @@ export type XChatBrowserSessionState =
   | { status: "unlocked" }
   | { status: "unavailable" }
   | { status: "configuration_required" }
+  | {
+      status: "dm_restricted";
+      reason: "subscription_required" | "not_allowed";
+    }
   | { status: "error"; message: string }
   | { status: "rate_limited"; message: string; retryAt?: number };
 
@@ -242,7 +249,7 @@ export function getXChatUnlockErrorMessage(error: unknown): string {
     return "That PIN isn't correct. Try again.";
   }
 
-  return "We couldn't unlock XChat. Try again.";
+  return "We couldn't unlock X/Twitter Chat. Try again.";
 }
 
 export async function decryptXChatWithRememberedPin(
@@ -2477,9 +2484,13 @@ export function decryptXChatInBrowser(args: {
   prospectId: string;
   bundle: XChatDecryptBundle;
   pin: string;
+  isCurrent?: () => boolean;
   getRealmAuthToken: (realmId: string) => Promise<string>;
   getEncryptedMedia?: XChatEncryptedMediaFetcher;
 }): Promise<XChatDecryptResult> {
+  if (args.isCurrent?.() === false) {
+    return Promise.reject(new Error("X/Twitter Chat target changed."));
+  }
   const operationKey = makeBrowserSessionKey({
     prospectId: args.prospectId,
     bundle: args.bundle,
@@ -2493,6 +2504,7 @@ async function decryptXChatInBrowserOnce(args: {
   prospectId: string;
   bundle: XChatDecryptBundle;
   pin: string;
+  isCurrent?: () => boolean;
   getRealmAuthToken: (realmId: string) => Promise<string>;
   getEncryptedMedia?: XChatEncryptedMediaFetcher;
 }): Promise<XChatDecryptResult> {
@@ -2513,11 +2525,19 @@ async function decryptXChatInBrowserOnce(args: {
         args.getRealmAuthToken
       ),
     });
+    if (args.isCurrent?.() === false) {
+      chat.free();
+      throw new Error("X/Twitter Chat target changed.");
+    }
     const pinBytes = new TextEncoder().encode(args.pin);
     try {
       await chat.unlock(pinBytes);
     } finally {
       pinBytes.fill(0);
+    }
+    if (args.isCurrent?.() === false) {
+      chat.free();
+      throw new Error("X/Twitter Chat target changed.");
     }
     activeSession = {
       chat,
@@ -2571,6 +2591,9 @@ async function decryptXChatInBrowserOnce(args: {
         isLoading: true,
       })
     : verifiedMessages;
+  if (args.isCurrent?.() === false) {
+    throw new Error("X/Twitter Chat target changed.");
+  }
   const session = cacheVerifiedXChatBrowserSession({
     prospectId: args.prospectId,
     bundle,
@@ -2593,10 +2616,13 @@ async function decryptXChatInBrowserOnce(args: {
       messages,
       getEncryptedMedia: args.getEncryptedMedia,
       isStillUnlocked: () =>
-        activeSession === browserSession && chat.isUnlocked(),
+        args.isCurrent?.() !== false &&
+        activeSession === browserSession &&
+        chat.isUnlocked(),
     })
       .then((hydratedMedia) => {
         if (
+          args.isCurrent?.() === false ||
           activeSession !== browserSession ||
           !chat.isUnlocked() ||
           !applyHydratedXChatMedia({

--- a/features/agent/ui/components/InlineDmPreviewCard.tsx
+++ b/features/agent/ui/components/InlineDmPreviewCard.tsx
@@ -100,7 +100,7 @@ export function InlineDmPreviewCard({
       return;
     }
     if (xChatState.status !== "unavailable") {
-      toast.error("Unlock XChat before sending", {
+      toast.error("Unlock X/Twitter Chat before sending", {
         description:
           "Open the conversation panel so the message can be encrypted in your browser.",
       });
@@ -179,7 +179,7 @@ export function InlineDmPreviewCard({
         : xChatState.status === "rate_limited"
           ? "Encrypted messages are temporarily rate limited"
           : xChatState.status === "configuration_required"
-            ? "XChat API access is unavailable"
+            ? "X/Twitter Chat API access is unavailable"
             : xChatState.status === "error"
               ? "Encrypted messages need attention"
               : "Encrypted conversation locked";

--- a/features/agent/ui/components/XChatPinPreferences.tsx
+++ b/features/agent/ui/components/XChatPinPreferences.tsx
@@ -29,7 +29,7 @@ export function XChatRememberPinOption({
         onCheckedChange={(checked) =>
           onRememberOnDeviceChange(checked === true)
         }
-        aria-label="Remember XChat PIN on this device"
+        aria-label="Remember X/Twitter Chat PIN on this device"
       />
       <span>Remember this device</span>
     </label>

--- a/features/agent/ui/components/xchat-history/XChatUnlockCard.tsx
+++ b/features/agent/ui/components/xchat-history/XChatUnlockCard.tsx
@@ -153,9 +153,12 @@ export function XChatUnlockCard({
       }
       if (response.availability === "blocked") {
         bundleRef.current = null;
-        setXChatBrowserSessionState(prospectId, {
-          status: "configuration_required",
-        });
+        setXChatBrowserSessionState(
+          prospectId,
+          response.reason === "xchat_access_denied"
+            ? { status: "configuration_required" }
+            : { status: "dm_restricted", reason: response.reason }
+        );
         return;
       }
       const nextBundle = response;
@@ -196,7 +199,7 @@ export function XChatUnlockCard({
         }
       }
     } catch (prepareError) {
-      const message = "We couldn't check XChat messages. Try again.";
+      const message = "We couldn't check X/Twitter Chat messages. Try again.";
       setXChatBrowserSessionState(
         prospectId,
         getXChatRateLimitState(prepareError) ?? { status: "error", message }
@@ -241,9 +244,12 @@ export function XChatUnlockCard({
       if (response.availability === "blocked") {
         bundleRef.current = null;
         setPin("");
-        setXChatBrowserSessionState(prospectId, {
-          status: "configuration_required",
-        });
+        setXChatBrowserSessionState(
+          prospectId,
+          response.reason === "xchat_access_denied"
+            ? { status: "configuration_required" }
+            : { status: "dm_restricted", reason: response.reason }
+        );
         return;
       }
       const nextBundle = response;
@@ -281,7 +287,7 @@ export function XChatUnlockCard({
       messages.length <= MAX_SHARED_XCHAT_MESSAGES &&
       decryptionErrorCount === 0;
     try {
-      const prompt = `Analyze the XChat conversation I unlocked with ${evidence.prospectName}. Summarize what happened and assess whether my responses were appropriate in context.`;
+      const prompt = `Analyze the X/Twitter Chat conversation I unlocked with ${evidence.prospectName}. Summarize what happened and assess whether my responses were appropriate in context.`;
       const saved = await initiateAnalysis({
         threadId,
         prospectId: prospectId as Id<"prospects">,
@@ -327,12 +333,16 @@ export function XChatUnlockCard({
   const shouldRequestPin =
     !browserSession && !isPreparingUnlock && gateMode === "pin";
   const isXChatAccessDenied = gateMode === "configuration_required";
+  const isDmRestricted = gateMode === "dm_restricted";
+  const verificationRequired =
+    sessionState.status === "dm_restricted" &&
+    sessionState.reason === "subscription_required";
   const attemptsExhausted = gateMode === "attempts_exhausted";
   const unlockFailed = !browserSession && gateMode === "error";
   const unlockErrorMessage =
     sessionState.status === "rate_limited"
-      ? "X is temporarily limiting requests. Try again shortly."
-      : error || "We couldn't check XChat messages. Try again.";
+      ? "X/Twitter is limiting requests. Try again shortly."
+      : error || "Try again.";
   const statusLabel = `Encrypted messages · ${evidence.eventCount} found · ${evidence.inboundEventCount} received · ${evidence.outboundEventCount} sent`;
 
   return (
@@ -344,7 +354,7 @@ export function XChatUnlockCard({
           variant="outline"
           onClick={() => void handleOpen()}
         >
-          Share XChat messages
+          Share X/Twitter Chat messages
         </Button>
       ) : (
         <InlineFeatureStrip
@@ -381,54 +391,66 @@ export function XChatUnlockCard({
           <DialogHeader>
             <DialogTitle>
               {isPreparingUnlock
-                ? "Unlocking XChat"
+                ? "Unlocking X/Twitter Chat"
                 : shouldRequestPin
-                  ? "Enter your XChat PIN"
-                  : hasReadableMessages
-                    ? "Share unlocked messages"
-                    : "XChat unlocked"}
+                  ? "Enter your X/Twitter Chat PIN"
+                  : isXChatAccessDenied
+                    ? "Reconnect X/Twitter"
+                    : isDmRestricted
+                      ? verificationRequired
+                        ? "Verification required"
+                        : `Can't message ${evidence.prospectName}`
+                      : hasReadableMessages
+                        ? "Share unlocked messages"
+                        : "X/Twitter Chat unlocked"}
             </DialogTitle>
             <DialogDescription
               id="xchat-pin-privacy"
               className={
-                isPreparingUnlock || shouldRequestPin ? "sr-only" : undefined
+                isPreparingUnlock || shouldRequestPin
+                  ? "sr-only"
+                  : "text-pretty"
               }
             >
               {isPreparingUnlock
-                ? "Recovering your encrypted XChat messages."
+                ? "Recovering your encrypted X/Twitter Chat messages."
                 : shouldRequestPin
-                  ? "Enter your four-digit XChat PIN."
-                  : hasReadableMessages
-                    ? `Share up to the latest ${MAX_SHARED_XCHAT_MESSAGES} messages with the Agent for this response.`
-                    : "The messages already visible in the thread remain available. This unlock did not add any additional XChat rows to share for this response."}
+                  ? "Enter your four-digit X/Twitter Chat PIN."
+                  : isXChatAccessDenied
+                    ? "Reconnect your account to restore Chat access."
+                    : isDmRestricted
+                      ? verificationRequired
+                        ? `${evidence.prospectName} only accepts DMs from verified accounts.`
+                        : `${evidence.prospectName} isn't accepting DMs from the connected account.`
+                      : hasReadableMessages
+                        ? `Share up to the latest ${MAX_SHARED_XCHAT_MESSAGES} messages with the Agent for this response.`
+                        : "The messages already visible in the thread remain available. This unlock did not add any additional X/Twitter Chat rows to share for this response."}
             </DialogDescription>
           </DialogHeader>
 
-          {isXChatAccessDenied ? (
-            <div className="space-y-3">
-              <p className="text-muted-foreground text-sm">
-                X accepted the connected account but denied this app access to
-                encrypted XChat endpoints. Reconnect X once; if this remains,
-                contact X Developer support.
-              </p>
-              <DialogFooter>
-                <Button asChild size="xs">
-                  <Link href="/settings/connected-accounts">
-                    Connected accounts
-                  </Link>
-                </Button>
-              </DialogFooter>
-            </div>
+          {isDmRestricted ? (
+            <p className="text-muted-foreground text-sm text-pretty">
+              {verificationRequired
+                ? "Verify the connected account or use another account."
+                : "Use another account or wait for a follow-back."}
+            </p>
+          ) : isXChatAccessDenied ? (
+            <DialogFooter>
+              <Button asChild size="xs">
+                <Link href="/settings/connected-accounts">
+                  Connected accounts
+                </Link>
+              </Button>
+            </DialogFooter>
           ) : attemptsExhausted ? (
             <div className="space-y-3">
               <p className="text-muted-foreground text-sm">
-                No PIN attempts remain. Use X&apos;s XChat help to review the
-                available recovery steps.
+                Reset your PIN in X/Twitter Chat.
               </p>
               <DialogFooter>
                 <Button asChild size="xs">
                   <a href={XCHAT_HELP_URL} target="_blank" rel="noreferrer">
-                    View XChat help
+                    View X/Twitter Chat help
                   </a>
                 </Button>
               </DialogFooter>
@@ -437,7 +459,7 @@ export function XChatUnlockCard({
             <div
               className="flex min-h-24 items-center justify-center"
               role="status"
-              aria-label="Unlocking XChat messages"
+              aria-label="Unlocking X/Twitter Chat messages"
             >
               <Spinner variant="circle" className="size-5" />
             </div>
@@ -475,7 +497,7 @@ export function XChatUnlockCard({
               }}
             >
               <label htmlFor="xchat-agent-pin" className="sr-only">
-                XChat PIN
+                X/Twitter Chat PIN
               </label>
               <div className="mx-auto h-11 w-44">
                 <InputOTP
@@ -515,7 +537,7 @@ export function XChatUnlockCard({
                 onClearSavedPins={() => {
                   setRememberOnDevice(false);
                   return forgetAllRememberedXChatPins().then(() => {
-                    toast.success("Saved XChat PINs removed");
+                    toast.success("Saved X/Twitter Chat PINs removed");
                   });
                 }}
               />
@@ -535,7 +557,7 @@ export function XChatUnlockCard({
             <div className="space-y-3">
               <p className="text-muted-foreground text-sm" role="status">
                 The conversation is already visible above. This unlock only adds
-                encrypted XChat rows when they are available.
+                encrypted X/Twitter Chat rows when they are available.
               </p>
               {error ? (
                 <p className="text-destructive text-sm" role="alert">

--- a/features/prospects/lib/outboundMessageFailure.test.ts
+++ b/features/prospects/lib/outboundMessageFailure.test.ts
@@ -21,7 +21,7 @@ describe("getOutboundMessageFailure", () => {
     [
       "twitter",
       "429 Too Many Requests",
-      "X is temporarily limiting messages. Try again shortly.",
+      "X/Twitter is temporarily limiting messages. Try again shortly.",
     ],
     [
       "linkedin",
@@ -54,7 +54,21 @@ describe("getOutboundMessageFailure", () => {
 
     expect(failure).toEqual({
       code: "unknown",
-      message: "X couldn't send this message. Try again.",
+      message: "X/Twitter couldn't send this message. Try again.",
+    });
+  });
+
+  it("preserves X/Twitter's verified-account requirement", () => {
+    expect(
+      getOutboundMessageFailure({
+        platform: "twitter",
+        error:
+          "Get verified to message this user. Only verified users can send Direct Message requests to people that don't follow them.",
+      })
+    ).toEqual({
+      code: "message_unavailable",
+      message:
+        "X/Twitter requires a verified connected account for this message request.",
     });
   });
 });

--- a/features/prospects/lib/outboundMessageOperations.test.ts
+++ b/features/prospects/lib/outboundMessageOperations.test.ts
@@ -86,7 +86,7 @@ describe("outbound message presentation", () => {
     });
     expect(merged[2]).toMatchObject({
       deliveryStatus: "failed",
-      deliveryError: "X couldn't send this message. Try again.",
+      deliveryError: "X/Twitter couldn't send this message. Try again.",
     });
   });
 

--- a/features/prospects/lib/xChatTargetGeneration.test.ts
+++ b/features/prospects/lib/xChatTargetGeneration.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  advanceXChatTargetGeneration,
+  createXChatTargetGeneration,
+  isCurrentXChatTargetGeneration,
+} from "./xChatTargetGeneration";
+
+describe("X/Twitter Chat target generations", () => {
+  it("invalidates an in-flight result when the connected account changes", async () => {
+    let current = createXChatTargetGeneration(
+      "prospect-1:viewer-old:participant-1"
+    );
+    const oldRequest = current;
+    let visibleState = "checking-new-target";
+
+    const oldResult = Promise.resolve().then(() => {
+      if (isCurrentXChatTargetGeneration(current, oldRequest)) {
+        visibleState = "old-result-applied";
+      }
+    });
+
+    current = advanceXChatTargetGeneration(
+      current,
+      "prospect-1:viewer-new:participant-1"
+    );
+    await oldResult;
+
+    expect(visibleState).toBe("checking-new-target");
+    expect(isCurrentXChatTargetGeneration(current, oldRequest)).toBe(false);
+  });
+
+  it("keeps concurrent work valid while the full target is unchanged", () => {
+    const current = createXChatTargetGeneration(
+      "prospect-1:viewer-1:participant-1"
+    );
+
+    expect(
+      isCurrentXChatTargetGeneration(
+        advanceXChatTargetGeneration(current, current.targetKey),
+        current
+      )
+    ).toBe(true);
+  });
+});

--- a/features/prospects/lib/xChatTargetGeneration.ts
+++ b/features/prospects/lib/xChatTargetGeneration.ts
@@ -1,0 +1,28 @@
+export type XChatTargetGeneration = {
+  targetKey: string;
+  generation: number;
+};
+
+export function createXChatTargetGeneration(
+  targetKey: string
+): XChatTargetGeneration {
+  return { targetKey, generation: 0 };
+}
+
+export function advanceXChatTargetGeneration(
+  current: XChatTargetGeneration,
+  targetKey: string
+): XChatTargetGeneration {
+  if (current.targetKey === targetKey) return current;
+  return { targetKey, generation: current.generation + 1 };
+}
+
+export function isCurrentXChatTargetGeneration(
+  current: XChatTargetGeneration,
+  request: XChatTargetGeneration
+): boolean {
+  return (
+    current.targetKey === request.targetKey &&
+    current.generation === request.generation
+  );
+}

--- a/features/prospects/lib/xChatUnlockGate.test.ts
+++ b/features/prospects/lib/xChatUnlockGate.test.ts
@@ -15,6 +15,7 @@ describe("getXChatUnlockGateMode", () => {
 
   it.each([
     ["configuration_required", "configuration_required"],
+    ["dm_restricted", "dm_restricted"],
     ["attempts_exhausted", "attempts_exhausted"],
     ["error", "error"],
     ["rate_limited", "error"],

--- a/features/prospects/lib/xChatUnlockGate.ts
+++ b/features/prospects/lib/xChatUnlockGate.ts
@@ -4,6 +4,7 @@ export type XChatUnlockGateMode =
   | "loading"
   | "pin"
   | "configuration_required"
+  | "dm_restricted"
   | "attempts_exhausted"
   | "error"
   | "hidden";
@@ -20,6 +21,8 @@ export function getXChatUnlockGateMode(
       return "pin";
     case "configuration_required":
       return "configuration_required";
+    case "dm_restricted":
+      return "dm_restricted";
     case "attempts_exhausted":
       return "attempts_exhausted";
     case "error":

--- a/features/prospects/ui/components/XChatConversationUnlock.tsx
+++ b/features/prospects/ui/components/XChatConversationUnlock.tsx
@@ -19,11 +19,28 @@ import {
   useXChatRetryCooldown,
   type XChatDecryptBundle,
   type XChatDecryptBundleResponse,
+  type XChatBrowserSessionState,
 } from "@/features/agent/lib/xChatBrowserSession";
 import { XChatUnlockGate } from "./XChatUnlockGate";
 import { forgetAllRememberedXChatPins } from "@/features/agent/lib/xChatDeviceCredentialStorage";
+import {
+  advanceXChatTargetGeneration,
+  createXChatTargetGeneration,
+  isCurrentXChatTargetGeneration,
+} from "@/features/prospects/lib/xChatTargetGeneration";
 
 const XCHAT_PIN_LENGTH = 4;
+
+function getBlockedSessionState(
+  reason: Extract<
+    XChatDecryptBundleResponse,
+    { availability: "blocked" }
+  >["reason"]
+): XChatBrowserSessionState {
+  return reason === "xchat_access_denied"
+    ? { status: "configuration_required" }
+    : { status: "dm_restricted", reason };
+}
 
 /**
  * Browser-only XChat unlock state. The PIN and decrypted plaintext stay in
@@ -31,17 +48,29 @@ const XCHAT_PIN_LENGTH = 4;
  */
 export function XChatConversationUnlock({
   prospectId,
+  viewerUserId,
   participantUserId,
+  recipientName,
+  recipientUsername,
+  senderUsername,
   className,
 }: {
   prospectId: string;
+  viewerUserId?: string | null;
   participantUserId?: string | null;
+  recipientName?: string;
+  recipientUsername?: string;
+  senderUsername?: string;
   className?: string;
 }) {
   const getDecryptBundle = useAction(api.x.getXChatDecryptBundle);
   const getEncryptedMedia = useAction(api.x.getXChatEncryptedMedia);
   const getRealmAuthToken = useAction(api.x.getXChatRealmAuthToken);
-  const session = useXChatBrowserSession({ prospectId, participantUserId });
+  const session = useXChatBrowserSession({
+    prospectId,
+    viewerUserId,
+    participantUserId,
+  });
   const sessionState = useXChatBrowserSessionState(prospectId);
   const pinInputId = React.useId();
   const errorDescriptionId = React.useId();
@@ -50,24 +79,50 @@ export function XChatConversationUnlock({
   const [pin, setPin] = React.useState("");
   const [rememberOnDevice, setRememberOnDevice] = React.useState(true);
   const [localError, setLocalError] = React.useState<string | null>(null);
+  const targetKey = `${prospectId}:${viewerUserId ?? "unknown-viewer"}:${participantUserId ?? "unknown-participant"}`;
+  const [initialTargetGeneration] = React.useState(() =>
+    createXChatTargetGeneration(targetKey)
+  );
+  const targetGenerationRef = React.useRef(initialTargetGeneration);
   const isBusy =
     sessionState.status === "checking" || sessionState.status === "unlocking";
   const isCoolingDown = useXChatRetryCooldown(
     sessionState.status === "rate_limited" ? sessionState.retryAt : undefined
   );
 
+  React.useEffect(() => {
+    const nextGeneration = advanceXChatTargetGeneration(
+      targetGenerationRef.current,
+      targetKey
+    );
+    if (nextGeneration === targetGenerationRef.current) return;
+    targetGenerationRef.current = nextGeneration;
+    unlockInFlightRef.current = false;
+    bundleRef.current = null;
+    setPin("");
+    setLocalError(null);
+    setXChatBrowserSessionState(prospectId, { status: "unknown" });
+  }, [prospectId, targetKey]);
+
   const prepareBundle = React.useCallback(async () => {
     if (isBusy || isCoolingDown) return;
+    const requestGeneration = targetGenerationRef.current;
+    const isCurrentRequest = () =>
+      isCurrentXChatTargetGeneration(
+        targetGenerationRef.current,
+        requestGeneration
+      );
     setLocalError(null);
     setXChatBrowserSessionState(prospectId, { status: "checking" });
     try {
       const response = await requestXChatDecryptBundleOnce(
-        prospectId,
+        targetKey,
         async () =>
           (await getDecryptBundle({
             prospectId: prospectId as Id<"prospects">,
           })) as XChatDecryptBundleResponse
       );
+      if (!isCurrentRequest()) return;
       if (response.availability === "unavailable") {
         bundleRef.current = null;
         setXChatBrowserSessionState(prospectId, { status: "unavailable" });
@@ -75,9 +130,10 @@ export function XChatConversationUnlock({
       }
       if (response.availability === "blocked") {
         bundleRef.current = null;
-        setXChatBrowserSessionState(prospectId, {
-          status: "configuration_required",
-        });
+        setXChatBrowserSessionState(
+          prospectId,
+          getBlockedSessionState(response.reason)
+        );
         return;
       }
       const bundle = response;
@@ -88,13 +144,24 @@ export function XChatConversationUnlock({
           prospectId,
           bundle,
           pin: "",
-          getRealmAuthToken: async (realmId) =>
-            await getRealmAuthToken({ realmId }),
-          getEncryptedMedia: async (mediaHashKey) =>
-            await getEncryptedMedia({
+          isCurrent: isCurrentRequest,
+          getRealmAuthToken: async (realmId) => {
+            const token = await getRealmAuthToken({ realmId });
+            if (!isCurrentRequest()) {
+              throw new Error("X/Twitter Chat target changed.");
+            }
+            return token;
+          },
+          getEncryptedMedia: async (mediaHashKey) => {
+            const media = await getEncryptedMedia({
               prospectId: prospectId as Id<"prospects">,
               mediaHashKey,
-            }),
+            });
+            if (!isCurrentRequest()) {
+              throw new Error("X/Twitter Chat target changed.");
+            }
+            return media;
+          },
         });
         return;
       }
@@ -102,14 +169,26 @@ export function XChatConversationUnlock({
       const rememberedUnlock = await decryptXChatWithRememberedPin({
         prospectId,
         bundle,
-        getRealmAuthToken: async (realmId) =>
-          await getRealmAuthToken({ realmId }),
-        getEncryptedMedia: async (mediaHashKey) =>
-          await getEncryptedMedia({
+        isCurrent: isCurrentRequest,
+        getRealmAuthToken: async (realmId) => {
+          const token = await getRealmAuthToken({ realmId });
+          if (!isCurrentRequest()) {
+            throw new Error("X/Twitter Chat target changed.");
+          }
+          return token;
+        },
+        getEncryptedMedia: async (mediaHashKey) => {
+          const media = await getEncryptedMedia({
             prospectId: prospectId as Id<"prospects">,
             mediaHashKey,
-          }),
+          });
+          if (!isCurrentRequest()) {
+            throw new Error("X/Twitter Chat target changed.");
+          }
+          return media;
+        },
       });
+      if (!isCurrentRequest()) return;
       if (rememberedUnlock.status === "unlocked") return;
       if (rememberedUnlock.status === "invalid") {
         const attemptsRemaining = rememberedUnlock.attemptsRemaining;
@@ -135,7 +214,8 @@ export function XChatConversationUnlock({
       }
       setXChatBrowserSessionState(prospectId, { status: "locked" });
     } catch (error) {
-      const message = "We couldn't check XChat messages. Try again.";
+      if (!isCurrentRequest()) return;
+      const message = "We couldn't check X/Twitter Chat messages. Try again.";
       setLocalError(message);
       setXChatBrowserSessionState(
         prospectId,
@@ -149,6 +229,7 @@ export function XChatConversationUnlock({
     isBusy,
     isCoolingDown,
     prospectId,
+    targetKey,
   ]);
 
   const handleUnlock = React.useCallback(
@@ -162,6 +243,12 @@ export function XChatConversationUnlock({
         return;
       }
 
+      const requestGeneration = targetGenerationRef.current;
+      const isCurrentRequest = () =>
+        isCurrentXChatTargetGeneration(
+          targetGenerationRef.current,
+          requestGeneration
+        );
       unlockInFlightRef.current = true;
       setLocalError(null);
       setXChatBrowserSessionState(prospectId, { status: "unlocking" });
@@ -170,12 +257,13 @@ export function XChatConversationUnlock({
         const response = cachedBundle
           ? ({ availability: "available", ...cachedBundle } as const)
           : await requestXChatDecryptBundleOnce(
-              prospectId,
+              targetKey,
               async () =>
                 (await getDecryptBundle({
                   prospectId: prospectId as Id<"prospects">,
                 })) as XChatDecryptBundleResponse
             );
+        if (!isCurrentRequest()) return;
         if (response.availability === "unavailable") {
           bundleRef.current = null;
           setPin("");
@@ -185,9 +273,10 @@ export function XChatConversationUnlock({
         if (response.availability === "blocked") {
           bundleRef.current = null;
           setPin("");
-          setXChatBrowserSessionState(prospectId, {
-            status: "configuration_required",
-          });
+          setXChatBrowserSessionState(
+            prospectId,
+            getBlockedSessionState(response.reason)
+          );
           return;
         }
         const bundle = response;
@@ -199,20 +288,34 @@ export function XChatConversationUnlock({
           prospectId,
           bundle,
           pin: pinToUse,
-          getRealmAuthToken: async (realmId) =>
-            await getRealmAuthToken({ realmId }),
-          getEncryptedMedia: async (mediaHashKey) =>
-            await getEncryptedMedia({
+          isCurrent: isCurrentRequest,
+          getRealmAuthToken: async (realmId) => {
+            const token = await getRealmAuthToken({ realmId });
+            if (!isCurrentRequest()) {
+              throw new Error("X/Twitter Chat target changed.");
+            }
+            return token;
+          },
+          getEncryptedMedia: async (mediaHashKey) => {
+            const media = await getEncryptedMedia({
               prospectId: prospectId as Id<"prospects">,
               mediaHashKey,
-            }),
+            });
+            if (!isCurrentRequest()) {
+              throw new Error("X/Twitter Chat target changed.");
+            }
+            return media;
+          },
         });
+        if (!isCurrentRequest()) return;
         if (pinToUse && rememberOnDevice) {
           await rememberSuccessfulXChatPin({ bundle, pin: pinToUse });
+          if (!isCurrentRequest()) return;
         }
         setPin("");
         setLocalError(null);
       } catch (error) {
+        if (!isCurrentRequest()) return;
         setPin("");
         const message = getXChatUnlockErrorMessage(error);
         setLocalError(message);
@@ -221,7 +324,9 @@ export function XChatConversationUnlock({
           getXChatRateLimitState(error) ?? getXChatUnlockFailureState(error)
         );
       } finally {
-        unlockInFlightRef.current = false;
+        if (isCurrentRequest()) {
+          unlockInFlightRef.current = false;
+        }
       }
     },
     [
@@ -232,6 +337,7 @@ export function XChatConversationUnlock({
       isCoolingDown,
       prospectId,
       rememberOnDevice,
+      targetKey,
     ]
   );
 
@@ -257,6 +363,9 @@ export function XChatConversationUnlock({
     <XChatUnlockGate
       className={className}
       sessionState={sessionState}
+      recipientName={recipientName}
+      recipientUsername={recipientUsername}
+      senderUsername={senderUsername}
       pin={pin}
       errorMessage={errorMessage}
       isBusy={isBusy}

--- a/features/prospects/ui/components/XChatUnlockGate.tsx
+++ b/features/prospects/ui/components/XChatUnlockGate.tsx
@@ -2,6 +2,7 @@
 
 import { REGEXP_ONLY_DIGITS } from "input-otp";
 import Link from "next/link";
+import { useId } from "react";
 import { Button } from "@/shared/ui/components/Button";
 import {
   InputOTP,
@@ -22,6 +23,9 @@ import { getXChatUnlockGateMode } from "@/features/prospects/lib/xChatUnlockGate
 const XCHAT_PIN_LENGTH = 4;
 export function XChatUnlockGate({
   sessionState,
+  recipientName,
+  recipientUsername,
+  senderUsername,
   pin,
   errorMessage,
   isBusy,
@@ -37,6 +41,9 @@ export function XChatUnlockGate({
   className,
 }: {
   sessionState: XChatBrowserSessionState;
+  recipientName?: string;
+  recipientUsername?: string;
+  senderUsername?: string;
   pin: string;
   errorMessage: string | null;
   isBusy: boolean;
@@ -51,10 +58,22 @@ export function XChatUnlockGate({
   onRetry: () => void;
   className?: string;
 }) {
+  const titleId = useId();
   const gateMode = getXChatUnlockGateMode(sessionState.status);
   const shouldRequestPin = gateMode === "pin";
   const isXChatAccessDenied = gateMode === "configuration_required";
+  const isDmRestricted = gateMode === "dm_restricted";
   const attemptsExhausted = gateMode === "attempts_exhausted";
+  const recipientLabel =
+    recipientName?.trim() ||
+    (recipientUsername ? `@${recipientUsername.replace(/^@/u, "")}` : null) ||
+    "this person";
+  const senderLabel = senderUsername
+    ? `@${senderUsername.replace(/^@/u, "")}`
+    : "your connected account";
+  const verificationRequired =
+    sessionState.status === "dm_restricted" &&
+    sessionState.reason === "subscription_required";
 
   if (gateMode === "loading") {
     return (
@@ -62,7 +81,7 @@ export function XChatUnlockGate({
         role="status"
         aria-label={
           sessionState.status === "unlocking"
-            ? "Unlocking XChat messages"
+            ? "Unlocking X/Twitter Chat messages"
             : "Loading X/Twitter conversation"
         }
         className={cn(
@@ -86,33 +105,45 @@ export function XChatUnlockGate({
         shouldRequestPin && "pb-20",
         className
       )}
-      aria-labelledby="xchat-unlock-title"
+      aria-labelledby={titleId}
     >
       <div className="flex w-full max-w-xs flex-col items-center text-center">
-        <XChatIcon className="mb-4 size-16" aria-hidden />
+        <XChatIcon
+          className={cn("mb-4", shouldRequestPin ? "size-16" : "size-12")}
+          aria-hidden
+        />
         <h2
-          id="xchat-unlock-title"
+          id={titleId}
           className={cn(
             shouldRequestPin
-              ? "text-foreground text-center text-xl font-medium text-pretty sm:text-2xl"
-              : "text-base font-medium"
+              ? "text-foreground text-center text-xl font-medium text-balance sm:text-2xl"
+              : "text-base font-medium text-balance"
           )}
         >
           {shouldRequestPin
-            ? "Enter your XChat PIN"
+            ? "Enter your X/Twitter Chat PIN"
             : isXChatAccessDenied
-              ? "XChat API access unavailable"
-              : attemptsExhausted
-                ? "No PIN attempts remain"
-                : "Couldn't check XChat messages"}
+              ? "Reconnect X/Twitter"
+              : isDmRestricted
+                ? verificationRequired
+                  ? "Verification required"
+                  : `Can't message ${recipientLabel}`
+                : attemptsExhausted
+                  ? "No PIN attempts left"
+                  : "Couldn't check X/Twitter Chat"}
         </h2>
-        {!shouldRequestPin ? (
-          <p className="text-muted-foreground mt-1.5 text-sm leading-5">
+        {!shouldRequestPin &&
+        (isXChatAccessDenied || isDmRestricted || attemptsExhausted) ? (
+          <p className="text-muted-foreground mt-1.5 max-w-64 text-sm leading-5 text-pretty">
             {isXChatAccessDenied
-              ? "X accepted the connected account but denied this app access to encrypted XChat endpoints. Reconnect X once; if this remains, contact X Developer support."
-              : attemptsExhausted
-                ? "Use X's XChat help to review the available recovery steps."
-                : "Retry the encrypted-message check."}
+              ? "Reconnect your X/Twitter account to restore Chat access."
+              : isDmRestricted
+                ? verificationRequired
+                  ? `${recipientLabel} only accepts DMs from verified accounts. Verify ${senderLabel} or use another account.`
+                  : `${recipientLabel} isn't accepting DMs from ${senderLabel}. Use another account or wait for a follow-back.`
+                : attemptsExhausted
+                  ? "Reset your PIN in X/Twitter Chat."
+                  : null}
           </p>
         ) : null}
 
@@ -126,7 +157,7 @@ export function XChatUnlockGate({
             }}
           >
             <label htmlFor={pinInputId} className="sr-only">
-              XChat PIN
+              X/Twitter Chat PIN
             </label>
             <div className="h-11 w-44">
               <InputOTP
@@ -172,18 +203,21 @@ export function XChatUnlockGate({
           <Button asChild type="button" size="sm" className="mt-5">
             <Link href="/settings/connected-accounts">Connected accounts</Link>
           </Button>
-        ) : attemptsExhausted ? (
+        ) : isDmRestricted ? null : attemptsExhausted ? (
           <Button asChild type="button" size="sm" className="mt-5">
             <a href={XCHAT_HELP_URL} target="_blank" rel="noreferrer">
-              View XChat help
+              View X/Twitter Chat help
             </a>
           </Button>
         ) : errorMessage ? (
           <div className="mt-5 flex flex-col items-center">
             {errorMessage ? (
-              <p className="text-muted-foreground text-sm" role="alert">
+              <p
+                className="text-muted-foreground max-w-64 text-sm text-pretty"
+                role="alert"
+              >
                 {sessionState.status === "rate_limited"
-                  ? "X is temporarily limiting requests. Try again when the cooldown ends."
+                  ? "X/Twitter is limiting requests. Try again shortly."
                   : errorMessage}
               </p>
             ) : null}

--- a/features/prospects/ui/components/XConversationPanel.tsx
+++ b/features/prospects/ui/components/XConversationPanel.tsx
@@ -25,13 +25,9 @@ import { useProspectDmPanel } from "../../hooks/useProspectDmPanel";
 import { useTwitterConversationTyping } from "../../hooks/useTwitterConversationTyping";
 import { ConversationMessageViewport } from "./ConversationMessageViewport";
 import { XChatConversationUnlock } from "./XChatConversationUnlock";
+import { XDmEligibilityAlert } from "./XDmEligibilityAlert";
 import { XDmConversationMenu } from "./XDmConversationMenu";
 import { Button } from "@/shared/ui/components/Button";
-import {
-  Alert,
-  AlertDescription,
-  AlertTitle,
-} from "@/shared/ui/components/Alert";
 import { Spinner } from "@/shared/ui/components/Spinner";
 import { MessageScrollerItem } from "@/shared/ui/components/MessageScroller";
 import {
@@ -162,6 +158,7 @@ export function XConversationPanel({
   });
   const xChatSession = useXChatBrowserSession({
     prospectId,
+    viewerUserId: data?.viewerUserId,
     participantUserId: data?.participantUserId,
   });
   const isParticipantTyping = useTwitterConversationTyping({
@@ -714,7 +711,8 @@ export function XConversationPanel({
   });
   const shouldDisableTaskSubmit =
     isTaskApprovalComposer &&
-    ((taskStatus !== "pending" && taskStatus !== "executing") ||
+    (!data?.eligibility.enabled ||
+      (taskStatus !== "pending" && taskStatus !== "executing") ||
       (taskApprovalUi.submitBlockedByPlan &&
         !taskApprovalUi.planCanBeApproved));
 
@@ -905,14 +903,16 @@ export function XConversationPanel({
                   new Uint8Array(uploadBuffer).fill(0);
                 }
                 if (!uploadResponse.ok) {
-                  throw new Error("Encrypted XChat media upload failed.");
+                  throw new Error(
+                    "Encrypted X/Twitter Chat media upload failed."
+                  );
                 }
                 const uploaded = (await uploadResponse.json()) as {
                   storageId?: string;
                 };
                 if (!uploaded.storageId) {
                   throw new Error(
-                    "Encrypted XChat media upload was incomplete."
+                    "Encrypted X/Twitter Chat media upload was incomplete."
                   );
                 }
                 const { mediaHashKey } = await uploadXChatEncryptedMedia({
@@ -1004,7 +1004,7 @@ export function XConversationPanel({
             await refreshNewestXChatPage();
           }
           if (isTaskApprovalComposer) {
-            toast.success("DM approved and sent through XChat.");
+            toast.success("DM approved and sent through X/Twitter Chat.");
           }
           setLocalDraftState({
             sourceKey: draftSourceKey,
@@ -1099,7 +1099,7 @@ export function XConversationPanel({
           remove,
         });
       } catch (reactionError) {
-        toast.error("Could not update XChat reaction", {
+        toast.error("Could not update X/Twitter Chat reaction", {
           description:
             reactionError instanceof Error
               ? reactionError.message
@@ -1121,7 +1121,7 @@ export function XConversationPanel({
           });
           if (!prepared) {
             throw new Error(
-              "This encrypted retry expired. Check X before sending it again."
+              "This encrypted retry expired. Check X/Twitter before sending it again."
             );
           }
           publishPendingXChatTextMessageInBrowser({
@@ -1175,8 +1175,7 @@ export function XConversationPanel({
   }, [cancel, isTaskBacked]);
 
   const shouldDisableComposer =
-    !isTaskApprovalComposer &&
-    (!data || !data.eligibility.enabled || isSendingActionRequest);
+    !data || !data.eligibility.enabled || isSendingActionRequest;
   const inlineDraftStatus =
     draftSync.status === "saving" ? (
       <span className="text-muted-foreground text-xs">Saving</span>
@@ -1245,7 +1244,11 @@ export function XConversationPanel({
         <div className="flex min-h-0 flex-1 flex-col">
           <XChatConversationUnlock
             prospectId={prospectId}
+            viewerUserId={data?.viewerUserId}
             participantUserId={data?.participantUserId}
+            recipientName={data?.prospect.displayName}
+            recipientUsername={resolvedTwitterUsername}
+            senderUsername={currentUser.screenName}
             className={cn(
               (!data || !shouldGateConversation || isInitialXChatCheck) &&
                 "hidden"
@@ -1385,29 +1388,12 @@ export function XConversationPanel({
                   ) : null}
                   {!data.eligibility.enabled ? (
                     <MessageScrollerItem messageId="conversation-unavailable">
-                      <Alert className="mt-2">
-                        <AlertTitle>DM unavailable</AlertTitle>
-                        <AlertDescription className="space-y-3">
-                          <p>{data.eligibility.reasonLabel}</p>
-                          {data.eligibility.reasonCode ===
-                            "missing_connection" ||
-                          data.eligibility.reasonCode === "missing_scopes" ? (
-                            <div>
-                              <Button
-                                size="xs"
-                                onClick={() =>
-                                  router.push("/settings/connected-accounts")
-                                }
-                              >
-                                {data.eligibility.reasonCode ===
-                                "missing_scopes"
-                                  ? "Reconnect account"
-                                  : "Connect account"}
-                              </Button>
-                            </div>
-                          ) : null}
-                        </AlertDescription>
-                      </Alert>
+                      <XDmEligibilityAlert
+                        eligibility={data.eligibility}
+                        onManageAccount={() =>
+                          router.push("/settings/connected-accounts")
+                        }
+                      />
                     </MessageScrollerItem>
                   ) : null}
                 </ConversationMessageViewport>

--- a/features/prospects/ui/components/XDmEligibilityAlert.tsx
+++ b/features/prospects/ui/components/XDmEligibilityAlert.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import type { XDmEligibility } from "@/shared/lib/twitter/dm";
+import { highlightTextMultiple } from "@/shared/lib/utils";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "@/shared/ui/components/Alert";
+import { Button } from "@/shared/ui/components/Button";
+import { WarningIcon } from "@/shared/ui/components/icons";
+
+export function XDmEligibilityAlert({
+  eligibility,
+  onManageAccount,
+}: {
+  eligibility: XDmEligibility;
+  onManageAccount: () => void;
+}) {
+  const copyTokens = Array.from(
+    new Set(
+      [
+        eligibility.recipientLabel,
+        eligibility.recipientUsername,
+        eligibility.senderUsername,
+      ].filter((value): value is string => Boolean(value?.trim()))
+    )
+  );
+  const highlightOptions = {
+    highlightClassName:
+      "bg-transparent font-mono text-muted-foreground font-normal",
+    includeAria: false,
+  } as const;
+  const description = highlightTextMultiple(
+    eligibility.reasonLabel,
+    copyTokens,
+    highlightOptions
+  ).highlightedText;
+  const needsAccountAction =
+    eligibility.reasonCode === "missing_connection" ||
+    eligibility.reasonCode === "missing_scopes";
+
+  return (
+    <Alert className="mt-2">
+      <WarningIcon className="size-4 fill-current" aria-hidden />
+      <AlertTitle className="text-sm leading-5 text-balance">
+        {eligibility.reasonTitle ?? "DM unavailable"}
+      </AlertTitle>
+      <AlertDescription className="space-y-3 text-pretty">
+        <p>{description}</p>
+        {needsAccountAction ? (
+          <div>
+            <Button size="xs" onClick={onManageAccount}>
+              {eligibility.reasonCode === "missing_scopes"
+                ? "Reconnect account"
+                : "Connect account"}
+            </Button>
+          </div>
+        ) : null}
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/features/webapp/ui/components/Header.tsx
+++ b/features/webapp/ui/components/Header.tsx
@@ -990,12 +990,12 @@ export function Header({
                 <DropdownMenuItem
                   onClick={() => {
                     void forgetAllRememberedXChatPins().then(() =>
-                      toast.success("Saved XChat PINs removed")
+                      toast.success("Saved X/Twitter Chat PINs removed")
                     );
                   }}
                 >
                   <LockIcon className="fill-current" aria-hidden="true" />
-                  Forget saved XChat PINs
+                  Forget saved X/Twitter Chat PINs
                 </DropdownMenuItem>
 
                 {/* Log out */}

--- a/shared/lib/platforms/outboundMessageFailure.ts
+++ b/shared/lib/platforms/outboundMessageFailure.ts
@@ -31,7 +31,7 @@ export function getOutboundMessageFailure(args: {
   platform: OutboundMessagePlatform;
 }): OutboundMessageFailure {
   const normalized = getErrorText(args.error).trim().toLowerCase();
-  const platformName = args.platform === "linkedin" ? "LinkedIn" : "X";
+  const platformName = args.platform === "linkedin" ? "LinkedIn" : "X/Twitter";
 
   if (
     normalized.includes("voice note expired") ||
@@ -43,7 +43,7 @@ export function getOutboundMessageFailure(args: {
       message:
         args.platform === "linkedin"
           ? "This voice note expired. Record it again."
-          : "This retry expired. Check X before sending it again.",
+          : "This retry expired. Check X/Twitter before sending it again.",
     };
   }
 
@@ -94,6 +94,18 @@ export function getOutboundMessageFailure(args: {
     return {
       code: "account_disconnected",
       message: `Reconnect ${platformName} in Settings, then try again.`,
+    };
+  }
+
+  if (
+    normalized.includes("get verified to message") ||
+    normalized.includes("only verified users can send direct message") ||
+    normalized.includes("only verified accounts can send")
+  ) {
+    return {
+      code: "message_unavailable",
+      message:
+        "X/Twitter requires a verified connected account for this message request.",
     };
   }
 

--- a/shared/lib/twitter/dm.ts
+++ b/shared/lib/twitter/dm.ts
@@ -3,14 +3,31 @@ export type XDmEligibilityReasonCode =
   | "not_allowed"
   | "missing_connection"
   | "missing_scopes"
+  | "subscription_required"
   | "unknown";
+
+export type XDmEligibilityNextStep =
+  | "connect_account"
+  | "reconnect_account"
+  | "verify_account"
+  | "switch_account"
+  | "public_engagement"
+  | "wait_for_follow_back"
+  | "recheck_eligibility";
 
 export interface XDmEligibility {
   enabled: boolean;
   reasonCode: XDmEligibilityReasonCode;
+  reasonTitle?: string;
   reasonLabel: string;
   receivesYourDm?: boolean;
   conversationId?: string;
+  recipientLabel?: string;
+  recipientUsername?: string;
+  recipientVerified?: boolean;
+  senderUsername?: string;
+  senderVerified?: boolean;
+  nextSteps?: XDmEligibilityNextStep[];
 }
 
 export interface XDmParticipantSummary {
@@ -154,6 +171,8 @@ export interface ConversationHistoryPageState {
 
 export interface XDmPanelContext {
   platform: "twitter";
+  /** Connected X/Twitter account id; keeps browser-only Chat state account-scoped. */
+  viewerUserId?: string;
   conversationId?: string;
   participantUserId?: string;
   /** From cached platform conversation; use when prospect.username is not yet resolved. */

--- a/shared/lib/twitter/hydration.ts
+++ b/shared/lib/twitter/hydration.ts
@@ -11,6 +11,8 @@ type TwitterProfileUrlEntity = {
 
 export type HydratedTwitterProfile = User & {
   username?: string;
+  /** False when X/Twitter omitted the viewer-specific receives_your_dm field. */
+  can_dm_known?: boolean;
   banner_url?: string;
   entities?: {
     description?: {

--- a/shared/ui/components/json-render/AgentArtifactRenderer.tsx
+++ b/shared/ui/components/json-render/AgentArtifactRenderer.tsx
@@ -37,6 +37,7 @@ import {
   ErrorIcon,
   OpenInNewIcon,
   RadioButtonUncheckedIcon,
+  XChatIcon,
 } from "@/shared/ui/components/icons";
 import {
   agentArtifactCatalog,
@@ -616,6 +617,14 @@ function TwitterActionArtifactCard({
     (props.eligibilityReasonCode === "missing_connection" ||
       props.message ===
         "Connect X/Twitter in Settings → Connected accounts to message this prospect.");
+  const isBlockedDm =
+    platform === "twitter" &&
+    (props.actionKey === "send_dm" ||
+      props.actionKey === "send_dm_in_existing_conversation") &&
+    liveStatus === "failed" &&
+    !!props.eligibilityReasonCode &&
+    props.eligibilityReasonCode !== "eligible" &&
+    props.eligibilityReasonCode !== "missing_connection";
 
   const reviewButtonLabel =
     liveStatus === "completed" ? "Open result" : "Review";
@@ -708,6 +717,21 @@ function TwitterActionArtifactCard({
           >
             Connect
           </Button>
+        }
+      />
+    );
+  }
+
+  if (isBlockedDm) {
+    return (
+      <InlineFeatureStrip
+        leading={
+          <>
+            <div className="border-border shrink-0 rounded-md border p-1">
+              <XChatIcon className="text-foreground size-4" aria-hidden />
+            </div>
+            <p className="truncate text-sm font-medium">{props.title}</p>
+          </>
         }
       />
     );

--- a/tests/dm-panel-ui-hardening.test.ts
+++ b/tests/dm-panel-ui-hardening.test.ts
@@ -55,6 +55,86 @@ test("both DM panels share the Agent Chat message-scroller behavior", () => {
   assert.doesNotMatch(xPanel, /const justUnlocked =/);
 });
 
+test("X/Twitter DM eligibility blocks every composer mode and uses recipient-specific copy", () => {
+  const panel = read("features/prospects/ui/components/XConversationPanel.tsx");
+  const unlock = read(
+    "features/prospects/ui/components/XChatConversationUnlock.tsx"
+  );
+  const gate = read("features/prospects/ui/components/XChatUnlockGate.tsx");
+  const eligibilityAlert = read(
+    "features/prospects/ui/components/XDmEligibilityAlert.tsx"
+  );
+
+  assert.match(
+    panel,
+    /const shouldDisableComposer =\s*!data \|\|\s*!data\.eligibility\.enabled \|\|/
+  );
+  assert.match(
+    panel,
+    /const shouldDisableTaskSubmit =\s*isTaskApprovalComposer &&\s*\(!data\?\.eligibility\.enabled/
+  );
+  assert.match(panel, /<XDmEligibilityAlert/);
+  assert.match(eligibilityAlert, /<Alert className="mt-2">/);
+  assert.match(eligibilityAlert, /<WarningIcon/);
+  assert.match(eligibilityAlert, /highlightTextMultiple/);
+  assert.match(
+    eligibilityAlert,
+    /<AlertTitle[\s\S]*?eligibility\.reasonTitle \?\? "DM unavailable"[\s\S]*?<\/AlertTitle>/
+  );
+  assert.doesNotMatch(
+    eligibilityAlert,
+    /<AlertDescription className="text-muted-foreground/
+  );
+  assert.match(
+    eligibilityAlert,
+    /bg-transparent font-mono text-muted-foreground font-normal/
+  );
+  assert.match(unlock, /status: "dm_restricted"/);
+  assert.match(unlock, /viewerUserId/);
+  assert.match(unlock, /targetGenerationRef/);
+  assert.match(unlock, /advanceXChatTargetGeneration/);
+  assert.match(unlock, /requestXChatDecryptBundleOnce\(\s*targetKey,/);
+  assert.match(unlock, /isCurrent: isCurrentRequest/);
+  assert.match(gate, /"Verification required"/);
+  assert.match(gate, /Can't message \$\{recipientLabel\}/);
+  assert.match(gate, /isDmRestricted \? null : attemptsExhausted/);
+});
+
+test("strategy-only plan edits recheck retained X/Twitter DM tasks", () => {
+  const refinePlan = read("convex/agents/outreach/tools/refinePlan.ts");
+
+  assert.match(
+    refinePlan,
+    /const xDmEligibilityTasks =\s*candidateTasks \?\?\s*existingPlanData\?\.tasks\.filter/
+  );
+  assert.match(
+    refinePlan,
+    /hasBlockedImmediateXDmTask\(\s*xDmEligibilityTasks,\s*dmState\.eligibility/
+  );
+});
+
+test("blocked Agent DMs render as a single compact status strip", () => {
+  const renderer = read(
+    "shared/ui/components/json-render/AgentArtifactRenderer.tsx"
+  );
+  const executor = read("convex/socialActionExecutors.ts");
+
+  assert.match(renderer, /const isBlockedDm =/);
+  assert.match(renderer, /liveStatus === "failed"/);
+  assert.match(
+    renderer,
+    /if \(isBlockedDm\) \{[\s\S]*?<InlineFeatureStrip[\s\S]*?<XChatIcon/
+  );
+  assert.doesNotMatch(
+    renderer.match(/if \(isBlockedDm\) \{[\s\S]*?\n  \}/)?.[0] ?? "",
+    /props\.message|riskLevel|Action preview/
+  );
+  assert.match(
+    executor,
+    /title: dmState\?\.eligibility\.reasonTitle \?\? "DM unavailable"/
+  );
+});
+
 test("XChat unlocks as soon as a complete PIN is entered", () => {
   const unlock = read(
     "features/prospects/ui/components/XChatConversationUnlock.tsx"
@@ -72,7 +152,7 @@ test("XChat unlocks as soon as a complete PIN is entered", () => {
   assert.match(gate, /onComplete=\{onPinComplete\}/);
   assert.match(gate, /autoFocus/);
   assert.doesNotMatch(gate, /type="submit"/);
-  assert.match(gate, /Enter your XChat PIN/);
+  assert.match(gate, /Enter your X\/Twitter Chat PIN/);
   assert.doesNotMatch(gate, /font-pixel-square/);
   assert.match(gate, /text-xl/);
   assert.match(gate, /sm:text-2xl/);
@@ -83,8 +163,13 @@ test("XChat unlocks as soon as a complete PIN is entered", () => {
   assert.match(gate, /variant="circle"/);
   assert.doesNotMatch(gate, /Unlocking…/);
   assert.doesNotMatch(gate, /rounded-full/);
-  assert.match(gate, /<XChatIcon className="mb-4 size-16" aria-hidden \/>/);
-  assert.match(gate, /<XChatIcon[\s\S]*?<h2[\s\S]*?id="xchat-unlock-title"/);
+  assert.match(
+    gate,
+    /<XChatIcon[\s\S]*?shouldRequestPin \? "size-16" : "size-12"/
+  );
+  assert.match(gate, /const titleId = useId\(\)/);
+  assert.match(gate, /aria-labelledby=\{titleId\}/);
+  assert.match(gate, /<XChatIcon[\s\S]*?<h2[\s\S]*?id=\{titleId\}/);
   assert.doesNotMatch(gate, /flex items-center justify-center gap-2/);
   assert.match(unlock, /unlockInFlightRef/);
   assert.match(unlock, /handleUnlock\(completedPin\)/);
@@ -115,7 +200,7 @@ test("XChat unlocks as soon as a complete PIN is entered", () => {
   assert.match(agentCard, /useState\(true\)/);
   assert.match(
     pinPreferences,
-    /aria-label="Remember XChat PIN on this device"/
+    /aria-label="Remember X\/Twitter Chat PIN on this device"/
   );
   assert.doesNotMatch(pinPreferences, /bg-muted\/50/);
   assert.match(unlock, /pinToUse && rememberOnDevice/);
@@ -124,7 +209,9 @@ test("XChat unlocks as soon as a complete PIN is entered", () => {
   assert.match(agentCard, /isPreparingUnlock/);
   assert.match(agentCard, /shouldRequestPin/);
   assert.match(agentCard, /if \(rememberOnDevice\)/);
-  assert.match(header, /Forget saved XChat PINs/);
+  assert.match(agentCard, /status: "dm_restricted"/);
+  assert.match(agentCard, /response\.reason === "xchat_access_denied"/);
+  assert.match(header, /Forget saved X\/Twitter Chat PINs/);
   assert.doesNotMatch(agentCard, /transition-opacity/);
   assert.doesNotMatch(agentCard, /type="submit"/);
   assert.doesNotMatch(agentCard, /It never leaves this browser/);
@@ -568,7 +655,7 @@ test("XChat access failures stay locked without becoming console errors", () => 
 
   assert.match(unlock, /response\.availability === "blocked"/);
   assert.match(unlock, /status: "configuration_required"/);
-  assert.match(gate, /XChat API access unavailable/);
+  assert.match(gate, /Reconnect X\/Twitter/);
   assert.match(gate, /\/settings\/connected-accounts/);
   assert.match(session, /reason: "xchat_access_denied"/);
 });


### PR DESCRIPTION
## Summary

- Detect X/Twitter DM eligibility before an outreach action is approved or sent.
- Give the Agent structured eligibility context so it can adjust the plan naturally, including following first when appropriate.
- Show concise, consistent blocked-DM guidance in the prospect panel and Agent artifact without hardcoding the Agent reply.
- Preserve the existing XChat PIN flow and distinguish PIN/auth failures from recipient DM restrictions.

## Type Of Change

- [x] Bug fix
- [ ] Documentation update
- [x] UI or UX improvement
- [ ] Refactor
- [ ] New feature
- [ ] Infrastructure or tooling

## Why This Change

ReacherX previously surfaced a generic retry-style failure when X/Twitter rejected a DM because the connected account was not eligible to message that recipient. This change identifies the restriction, blocks invalid sends, gives the Agent the relevant context, and explains the available next steps in the product's existing language and UI patterns.

## Screenshots Or Recordings

After-state screenshots were captured during authenticated browser QA for both the Agent artifact and prospect conversation panel.

## Testing

- [x] `pnpm lint`
- [x] `pnpm build`
- [x] Full Vitest suite: 121 files / 618 tests
- [x] Targeted DM panel UI suite: 24 tests
- [x] TypeScript: `pnpm exec tsc --noEmit`
- [x] Prettier check on changed UI/test files
- [x] Manual authenticated browser verification
- [x] CodeRabbit review: 0 findings

Manual QA covered eligible recipients, blocked recipients, follow-back guidance, account switching guidance, XChat PIN handling, Agent artifact rendering, and prospect-panel alert rendering.

## Environment Or Schema Impact

No environment-variable changes or data migration. The eligibility metadata is backward compatible with existing records and provider responses.

## Checklist

- [x] I read `README.md` and `CONTRIBUTING.md`
- [x] I kept this PR focused
- [x] I used existing helpers and patterns where possible
- [ ] I updated docs when needed
- [x] I added screenshots for UI changes

## Notes For Maintainer

The Agent response remains model-generated. The implementation supplies structured X/Twitter eligibility context and renders only the compact status artifact; it does not turn the flow into a hardcoded state machine.
