### PR TITLE
Fix missing logger dependency in production functions

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,16 +1,19 @@
-import { defineNodeInstrumentation } from "evlog/next/instrumentation";
-import {
-  getLogEnvironmentContext,
-  getLogServiceName,
-} from "@/shared/lib/logging/config";
+import type { NodeInstrumentationHooks } from "evlog/next/instrumentation";
 
-const environment = getLogEnvironmentContext();
+export async function register() {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    // A literal import lets Next.js trace the logger into deployed functions.
+    const instrumentation =
+      await import("@/shared/lib/logging/instrumentationHelpers");
+    await instrumentation.register();
+  }
+}
 
-export const { register, onRequestError } = defineNodeInstrumentation({
-  service: getLogServiceName(),
-  env: environment,
-  pretty: environment.environment !== "production",
-  stringify: true,
-  minLevel: environment.environment === "production" ? "info" : "debug",
-  captureOutput: false,
-});
+export const onRequestError: NodeInstrumentationHooks["onRequestError"] =
+  async (error, request, context) => {
+    if (process.env.NEXT_RUNTIME === "nodejs") {
+      const instrumentation =
+        await import("@/shared/lib/logging/instrumentationHelpers");
+      await instrumentation.onRequestError(error, request, context);
+    }
+  };

--- a/shared/lib/logging/instrumentationHelpers.ts
+++ b/shared/lib/logging/instrumentationHelpers.ts
@@ -1,0 +1,13 @@
+import { createInstrumentation } from "evlog/next/instrumentation/create";
+import { getLogEnvironmentContext, getLogServiceName } from "./config";
+
+const environment = getLogEnvironmentContext();
+
+export const { register, onRequestError } = createInstrumentation({
+  service: getLogServiceName(),
+  env: environment,
+  pretty: environment.environment !== "production",
+  stringify: true,
+  minLevel: environment.environment === "production" ? "info" : "debug",
+  captureOutput: false,
+});

--- a/tests/build/instrumentation.test.mjs
+++ b/tests/build/instrumentation.test.mjs
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, relative, resolve } from "node:path";
+import test from "node:test";
+
+// Run after `pnpm build`: only traced deployment files are available to the child.
+test("deployed instrumentation starts and logs errors without repository dependencies", () => {
+  const root = process.cwd();
+  const entry = resolve(root, ".next/server/instrumentation.js");
+  const trace = JSON.parse(readFileSync(`${entry}.nft.json`, "utf8"));
+  const isolated = mkdtempSync(join(tmpdir(), "reacher-instrumentation-"));
+
+  try {
+    for (const file of [
+      entry,
+      ...trace.files.map((file) => resolve(dirname(entry), file)),
+    ]) {
+      const projectPath = relative(root, file);
+      assert.ok(
+        !projectPath.startsWith(".."),
+        `Trace escapes project: ${projectPath}`
+      );
+      const destination = join(isolated, projectPath);
+      mkdirSync(dirname(destination), { recursive: true });
+      copyFileSync(file, destination);
+    }
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--input-type=commonjs",
+        "-e",
+        `
+      const hooks = require('./.next/server/instrumentation.js');
+      (async () => {
+        await Promise.all([hooks.register(), hooks.register()]);
+        await hooks.onRequestError(
+          new Error('Instrumentation deployment smoke test'),
+          { path: '/instrumentation-smoke', method: 'GET', headers: {} },
+          { routerKind: 'App Router', routePath: '/instrumentation-smoke', routeType: 'render' }
+        );
+      })().catch(error => { console.error(error); process.exitCode = 1; });
+    `,
+      ],
+      {
+        cwd: isolated,
+        env: {
+          NODE_ENV: "production",
+          NEXT_RUNTIME: "nodejs",
+          LOG_ENVIRONMENT: "production",
+        },
+        encoding: "utf8",
+        timeout: 10_000,
+      }
+    );
+
+    assert.ifError(result.error);
+    assert.equal(result.status, 0, result.stderr);
+    const events = `${result.stdout}\n${result.stderr}`
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+    assert.ok(
+      events.some(
+        (event) =>
+          event.message === "Instrumentation deployment smoke test" &&
+          event.path === "/instrumentation-smoke" &&
+          event.level === "error"
+      ),
+      "The packaged error hook must emit the structured error"
+    );
+  } finally {
+    rmSync(isolated, { recursive: true, force: true });
+  }
+});

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,8 @@
   "installCommand": "corepack install && corepack pnpm install --frozen-lockfile",
   "git": {
     "deploymentEnabled": {
-      "codex/discovery-learning-completion": false
+      "codex/discovery-learning-completion": false,
+      "codex/instrumentation-runtime-fix": false
     }
   }
 }


### PR DESCRIPTION
Production functions crash while loading instrumentation because evlog's options-based loader constructs a dynamic package import that Next.js cannot trace. Import the Node-only logger through a literal, runtime-guarded module so deployed functions contain its dependencies. Existing logger settings and request-error behavior are preserved.

Validation:
- Production Next.js build, including TypeScript, passed without warnings.
- A packaged-runtime regression test copies only the instrumentation trace into a temporary directory, initializes concurrent hooks, and verifies structured error output. It reproduces `ERR_MODULE_NOT_FOUND` on the previous main build and passes with this fix.
- Changed-file strict lint and CodeRabbit review passed (0 issues).

Run the packaging check after a build: `node --test tests/build/instrumentation.test.mjs`.

The branch disables its automatic preview deployment; merging to main uses the existing production pipeline. No Convex code or data migration is included.

Reference: https://nextjs.org/docs/app/guides/instrumentation#importing-runtime-specific-code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Node.js runtime instrumentation so application registration and request errors are handled consistently.
  * Enhanced structured error logging during production requests, including environment and service context.

* **Tests**
  * Added an integration test validating instrumentation behavior in an isolated production deployment environment.

* **Chores**
  * Updated deployment settings for the instrumentation runtime branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->