### PR TITLE
Clear saved XChat PINs on logout

### DIFF
--- a/app/logout/complete/route.ts
+++ b/app/logout/complete/route.ts
@@ -1,8 +1,7 @@
 import { signOut } from "@workos-inc/authkit-nextjs";
-import { redirect } from "next/navigation";
 import { useLogger, withEvlog } from "@/shared/lib/logging/next";
 
-export const GET = withEvlog(async () => {
+export const POST = withEvlog(async () => {
   const log = useLogger();
   log.set({
     auth: {
@@ -12,6 +11,10 @@ export const GET = withEvlog(async () => {
     operation: "logout_route",
   });
 
-  await signOut();
-  redirect("/");
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL;
+  if (!siteUrl) {
+    throw new Error("NEXT_PUBLIC_SITE_URL is required for logout redirects.");
+  }
+
+  await signOut({ returnTo: new URL("/", siteUrl).toString() });
 });

--- a/app/logout/page.tsx
+++ b/app/logout/page.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { clearXChatBrowserData } from "@/features/agent/lib/xChatBrowserSession";
+import { submitDocumentFormIntentionally } from "@/shared/lib/convex/intentionalDocumentNavigation";
+
+const LOGOUT_COMPLETION_HREF = "/logout/complete";
+
+export default function LogoutPage() {
+  const completionFormRef = useRef<HTMLFormElement>(null);
+
+  useEffect(() => {
+    let isActive = true;
+
+    void clearXChatBrowserData()
+      .catch((error: unknown) => {
+        console.error("[Logout] Failed to clear XChat browser data", error);
+      })
+      .finally(() => {
+        if (isActive && completionFormRef.current) {
+          submitDocumentFormIntentionally(completionFormRef.current);
+        }
+      });
+
+    return () => {
+      isActive = false;
+    };
+  }, []);
+
+  return (
+    <main className="flex min-h-dvh items-center justify-center p-6">
+      <form
+        ref={completionFormRef}
+        action={LOGOUT_COMPLETION_HREF}
+        method="post"
+      />
+      <p className="text-muted-foreground text-sm" role="status">
+        Logging out…
+      </p>
+    </main>
+  );
+}

--- a/features/agent/lib/xChatBrowserSession.ts
+++ b/features/agent/lib/xChatBrowserSession.ts
@@ -32,6 +32,7 @@ import {
   writeStoredXChatPendingSend,
 } from "./xChatPendingSendStorage";
 import {
+  forgetAllRememberedXChatPins,
   forgetRememberedXChatPin,
   readRememberedXChatPin,
   rememberXChatPinOnDevice,
@@ -1746,6 +1747,12 @@ export function lockXChatInBrowser(): void {
     sessionStatesByProspectId.set(prospectId, { status: "locked" });
   }
   emitChange();
+}
+
+/** Removes decrypted XChat state and every PIN remembered by this browser. */
+export async function clearXChatBrowserData(): Promise<void> {
+  lockXChatInBrowser();
+  await forgetAllRememberedXChatPins();
 }
 
 type XChatMediaDecryptor = Pick<ChatWithJuicebox, "decryptStream">;

--- a/features/agent/lib/xChatDeviceCredentialStorage.ts
+++ b/features/agent/lib/xChatDeviceCredentialStorage.ts
@@ -252,11 +252,17 @@ export async function forgetRememberedXChatPin(
 
 /** Clears both encrypted PIN records and their non-extractable device key. */
 export async function forgetAllRememberedXChatPins(): Promise<void> {
-  if (typeof indexedDB === "undefined") return;
-  await new Promise<void>((resolve) => {
-    const request = indexedDB.deleteDatabase(DATABASE_NAME);
-    request.addEventListener("success", () => resolve(), { once: true });
-    request.addEventListener("error", () => resolve(), { once: true });
-    request.addEventListener("blocked", () => resolve(), { once: true });
-  });
+  const database = await openCredentialDatabase();
+  if (!database) return;
+  try {
+    const transaction = database.transaction(
+      [DEVICE_KEYS_STORE, CREDENTIALS_STORE],
+      "readwrite"
+    );
+    transaction.objectStore(DEVICE_KEYS_STORE).clear();
+    transaction.objectStore(CREDENTIALS_STORE).clear();
+    await transactionComplete(transaction);
+  } finally {
+    database.close();
+  }
 }

--- a/features/agent/ui/components/XChatPinPreferences.tsx
+++ b/features/agent/ui/components/XChatPinPreferences.tsx
@@ -29,9 +29,9 @@ export function XChatRememberPinOption({
         onCheckedChange={(checked) =>
           onRememberOnDeviceChange(checked === true)
         }
-        aria-label="Remember X/Twitter Chat PIN on this device"
+        aria-label="Remember X/Twitter Chat PIN until logout"
       />
-      <span>Remember this device</span>
+      <span>Remember until I log out</span>
     </label>
   );
 }

--- a/features/linked-accounts/hooks/useXAccountConnection.ts
+++ b/features/linked-accounts/hooks/useXAccountConnection.ts
@@ -7,8 +7,7 @@ import { api } from "@/convex/_generated/api";
 import { showStyleSyncIssueToast } from "@/features/linked-accounts/lib/styleSyncIssueToast";
 import { logger } from "@/shared/lib/logger";
 import { toast } from "sonner";
-import { lockXChatInBrowser } from "@/features/agent/lib/xChatBrowserSession";
-import { forgetAllRememberedXChatPins } from "@/features/agent/lib/xChatDeviceCredentialStorage";
+import { clearXChatBrowserData } from "@/features/agent/lib/xChatBrowserSession";
 
 export type TwitterConnectionStatus = {
   isConnected: boolean;
@@ -216,8 +215,14 @@ export function useXAccountConnection({
           state: oauthState,
         });
         if (connectedAccountIdRef.current !== nextStatus.connectedAccountId) {
-          lockXChatInBrowser();
-          await forgetAllRememberedXChatPins();
+          try {
+            await clearXChatBrowserData();
+          } catch (cleanupError) {
+            logger.warn(
+              "Failed to clear XChat browser data after X account change:",
+              cleanupError
+            );
+          }
         }
         setXStatus(nextStatus);
         setStatusError(null);
@@ -286,8 +291,14 @@ export function useXAccountConnection({
     try {
       setIsMutating(true);
       await disconnectTwitter({});
-      lockXChatInBrowser();
-      await forgetAllRememberedXChatPins();
+      try {
+        await clearXChatBrowserData();
+      } catch (cleanupError) {
+        logger.warn(
+          "Failed to clear XChat browser data after X account disconnect:",
+          cleanupError
+        );
+      }
       toast.success("Disconnected X/Twitter account");
       await refreshStatus();
     } catch (err) {

--- a/features/webapp/ui/components/Header.tsx
+++ b/features/webapp/ui/components/Header.tsx
@@ -82,8 +82,6 @@ import {
   usePreferredShellContext,
 } from "@/shared/stores/preferredShellContext";
 import { logger } from "@/shared/lib/logger";
-import { lockXChatInBrowser } from "@/features/agent/lib/xChatBrowserSession";
-import { forgetAllRememberedXChatPins } from "@/features/agent/lib/xChatDeviceCredentialStorage";
 
 const headerLogger = logger.withScope("Header");
 import { useNewWorkspaceDraftFlow } from "@/features/webapp/hooks/useNewWorkspaceDraftFlow";
@@ -987,24 +985,10 @@ export function Header({
                   </Link>
                 </DropdownMenuItem>
 
-                <DropdownMenuItem
-                  onClick={() => {
-                    void forgetAllRememberedXChatPins().then(() =>
-                      toast.success("Saved X/Twitter Chat PINs removed")
-                    );
-                  }}
-                >
-                  <LockIcon className="fill-current" aria-hidden="true" />
-                  Forget saved X/Twitter Chat PINs
-                </DropdownMenuItem>
-
                 {/* Log out */}
                 <DropdownMenuItem
                   onClick={() => {
-                    lockXChatInBrowser();
-                    void forgetAllRememberedXChatPins().finally(() =>
-                      router.push("/logout")
-                    );
+                    router.push("/logout");
                   }}
                 >
                   <LogoutIcon className="fill-current" aria-hidden="true" />

--- a/proxy.ts
+++ b/proxy.ts
@@ -4,7 +4,7 @@ import type { NextRequest } from "next/server";
 const PUBLIC_PATH_PATTERNS = [
   /^\/login$/,
   /^\/signup$/,
-  /^\/logout$/,
+  /^\/logout(?:\/complete)?$/,
   /^\/callback$/,
   /^\/home(?:\/.*)?$/,
   /^\/threads(?:\/.*)?$/,

--- a/shared/lib/convex/intentionalDocumentNavigation.ts
+++ b/shared/lib/convex/intentionalDocumentNavigation.ts
@@ -8,6 +8,12 @@ type DocumentLocation = {
   assign: (href: string) => void;
 };
 
+type DocumentForm = {
+  checkValidity: () => boolean;
+  noValidate: boolean;
+  requestSubmit: () => void;
+};
+
 type ScheduleReset = (reset: () => void) => void;
 
 type BeforeUnloadTarget = {
@@ -42,6 +48,24 @@ export function createIntentionalDocumentNavigationController() {
         intentionalNavigationPending = false;
       });
     },
+    submit(form: DocumentForm, scheduleReset: ScheduleReset) {
+      if (!form.noValidate && !form.checkValidity()) {
+        return;
+      }
+
+      intentionalNavigationPending = true;
+
+      try {
+        form.requestSubmit();
+      } catch (error) {
+        intentionalNavigationPending = false;
+        throw error;
+      }
+
+      scheduleReset(() => {
+        intentionalNavigationPending = false;
+      });
+    },
     shouldWarnBeforeUnload(hasInflightRequests: boolean): boolean {
       if (intentionalNavigationPending) {
         intentionalNavigationPending = false;
@@ -58,6 +82,12 @@ const intentionalNavigationController =
 
 export function navigateDocumentIntentionally(href: string): void {
   intentionalNavigationController.navigate(href, window.location, (reset) => {
+    window.setTimeout(reset, INTENTIONAL_NAVIGATION_RESET_MS);
+  });
+}
+
+export function submitDocumentFormIntentionally(form: HTMLFormElement): void {
+  intentionalNavigationController.submit(form, (reset) => {
     window.setTimeout(reset, INTENTIONAL_NAVIGATION_RESET_MS);
   });
 }

--- a/tests/dm-panel-ui-hardening.test.ts
+++ b/tests/dm-panel-ui-hardening.test.ts
@@ -178,7 +178,7 @@ test("XChat unlocks as soon as a complete PIN is entered", () => {
   assert.match(gate, /<XChatPinRecoveryActions/);
   assert.match(agentCard, /<XChatRememberPinOption/);
   assert.match(agentCard, /<XChatPinRecoveryActions/);
-  assert.match(pinPreferences, /Remember this device/);
+  assert.match(pinPreferences, /Remember until I log out/);
   assert.match(pinPreferences, /Clear saved PINs/);
   assert.match(pinPreferences, /Forgot PIN\?/);
   assert.match(pinPreferences, /variant="link"/);
@@ -200,7 +200,7 @@ test("XChat unlocks as soon as a complete PIN is entered", () => {
   assert.match(agentCard, /useState\(true\)/);
   assert.match(
     pinPreferences,
-    /aria-label="Remember X\/Twitter Chat PIN on this device"/
+    /aria-label="Remember X\/Twitter Chat PIN until logout"/
   );
   assert.doesNotMatch(pinPreferences, /bg-muted\/50/);
   assert.match(unlock, /pinToUse && rememberOnDevice/);
@@ -211,7 +211,7 @@ test("XChat unlocks as soon as a complete PIN is entered", () => {
   assert.match(agentCard, /if \(rememberOnDevice\)/);
   assert.match(agentCard, /status: "dm_restricted"/);
   assert.match(agentCard, /response\.reason === "xchat_access_denied"/);
-  assert.match(header, /Forget saved X\/Twitter Chat PINs/);
+  assert.doesNotMatch(header, /Forget saved X\/Twitter Chat PINs/);
   assert.doesNotMatch(agentCard, /transition-opacity/);
   assert.doesNotMatch(agentCard, /type="submit"/);
   assert.doesNotMatch(agentCard, /It never leaves this browser/);

--- a/tests/intentional-document-navigation.test.ts
+++ b/tests/intentional-document-navigation.test.ts
@@ -57,3 +57,76 @@ test("the fallback reset restores protection when no unload occurs", () => {
 
   assert.equal(controller.shouldWarnBeforeUnload(true), true);
 });
+
+test("intentional form submission bypasses one unload warning", () => {
+  const controller = createIntentionalDocumentNavigationController();
+  let submissions = 0;
+
+  controller.submit(
+    {
+      checkValidity: () => true,
+      noValidate: false,
+      requestSubmit: () => submissions++,
+    },
+    () => undefined
+  );
+
+  assert.equal(submissions, 1);
+  assert.equal(controller.shouldWarnBeforeUnload(true), false);
+  assert.equal(controller.shouldWarnBeforeUnload(true), true);
+});
+
+test("failed form submission preserves the genuine unload warning", () => {
+  const controller = createIntentionalDocumentNavigationController();
+
+  assert.throws(
+    () =>
+      controller.submit(
+        {
+          checkValidity: () => true,
+          noValidate: false,
+          requestSubmit: () => {
+            throw new Error("submission failed");
+          },
+        },
+        () => undefined
+      ),
+    /submission failed/
+  );
+
+  assert.equal(controller.shouldWarnBeforeUnload(true), true);
+});
+
+test("invalid form submission preserves the genuine unload warning", () => {
+  const controller = createIntentionalDocumentNavigationController();
+  let submissions = 0;
+
+  controller.submit(
+    {
+      checkValidity: () => false,
+      noValidate: false,
+      requestSubmit: () => submissions++,
+    },
+    () => undefined
+  );
+
+  assert.equal(submissions, 0);
+  assert.equal(controller.shouldWarnBeforeUnload(true), true);
+});
+
+test("noValidate forms may submit without constraint validation", () => {
+  const controller = createIntentionalDocumentNavigationController();
+  let submissions = 0;
+
+  controller.submit(
+    {
+      checkValidity: () => false,
+      noValidate: true,
+      requestSubmit: () => submissions++,
+    },
+    () => undefined
+  );
+
+  assert.equal(submissions, 1);
+  assert.equal(controller.shouldWarnBeforeUnload(true), false);
+});

--- a/tests/xchat-logout-cleanup.test.ts
+++ b/tests/xchat-logout-cleanup.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+function read(path: string): string {
+  return readFileSync(path, "utf8");
+}
+
+test("logout clears XChat browser data before ending the WorkOS session", () => {
+  const logoutPage = read("app/logout/page.tsx");
+  const logoutRoute = read("app/logout/complete/route.ts");
+  const proxy = read("proxy.ts");
+
+  assert.match(logoutPage, /clearXChatBrowserData\(\)/);
+  assert.ok(
+    logoutPage.indexOf("clearXChatBrowserData()") <
+      logoutPage.indexOf("submitDocumentFormIntentionally(")
+  );
+  assert.match(logoutPage, /\/logout\/complete/);
+  assert.match(logoutPage, /method="post"/);
+  assert.match(logoutRoute, /export const POST/);
+  assert.doesNotMatch(logoutRoute, /export const GET/);
+  assert.match(
+    logoutRoute,
+    /await signOut\(\{ returnTo: new URL\("\/", siteUrl\)\.toString\(\) \}\)/
+  );
+  assert.doesNotMatch(logoutRoute, /redirect\("\/"\)/);
+  assert.match(proxy, /\^\\\/logout\(\?:\\\/complete\)\?\$/);
+});
+
+test("clearing XChat browser data removes memory, PINs, and the device key", () => {
+  const browserSession = read("features/agent/lib/xChatBrowserSession.ts");
+  const credentialStorage = read(
+    "features/agent/lib/xChatDeviceCredentialStorage.ts"
+  );
+
+  assert.match(
+    browserSession,
+    /clearXChatBrowserData[\s\S]*?lockXChatInBrowser\(\);[\s\S]*?await forgetAllRememberedXChatPins\(\)/
+  );
+  assert.match(
+    credentialStorage,
+    /transaction\.objectStore\(DEVICE_KEYS_STORE\)\.clear\(\)/
+  );
+  assert.match(
+    credentialStorage,
+    /transaction\.objectStore\(CREDENTIALS_STORE\)\.clear\(\)/
+  );
+  assert.doesNotMatch(credentialStorage, /deleteDatabase/);
+});
+
+test("X account replacement and disconnect clear XChat browser data", () => {
+  const connection = read(
+    "features/linked-accounts/hooks/useXAccountConnection.ts"
+  );
+
+  assert.equal(connection.match(/await clearXChatBrowserData\(\)/g)?.length, 2);
+  assert.equal(connection.match(/catch \(cleanupError\)/g)?.length, 2);
+  assert.match(
+    connection,
+    /connectedAccountIdRef\.current !== nextStatus\.connectedAccountId[\s\S]*?await clearXChatBrowserData\(\)[\s\S]*?Failed to clear XChat browser data after X account change:[\s\S]*?setXStatus\(nextStatus\)/
+  );
+  assert.match(
+    connection,
+    /await disconnectTwitter\(\{\}\);[\s\S]*?await clearXChatBrowserData\(\)[\s\S]*?Failed to clear XChat browser data after X account disconnect:[\s\S]*?toast\.success\("Disconnected X\/Twitter account"\)/
+  );
+});
+
+test("invalid remembered PINs are removed automatically", () => {
+  const browserSession = read("features/agent/lib/xChatBrowserSession.ts");
+
+  assert.match(
+    browserSession,
+    /failure\.kind === "invalid_pin"[\s\S]*?await forgetRememberedXChatPin\(target\)/
+  );
+});


### PR DESCRIPTION
## Summary

- remove the global saved XChat PIN cleanup action from the account dropdown
- rename the PIN preference to Remember until I log out while keeping the contextual Clear saved PINs action
- clear decrypted XChat state, remembered PINs, and the browser device key on logout, X account replacement, and disconnect
- complete logout through a POST route and return to the configured app URL

## Verification

- 509 Node tests passed
- 618 Convex/Vitest tests passed
- strict lint passed with zero warnings
- TypeScript passed
- Prettier passed
- Next.js production build passed
- browser E2E verified PIN entry, contextual clearing, logout cleanup, correct return URL, and empty IndexedDB stores
- CodeRabbit final review returned zero findings

## Notes

- no Convex backend changes or migrations
- intentionally not merged