### PR TITLE
Allow longer workspace targeting generation

### DIFF
--- a/convex/lib/ai.ts
+++ b/convex/lib/ai.ts
@@ -111,7 +111,10 @@ type OpenRouterRoutingPreset =
 
 const FAST_MODEL_TIMEOUT_MS = 10_000;
 const REASONING_MODEL_TIMEOUT_MS = 45_000;
-const ONBOARDING_MODEL_TIMEOUT_MS = 45_000;
+// Targeting generation returns a description, criteria, profiles, and search
+// signals in one response. Production refreshes can exceed the shorter
+// qualification budget; two bounded attempts still fit within an action.
+const ONBOARDING_MODEL_TIMEOUT_MS = 120_000;
 
 type RoutingPreset = "fast" | "reasoning";
 

--- a/convex/lib/onboardingTimeout.test.ts
+++ b/convex/lib/onboardingTimeout.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { generateTextWithJsonParse } from "./ai";
+
+const { generateTextMock } = vi.hoisted(() => ({
+  generateTextMock: vi.fn(),
+}));
+
+vi.mock("ai", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("ai")>()),
+  generateText: generateTextMock,
+}));
+
+vi.mock("@openrouter/ai-sdk-provider", () => ({
+  createOpenRouter: () => () => ({ specificationVersion: "v3" }),
+}));
+
+describe("onboarding generation timeout", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubEnv("OPENROUTER_API_KEY", "test-key");
+    vi.spyOn(AbortSignal, "timeout").mockImplementation((delay) => {
+      const controller = new AbortController();
+      setTimeout(() => controller.abort(new Error("request timed out")), delay);
+      return controller.signal;
+    });
+    generateTextMock.mockImplementation(
+      ({ abortSignal }: { abortSignal: AbortSignal }) =>
+        new Promise((resolve, reject) => {
+          const timer = setTimeout(
+            () => resolve({ text: '{"audience":"creators"}', usage: {} }),
+            60_000
+          );
+          abortSignal.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(abortSignal.reason);
+            },
+            { once: true }
+          );
+        })
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    generateTextMock.mockReset();
+  });
+
+  const generate = (routing: "onboarding" | "reasoning") =>
+    generateTextWithJsonParse({
+      operation: "regenerateWorkspaceTargeting",
+      schema: z.object({ audience: z.string() }),
+      system: "Return the requested audience.",
+      prompt: "Find creators.",
+      routing,
+      maxRetries: 1,
+    });
+
+  it("accepts a valid targeting response that takes longer than 45 seconds", async () => {
+    const result = generate("onboarding");
+    const assertion = expect(result).resolves.toMatchObject({
+      object: { audience: "creators" },
+    });
+    await vi.advanceTimersByTimeAsync(60_000);
+    await assertion;
+    expect(generateTextMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps qualification requests on their existing shorter timeout", async () => {
+    const assertion = expect(generate("reasoning")).rejects.toThrow(
+      "request timed out"
+    );
+    await vi.advanceTimersByTimeAsync(60_000);
+    await assertion;
+  });
+
+  it("still aborts an onboarding provider that never returns", async () => {
+    generateTextMock.mockImplementation(
+      ({ abortSignal }: { abortSignal: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          abortSignal.addEventListener(
+            "abort",
+            () => reject(abortSignal.reason),
+            {
+              once: true,
+            }
+          );
+        })
+    );
+    const assertion = expect(generate("onboarding")).rejects.toThrow(
+      "request timed out"
+    );
+    await vi.advanceTimersByTimeAsync(120_000);
+    await assertion;
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,8 @@
   "git": {
     "deploymentEnabled": {
       "codex/discovery-learning-completion": false,
-      "codex/instrumentation-runtime-fix": false
+      "codex/instrumentation-runtime-fix": false,
+      "codex/workspace-refresh-timeout": false
     }
   }
 }


### PR DESCRIPTION
Production workspace refreshes repeatedly aborted valid targeting generation after 45 seconds. Give the dedicated onboarding route a bounded 120-second budget so it can return the complete description, criteria, profiles, and search signals. Fast discovery and normal qualification retain their existing timeouts, models, and retry behavior.

A live QA refresh of the same request completed in 73 seconds with the new budget. All saved qualification decisions and the reporting checkpoint were preserved; preexisting RAG cleanup only updated its cleanup timestamps. Additional live QA checks passed for a short candidate request (39 seconds) and a refresh preserving all four manually maintained profiles (68 seconds). All four existing QA prospect records and the reporting checkpoint stayed unchanged in those checks.

Validation: regression reproduced with the old budget and passed with the new one; bounded-timeout and unchanged-qualification-budget tests; targeting preservation integration tests; TypeScript; lint; production build. CodeRabbit raised 0 issues in the production-code diff. Automatic deployment of this branch is disabled so review and QA finish before release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the onboarding AI response time limit to 120 seconds, allowing longer-running onboarding requests to complete successfully.
  * Preserved the shorter timeout for reasoning requests.
* **Tests**
  * Added coverage for delayed, successful, and unresponsive onboarding AI requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->