### PR TITLE
Keep logout on the current page with delayed Sonner feedback

### DIFF
--- a/app/logout/page.tsx
+++ b/app/logout/page.tsx
@@ -1,42 +1,12 @@
 "use client";
 
-import { useEffect, useRef } from "react";
-import { clearXChatBrowserData } from "@/features/agent/lib/xChatBrowserSession";
-import { submitDocumentFormIntentionally } from "@/shared/lib/convex/intentionalDocumentNavigation";
-
-const LOGOUT_COMPLETION_HREF = "/logout/complete";
+import { useEffect } from "react";
+import { logout } from "@/shared/lib/auth/logout";
 
 export default function LogoutPage() {
-  const completionFormRef = useRef<HTMLFormElement>(null);
-
   useEffect(() => {
-    let isActive = true;
-
-    void clearXChatBrowserData()
-      .catch((error: unknown) => {
-        console.error("[Logout] Failed to clear XChat browser data", error);
-      })
-      .finally(() => {
-        if (isActive && completionFormRef.current) {
-          submitDocumentFormIntentionally(completionFormRef.current);
-        }
-      });
-
-    return () => {
-      isActive = false;
-    };
+    void logout();
   }, []);
 
-  return (
-    <main className="flex min-h-dvh items-center justify-center p-6">
-      <form
-        ref={completionFormRef}
-        action={LOGOUT_COMPLETION_HREF}
-        method="post"
-      />
-      <p className="text-muted-foreground text-sm" role="status">
-        Logging out…
-      </p>
-    </main>
-  );
+  return null;
 }

--- a/features/landing/ui/components/LandingAuthLink.tsx
+++ b/features/landing/ui/components/LandingAuthLink.tsx
@@ -2,6 +2,7 @@
 
 import { forwardRef, type ComponentProps, type MouseEvent } from "react";
 import Link from "next/link";
+import { logout } from "@/shared/lib/auth/logout";
 import { navigateDocumentIntentionally } from "@/shared/lib/convex/intentionalDocumentNavigation";
 import type { AuthRouteHref } from "@/shared/lib/urls/authRoutes";
 
@@ -31,6 +32,10 @@ export const LandingAuthLink = forwardRef<
     }
 
     event.preventDefault();
+    if (href.split("?")[0] === "/logout") {
+      void logout();
+      return;
+    }
     navigateDocumentIntentionally(href);
   };
 

--- a/features/webapp/ui/components/Header.tsx
+++ b/features/webapp/ui/components/Header.tsx
@@ -10,6 +10,7 @@ import { usePathname, useRouter } from "next/navigation";
 import { useAuth } from "@workos-inc/authkit-nextjs/components";
 
 import { cn } from "@/shared/lib/utils";
+import { logout } from "@/shared/lib/auth/logout";
 import { buildSetupHref } from "@/shared/lib/urls/setupHref";
 import { getWorkspaceSwitchHref } from "@/shared/lib/urls/workspaceSwitchHref";
 import { api } from "@/convex/_generated/api";
@@ -987,8 +988,8 @@ export function Header({
 
                 {/* Log out */}
                 <DropdownMenuItem
-                  onClick={() => {
-                    router.push("/logout");
+                  onSelect={() => {
+                    void logout();
                   }}
                 >
                   <LogoutIcon className="fill-current" aria-hidden="true" />

--- a/shared/lib/auth/logout.test.ts
+++ b/shared/lib/auth/logout.test.ts
@@ -24,6 +24,45 @@ afterEach(() => {
 });
 
 describe("browser logout integration", () => {
+  test("a stalled POST replaces loading with retry and pagehide clears the new deadline", async () => {
+    const requestSubmit = vi.fn();
+    const addEventListener = vi.fn();
+    vi.stubGlobal("window", { addEventListener, setTimeout });
+    vi.stubGlobal("document", {
+      createElement: () => ({
+        checkValidity: () => true,
+        requestSubmit,
+        remove: vi.fn(),
+      }),
+      body: { append: vi.fn() },
+    });
+    vi.stubGlobal("requestAnimationFrame", vi.fn());
+    const { logout } = await import("./logout");
+    const { toast } = await import("sonner");
+    await logout();
+    vi.advanceTimersByTime(750);
+    expect(toast.getToasts()).toEqual([
+      expect.objectContaining({ type: "loading", title: "Logging out…" }),
+    ]);
+    vi.advanceTimersByTime(14_250);
+    expect(toast.getToasts()).toEqual([
+      expect.objectContaining({
+        type: "error",
+        title: "Couldn't log out. Please try again.",
+        action: expect.objectContaining({ label: "Try again" }),
+      }),
+    ]);
+    await logout();
+    expect(requestSubmit).toHaveBeenCalledTimes(2);
+    vi.advanceTimersByTime(750);
+    expect(toast.getToasts()).toEqual([
+      expect.objectContaining({ type: "loading", action: undefined }),
+    ]);
+    addEventListener.mock.calls[0][1]();
+    vi.advanceTimersByTime(30_000);
+    expect(toast.getToasts()).toHaveLength(0);
+  });
+
   test("submits a hidden POST after cleanup and resets on pagehide", async () => {
     const form = {
       action: "",

--- a/shared/lib/auth/logout.test.ts
+++ b/shared/lib/auth/logout.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const { clearBrowserData } = vi.hoisted(() => ({
+  clearBrowserData: vi.fn(async () => undefined),
+}));
+
+vi.mock("@/features/agent/lib/xChatBrowserSession", () => ({
+  clearXChatBrowserData: clearBrowserData,
+}));
+
+beforeEach(async () => {
+  vi.resetModules();
+  vi.useFakeTimers();
+  clearBrowserData.mockClear();
+  // Load Sonner before the minimal document stub; no stylesheet is needed.
+  await import("sonner");
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("browser logout integration", () => {
+  test("submits a hidden POST after cleanup and resets on pagehide", async () => {
+    const form = {
+      action: "",
+      method: "",
+      hidden: false,
+      checkValidity: () => true,
+      noValidate: false,
+      requestSubmit: vi.fn(() => {
+        expect(clearBrowserData).toHaveBeenCalledOnce();
+      }),
+      remove: vi.fn(),
+    };
+    const addEventListener = vi.fn();
+    const append = vi.fn();
+    vi.stubGlobal("window", { addEventListener, setTimeout });
+    vi.stubGlobal("document", { createElement: () => form, body: { append } });
+    vi.stubGlobal("requestAnimationFrame", vi.fn());
+    const { logout } = await import("./logout");
+    const { toast } = await import("sonner");
+    await logout();
+    expect(form).toMatchObject({
+      action: "/logout/complete",
+      method: "post",
+      hidden: true,
+    });
+    expect(append).toHaveBeenCalledWith(form);
+    expect(form.requestSubmit).toHaveBeenCalledOnce();
+    const reset = addEventListener.mock.calls[0][1];
+    reset();
+    vi.advanceTimersByTime(750);
+    expect(toast.getToasts()).toHaveLength(0);
+    await logout();
+    expect(form.requestSubmit).toHaveBeenCalledTimes(2);
+  });
+
+  test("Sonner keeps the error visible and removes its retry action when loading again", async () => {
+    const requestSubmit = vi.fn().mockImplementationOnce(() => {
+      throw new Error("submission blocked");
+    });
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.stubGlobal("window", { addEventListener: vi.fn(), setTimeout });
+    vi.stubGlobal("document", {
+      createElement: () => ({
+        checkValidity: () => true,
+        requestSubmit,
+        remove: vi.fn(),
+      }),
+      body: { append: vi.fn() },
+    });
+    vi.stubGlobal("requestAnimationFrame", vi.fn());
+    const { logout } = await import("./logout");
+    const { toast } = await import("sonner");
+    await logout();
+    expect(toast.getToasts()).toEqual([
+      expect.objectContaining({
+        type: "error",
+        title: "Couldn't log out. Please try again.",
+        action: expect.objectContaining({ label: "Try again" }),
+      }),
+    ]);
+    await logout();
+    vi.advanceTimersByTime(750);
+    expect(toast.getToasts()).toEqual([
+      expect.objectContaining({
+        type: "loading",
+        title: "Logging out…",
+        action: undefined,
+      }),
+    ]);
+    expect(requestSubmit).toHaveBeenCalledTimes(2);
+  });
+});

--- a/shared/lib/auth/logout.ts
+++ b/shared/lib/auth/logout.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { toast } from "sonner";
+import { submitDocumentFormIntentionally } from "@/shared/lib/convex/intentionalDocumentNavigation";
+import { createLogoutController } from "./logoutCore";
+
+const LOGOUT_TOAST_ID = "logout";
+
+const controller = createLogoutController({
+  clearBrowserData: async () => {
+    const { clearXChatBrowserData } =
+      await import("@/features/agent/lib/xChatBrowserSession");
+    await clearXChatBrowserData();
+  },
+  submitLogout: () => {
+    const form = document.createElement("form");
+    form.action = "/logout/complete";
+    form.method = "post";
+    form.hidden = true;
+    document.body.append(form);
+    try {
+      submitDocumentFormIntentionally(form);
+    } finally {
+      form.remove();
+    }
+  },
+  showPending: () =>
+    toast.loading("Logging out…", {
+      id: LOGOUT_TOAST_ID,
+      action: undefined,
+    }),
+  dismissPending: () => toast.dismiss(LOGOUT_TOAST_ID),
+  showError: () =>
+    toast.error("Couldn't log out. Please try again.", {
+      id: LOGOUT_TOAST_ID,
+      duration: Infinity,
+      action: { label: "Try again", onClick: () => void logout() },
+    }),
+});
+
+export function logout(): Promise<void> {
+  // The same listener is registered only once. Reset on pagehide also allows
+  // another logout after this document is restored from the back/forward cache.
+  window.addEventListener("pagehide", controller.reset);
+  return controller.start();
+}

--- a/shared/lib/auth/logoutCore.ts
+++ b/shared/lib/auth/logoutCore.ts
@@ -1,4 +1,10 @@
 const LOGOUT_TOAST_DELAY_MS = 750;
+const LOGOUT_NAVIGATION_TIMEOUT_MS = 15_000;
+
+type LogoutAttempt = {
+  toastTimer: ReturnType<typeof setTimeout>;
+  navigationTimer?: ReturnType<typeof setTimeout>;
+};
 
 type LogoutDependencies = {
   clearBrowserData: () => Promise<void>;
@@ -10,19 +16,33 @@ type LogoutDependencies = {
 
 /** Keeps one logout running even if its menu closes or the page re-renders. */
 export function createLogoutController(dependencies: LogoutDependencies) {
-  let attempt: { timer: ReturnType<typeof setTimeout> } | null = null;
+  let attempt: LogoutAttempt | null = null;
+
+  function clearAttempt() {
+    if (!attempt) return;
+    clearTimeout(attempt.toastTimer);
+    clearTimeout(attempt.navigationTimer);
+    attempt = null;
+  }
 
   function reset() {
     if (!attempt) return;
-    clearTimeout(attempt.timer);
-    attempt = null;
+    clearAttempt();
     dependencies.dismissPending();
+  }
+
+  function fail(currentAttempt: LogoutAttempt) {
+    if (attempt !== currentAttempt) return;
+    clearAttempt();
+    // Replace the toast in place. Dismissing its ID first can also dismiss
+    // the error Sonner publishes in the same render.
+    dependencies.showError();
   }
 
   async function start(): Promise<void> {
     if (attempt) return;
-    const currentAttempt = {
-      timer: setTimeout(dependencies.showPending, LOGOUT_TOAST_DELAY_MS),
+    const currentAttempt: LogoutAttempt = {
+      toastTimer: setTimeout(dependencies.showPending, LOGOUT_TOAST_DELAY_MS),
     };
     attempt = currentAttempt;
 
@@ -36,16 +56,16 @@ export function createLogoutController(dependencies: LogoutDependencies) {
 
       // The user may have left while browser cleanup was still pending.
       if (attempt !== currentAttempt) return;
+      // Keep the toast delay independent of the deadline for navigation.
+      // Arm this before submitting so even a synchronous reset cancels it.
+      currentAttempt.navigationTimer = setTimeout(
+        () => fail(currentAttempt),
+        LOGOUT_NAVIGATION_TIMEOUT_MS
+      );
       dependencies.submitLogout();
-      // Keep feedback and deduplication active until the document leaves,
-      // including time spent waiting for the sign-out response.
     } catch (error) {
       console.error("[Logout] Failed to submit logout", error);
-      clearTimeout(currentAttempt.timer);
-      attempt = null;
-      // Replace the loading toast in place. Dismissing its ID first can also
-      // dismiss the error Sonner publishes in the same render.
-      dependencies.showError();
+      fail(currentAttempt);
     }
   }
 

--- a/shared/lib/auth/logoutCore.ts
+++ b/shared/lib/auth/logoutCore.ts
@@ -1,0 +1,53 @@
+const LOGOUT_TOAST_DELAY_MS = 750;
+
+type LogoutDependencies = {
+  clearBrowserData: () => Promise<void>;
+  submitLogout: () => void;
+  showPending: () => void;
+  dismissPending: () => void;
+  showError: () => void;
+};
+
+/** Keeps one logout running even if its menu closes or the page re-renders. */
+export function createLogoutController(dependencies: LogoutDependencies) {
+  let attempt: { timer: ReturnType<typeof setTimeout> } | null = null;
+
+  function reset() {
+    if (!attempt) return;
+    clearTimeout(attempt.timer);
+    attempt = null;
+    dependencies.dismissPending();
+  }
+
+  async function start(): Promise<void> {
+    if (attempt) return;
+    const currentAttempt = {
+      timer: setTimeout(dependencies.showPending, LOGOUT_TOAST_DELAY_MS),
+    };
+    attempt = currentAttempt;
+
+    try {
+      try {
+        await dependencies.clearBrowserData();
+      } catch (error) {
+        // A browser storage failure must not prevent ending the auth session.
+        console.error("[Logout] Failed to clear XChat browser data", error);
+      }
+
+      // The user may have left while browser cleanup was still pending.
+      if (attempt !== currentAttempt) return;
+      dependencies.submitLogout();
+      // Keep feedback and deduplication active until the document leaves,
+      // including time spent waiting for the sign-out response.
+    } catch (error) {
+      console.error("[Logout] Failed to submit logout", error);
+      clearTimeout(currentAttempt.timer);
+      attempt = null;
+      // Replace the loading toast in place. Dismissing its ID first can also
+      // dismiss the error Sonner publishes in the same render.
+      dependencies.showError();
+    }
+  }
+
+  return { start, reset };
+}

--- a/tests/logout.test.ts
+++ b/tests/logout.test.ts
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import test, { type TestContext } from "node:test";
+import { createLogoutController } from "../shared/lib/auth/logoutCore";
+
+function setup(t: TestContext) {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  let finishCleanup!: () => void;
+  let failCleanup!: (error: Error) => void;
+  const cleanup = new Promise<void>((resolve, reject) => {
+    finishCleanup = resolve;
+    failCleanup = reject;
+  });
+  const dependencies = {
+    clearBrowserData: t.mock.fn(() => cleanup),
+    submitLogout: t.mock.fn(),
+    showPending: t.mock.fn(),
+    dismissPending: t.mock.fn(),
+    showError: t.mock.fn(),
+  };
+  const controller = createLogoutController(dependencies);
+  t.after(controller.reset);
+  return { controller, dependencies, finishCleanup, failCleanup };
+}
+
+test("fast logout clears data before submitting and never flashes a toast", async (t) => {
+  const { controller, dependencies, finishCleanup } = setup(t);
+  const logout = controller.start();
+  assert.equal(dependencies.submitLogout.mock.callCount(), 0);
+  finishCleanup();
+  await logout;
+  assert.equal(dependencies.submitLogout.mock.callCount(), 1);
+  controller.reset();
+  t.mock.timers.tick(1_000);
+  assert.equal(dependencies.showPending.mock.callCount(), 0);
+});
+
+test("slow cleanup shows one toast after 750 ms and waits before submitting", async (t) => {
+  const { controller, dependencies, finishCleanup } = setup(t);
+  const logout = controller.start();
+  t.mock.timers.tick(749);
+  assert.equal(dependencies.showPending.mock.callCount(), 0);
+  t.mock.timers.tick(1);
+  assert.equal(dependencies.showPending.mock.callCount(), 1);
+  assert.equal(dependencies.submitLogout.mock.callCount(), 0);
+  t.mock.timers.tick(10_000);
+  assert.equal(dependencies.showPending.mock.callCount(), 1);
+  finishCleanup();
+  await logout;
+  assert.equal(dependencies.submitLogout.mock.callCount(), 1);
+});
+
+test("a slow sign-out response also gets feedback after fast cleanup", async (t) => {
+  const { controller, dependencies, finishCleanup } = setup(t);
+  const logout = controller.start();
+  finishCleanup();
+  await logout;
+  t.mock.timers.tick(750);
+  assert.equal(dependencies.showPending.mock.callCount(), 1);
+  controller.reset();
+  assert.equal(dependencies.dismissPending.mock.callCount(), 1);
+});
+
+test("repeated clicks and Strict Mode do not repeat cleanup or submission", async (t) => {
+  const { controller, dependencies, finishCleanup } = setup(t);
+  const logout = controller.start();
+  await controller.start();
+  finishCleanup();
+  await logout;
+  await controller.start();
+  assert.equal(dependencies.clearBrowserData.mock.callCount(), 1);
+  assert.equal(dependencies.submitLogout.mock.callCount(), 1);
+});
+
+test("storage rejection is logged but does not strand an authenticated session", async (t) => {
+  const { controller, dependencies, failCleanup } = setup(t);
+  const log = t.mock.method(console, "error", () => undefined);
+  const logout = controller.start();
+  failCleanup(new Error("IndexedDB unavailable"));
+  await logout;
+  assert.equal(log.mock.callCount(), 1);
+  assert.equal(dependencies.submitLogout.mock.callCount(), 1);
+  assert.equal(dependencies.showError.mock.callCount(), 0);
+});
+
+test("a synchronous cleanup error also allows sign-out", async (t) => {
+  const { controller, dependencies } = setup(t);
+  t.mock.method(console, "error", () => undefined);
+  dependencies.clearBrowserData.mock.mockImplementation(() => {
+    throw new Error("storage access denied");
+  });
+  await controller.start();
+  assert.equal(dependencies.submitLogout.mock.callCount(), 1);
+});
+
+test("submission failure replaces the pending toast and permits retry", async (t) => {
+  const { controller, dependencies, finishCleanup } = setup(t);
+  t.mock.method(console, "error", () => undefined);
+  dependencies.submitLogout.mock.mockImplementationOnce(() => {
+    throw new Error("form submission failed");
+  });
+  const logout = controller.start();
+  t.mock.timers.tick(750);
+  finishCleanup();
+  await logout;
+  assert.equal(dependencies.dismissPending.mock.callCount(), 0);
+  assert.equal(dependencies.showError.mock.callCount(), 1);
+  await controller.start();
+  assert.equal(dependencies.submitLogout.mock.callCount(), 2);
+});
+
+test("leaving during cleanup cancels its later submission and toast", async (t) => {
+  const { controller, dependencies, finishCleanup } = setup(t);
+  const logout = controller.start();
+  controller.reset();
+  finishCleanup();
+  await logout;
+  t.mock.timers.tick(750);
+  assert.equal(dependencies.submitLogout.mock.callCount(), 0);
+  assert.equal(dependencies.showPending.mock.callCount(), 0);
+});
+
+test("restoring the document permits a new logout without an old attempt submitting", async (t) => {
+  const { controller, dependencies, finishCleanup } = setup(t);
+  const first = controller.start();
+  controller.reset();
+  const second = controller.start();
+  finishCleanup();
+  await Promise.all([first, second]);
+  assert.equal(dependencies.clearBrowserData.mock.callCount(), 2);
+  assert.equal(dependencies.submitLogout.mock.callCount(), 1);
+});

--- a/tests/logout.test.ts
+++ b/tests/logout.test.ts
@@ -129,3 +129,100 @@ test("restoring the document permits a new logout without an old attempt submitt
   assert.equal(dependencies.clearBrowserData.mock.callCount(), 2);
   assert.equal(dependencies.submitLogout.mock.callCount(), 1);
 });
+
+test("stalled navigation preserves delayed feedback, then allows one retry", async (t) => {
+  const { controller, dependencies, finishCleanup } = setup(t);
+  const logout = controller.start();
+  finishCleanup();
+  await logout;
+  t.mock.timers.tick(749);
+  assert.equal(dependencies.showPending.mock.callCount(), 0);
+  t.mock.timers.tick(1);
+  assert.equal(dependencies.showPending.mock.callCount(), 1);
+  t.mock.timers.tick(14_249);
+  assert.equal(dependencies.showError.mock.callCount(), 0);
+  await controller.start();
+  assert.equal(dependencies.submitLogout.mock.callCount(), 1);
+
+  t.mock.timers.tick(1);
+  assert.equal(dependencies.showError.mock.callCount(), 1);
+  assert.equal(dependencies.dismissPending.mock.callCount(), 0);
+  t.mock.timers.tick(60_000);
+  assert.equal(dependencies.showError.mock.callCount(), 1);
+
+  await controller.start();
+  await controller.start();
+  assert.equal(dependencies.submitLogout.mock.callCount(), 2);
+  t.mock.timers.tick(14_999);
+  assert.equal(dependencies.showError.mock.callCount(), 1);
+  t.mock.timers.tick(1);
+  assert.equal(dependencies.showError.mock.callCount(), 2);
+});
+
+test("cleanup time does not consume the navigation deadline", async (t) => {
+  const { controller, dependencies, finishCleanup } = setup(t);
+  const logout = controller.start();
+  t.mock.timers.tick(20_000);
+  assert.equal(dependencies.showError.mock.callCount(), 0);
+  assert.equal(dependencies.submitLogout.mock.callCount(), 0);
+  finishCleanup();
+  await logout;
+  t.mock.timers.tick(14_999);
+  assert.equal(dependencies.showError.mock.callCount(), 0);
+  t.mock.timers.tick(1);
+  assert.equal(dependencies.showError.mock.callCount(), 1);
+});
+
+test("leaving after submission cancels the toast and navigation timers", async (t) => {
+  const { controller, dependencies, finishCleanup } = setup(t);
+  const logout = controller.start();
+  finishCleanup();
+  await logout;
+  controller.reset();
+  t.mock.timers.tick(60_000);
+  assert.equal(dependencies.showPending.mock.callCount(), 0);
+  assert.equal(dependencies.showError.mock.callCount(), 0);
+});
+
+test("a synchronous reset during submission leaves no navigation timer", async (t) => {
+  const { controller, dependencies, finishCleanup } = setup(t);
+  dependencies.submitLogout.mock.mockImplementation(() => {
+    controller.reset();
+  });
+  const logout = controller.start();
+  finishCleanup();
+  await logout;
+  t.mock.timers.tick(60_000);
+  assert.equal(dependencies.showPending.mock.callCount(), 0);
+  assert.equal(dependencies.showError.mock.callCount(), 0);
+});
+
+test("submission errors cancel their deadline before a later retry", async (t) => {
+  const { controller, dependencies, finishCleanup } = setup(t);
+  t.mock.method(console, "error", () => undefined);
+  dependencies.submitLogout.mock.mockImplementationOnce(() => {
+    throw new Error("submission failed");
+  });
+  finishCleanup();
+  await controller.start();
+  assert.equal(dependencies.showError.mock.callCount(), 1);
+  t.mock.timers.tick(5_000);
+  await controller.start();
+  t.mock.timers.tick(10_000);
+  assert.equal(dependencies.showError.mock.callCount(), 1);
+  t.mock.timers.tick(5_000);
+  assert.equal(dependencies.showError.mock.callCount(), 2);
+});
+
+test("a restored document's new attempt cannot be expired by the old deadline", async (t) => {
+  const { controller, dependencies, finishCleanup } = setup(t);
+  finishCleanup();
+  await controller.start();
+  t.mock.timers.tick(5_000);
+  controller.reset();
+  await controller.start();
+  t.mock.timers.tick(10_000);
+  assert.equal(dependencies.showError.mock.callCount(), 0);
+  t.mock.timers.tick(5_000);
+  assert.equal(dependencies.showError.mock.callCount(), 1);
+});

--- a/tests/xchat-logout-cleanup.test.ts
+++ b/tests/xchat-logout-cleanup.test.ts
@@ -8,16 +8,21 @@ function read(path: string): string {
 
 test("logout clears XChat browser data before ending the WorkOS session", () => {
   const logoutPage = read("app/logout/page.tsx");
+  const logout = read("shared/lib/auth/logout.ts");
+  const logoutCore = read("shared/lib/auth/logoutCore.ts");
   const logoutRoute = read("app/logout/complete/route.ts");
   const proxy = read("proxy.ts");
 
-  assert.match(logoutPage, /clearXChatBrowserData\(\)/);
+  assert.match(logoutPage, /void logout\(\)/);
+  assert.doesNotMatch(logoutPage, /<main|Logging out/);
+  assert.match(logout, /await clearXChatBrowserData\(\)/);
   assert.ok(
-    logoutPage.indexOf("clearXChatBrowserData()") <
-      logoutPage.indexOf("submitDocumentFormIntentionally(")
+    logoutCore.indexOf("await dependencies.clearBrowserData()") <
+      logoutCore.indexOf("dependencies.submitLogout()")
   );
-  assert.match(logoutPage, /\/logout\/complete/);
-  assert.match(logoutPage, /method="post"/);
+  assert.match(logout, /\/logout\/complete/);
+  assert.match(logout, /form.method = "post"/);
+  assert.match(logout, /submitDocumentFormIntentionally\(form\)/);
   assert.match(logoutRoute, /export const POST/);
   assert.doesNotMatch(logoutRoute, /export const GET/);
   assert.match(
@@ -26,6 +31,18 @@ test("logout clears XChat browser data before ending the WorkOS session", () => 
   );
   assert.doesNotMatch(logoutRoute, /redirect\("\/"\)/);
   assert.match(proxy, /\^\\\/logout\(\?:\\\/complete\)\?\$/);
+});
+
+test("both account menus start logout without navigating to the logout page", () => {
+  const header = read("features/webapp/ui/components/Header.tsx");
+  const landingLink = read(
+    "features/landing/ui/components/LandingAuthLink.tsx"
+  );
+  assert.match(header, /onSelect=\{\(\) => \{\s*void logout\(\)/);
+  assert.doesNotMatch(header, /router.push\("\/logout"\)/);
+  assert.match(landingLink, /href.split\("\?"\)\[0\] === "\/logout"/);
+  assert.match(landingLink, /void logout\(\);\s*return;/);
+  assert.match(landingLink, /navigateDocumentIntentionally\(href\)/);
 });
 
 test("clearing XChat browser data removes memory, PINs, and the device key", () => {


### PR DESCRIPTION
## Summary

Logging out now keeps the current page visible while XChat cleanup runs. Both account menus show a Sonner toast saying "Logging out…" after 750 ms if logout is still pending, then complete the existing sign-out flow. This removes the intermediate logout screen.

Saved PIN and device-key cleanup still runs before sign-out. Repeated clicks share one attempt, and submission failures or navigation stalled for 15 seconds offer a retry. The navigation deadline starts after cleanup and uses a separate timer, preserving the 750 ms loading toast. Direct `/logout` links retain a fallback.

## Type of change

- [x] Bug fix
- [x] UI or UX improvement

## Testing

- Final full suites: 1,332 tests passed, comprising 523 Node tests and 809 Vitest tests. TypeScript, ESLint on all eight PR files, repository lint, Prettier, diff checks, and the production build passed.
- Built-in browser QA covered both account menus, slow IndexedDB cleanup, repeated clicks, saved PIN/key deletion, storage failures, submission failure/retry, keyboard activation, and desktop/mobile layouts.
- Production browser QA covered Google sign-in, the AuthKit callback, authenticated logout, and the anonymous direct-logout fallback. Logout submitted once and produced no unload warning.
- The follow-up timeout fix passed local CodeRabbit review with 0 issues. The earlier PR review identified the timeout gap; it is now addressed.
- Built-in browser fault injection confirmed a cancelled POST shows retry after 15.01 seconds, and retry completes the real logout route with no lingering toast or unload warning.

## Environment or schema impact

No environment, schema, migration, or dependency changes.

## Notes for maintainer

New-user onboarding through the first agent response was not manually exercised. The available account has completed onboarding and reached its workspace limit. Existing setup/callback regression tests passed.

Authenticated WorkOS logout returned to `preview.reacherx.com` in the QA environment; the local session was confirmed cleared. This PR leaves the existing server sign-out route unchanged.

Wait for explicit approval before merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a centralized logout flow that clears browser session data and completes logout through a background request.
  * Added loading and error notifications with retry support when logout encounters problems.
  * Updated landing-page and account-menu logout actions to use the centralized flow.

* **Bug Fixes**
  * Improved handling of repeated logout attempts, submission failures, and interrupted navigation with timeout recovery.

* **Tests**
  * Added comprehensive coverage for logout cleanup, notifications, retries, cancellation, timeouts, and menu integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->