### PR TITLE
Fix Convex deployment typecheck in Agent Ops tests

### DIFF
--- a/convex/agentOpsDashboard.integration.test.ts
+++ b/convex/agentOpsDashboard.integration.test.ts
@@ -244,7 +244,7 @@ describe("bounded reactive Agent Ops dashboard", () => {
       expect(bucketSet.buckets[0].startMs).toBe(
         normalizedWindow.current.startMs
       );
-      expect(bucketSet.buckets.at(-1)!.endMs).toBe(
+      expect(bucketSet.buckets[bucketSet.buckets.length - 1].endMs).toBe(
         normalizedWindow.current.endMs
       );
       const summary = await owner.query(

--- a/convex/lib/agentOpsDashboardCore.test.ts
+++ b/convex/lib/agentOpsDashboardCore.test.ts
@@ -28,7 +28,7 @@ describe("Agent Ops chart bounds and calendar coverage", () => {
       expect(bucketSet.buckets[0].startMs).toBe(
         normalizedWindow.current.startMs
       );
-      expect(bucketSet.buckets.at(-1)!.endMs).toBe(
+      expect(bucketSet.buckets[bucketSet.buckets.length - 1].endMs).toBe(
         normalizedWindow.current.endMs
       );
     }
@@ -55,7 +55,7 @@ describe("Agent Ops chart bounds and calendar coverage", () => {
         expect(bucketSet.buckets[i].startMs).toBe(
           bucketSet.buckets[i - 1].endMs
         );
-      expect(bucketSet.buckets.at(-1)!.endMs).toBe(
+      expect(bucketSet.buckets[bucketSet.buckets.length - 1].endMs).toBe(
         normalizedWindow.current.endMs
       );
     }

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,7 @@
   "installCommand": "corepack install && corepack pnpm install --frozen-lockfile",
   "git": {
     "deploymentEnabled": {
+      "codex/fix-agent-ops-convex-typecheck": false,
       "codex/fix-agent-ops-query-budget": false,
       "codex/discovery-learning-completion": false,
       "codex/instrumentation-runtime-fix": false,


### PR DESCRIPTION
## Summary

Replace three `Array.at(-1)` calls in Agent Ops test assertions with standard array indexing. Convex checks these files with its ES2021 library configuration, where `.at()` is unavailable, so production deployment failed even though the Next.js build passed.

## Type Of Change

- [x] Bug fix

## Why This Change

Unblock the deployment of #77 without changing dashboard behavior, compiler settings, schema, or stored data. Keep automatic deployment disabled for this review branch until merge approval; main deployment remains enabled.

## Screenshots Or Recordings

Not applicable: test assertions and branch deployment configuration only.

## Testing

- Reproduced all three production TS2550 errors before the fix using `tsc --noEmit -p convex/tsconfig.json`.
- Convex TypeScript check passed after the fix.
- App TypeScript check passed.
- `convex codegen --typecheck enable` passed, exercising Convex’s CLI generation and typecheck path.
- CodeRabbit reviewed all three changed files and raised 0 issues.
- Both affected test files passed: 17 tests, including the Aggregate limit regression and calendar/slice coverage.
- Strict lint, Prettier, and `git diff --check` passed.

## Environment Or Schema Impact

No migration, backfill, dependency, environment-variable, or schema changes. No typecheck bypass. Automatic deployment remains enabled for main and disabled for this review branch.

## Checklist

- [x] Read README.md and CONTRIBUTING.md.
- [x] Kept the PR focused and used an existing array-indexing pattern.
- [x] Validated using the separate Convex compiler configuration.

## Notes For Maintainer

Wait for explicit merge approval. After merge, the existing automatic deployment can run normally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated dashboard test coverage to use broadly compatible array access while preserving existing validation behavior.

- **Chores**
  - Added deployment configuration to prevent Git-based deployments for a designated development branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->